### PR TITLE
fix: Publish notes workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,8 @@ jobs:
         executor: node
         steps:
         - checkout
+        - attach_workspace:
+            at: ./
         - run:
             name: Tag release & generate GitHub notes
             command: sh scripts/publish-notes.sh

--- a/scripts/publish-notes.sh
+++ b/scripts/publish-notes.sh
@@ -28,7 +28,7 @@ createAndPushTag () {
 publishNotes () {
     echo "🚀 Publishing the GitHub Release"
     export CONVENTIONAL_GITHUB_RELEASER_TOKEN="$GH_TOKEN"
-    yarn conventional-github-releaser
+    yarn run conventional-github-releaser
     echo "👻 Success! Release published at https://github.com/$REPO_SLUG/releases/tag/v$PACKAGE_VERSION"
 }
 


### PR DESCRIPTION
This PR brings `node_modules/` into the `publish_notes` job so we can run the `conventional-github-releaser` command.

![image](https://user-images.githubusercontent.com/6333409/89793956-5896c880-db1e-11ea-8404-fd49ac784bc2.png)
