### PR TITLE
fix(TNLT-3679): Renders FrontSection slice without FlatList.

### DIFF
--- a/packages/edition-slices/__tests__/shared-tablet-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-tablet-slices.base.js
@@ -40,7 +40,7 @@ import {
   SecondaryTwoAndTwoSlice,
   StandardSlice,
   ListTwoAndSixNoPicSlice,
-  LeadTwoNoPicandTwoFrontSlice,
+  LeadTwoNoPicAndTwoFrontSlice,
 } from "../src/slices";
 
 const slices = [
@@ -127,7 +127,7 @@ const slices = [
   {
     mock: mockLeadTwoNoPicAndTwoSlice(),
     name: "front lead two no pic and two",
-    Slice: LeadTwoNoPicandTwoFrontSlice,
+    Slice: LeadTwoNoPicAndTwoFrontSlice,
   },
 ];
 

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -35,7 +35,7 @@ import {
   LeadersSlice,
   DailyRegisterLeadFourSlice,
   StandardSlice,
-  LeadTwoNoPicandTwoFrontSlice,
+  LeadTwoNoPicAndTwoFrontSlice,
 } from "./src/slices";
 import { mockFrontLeadTwoNoPicAndTwoSlice } from "@times-components-native/fixture-generator/src/mock-slice";
 
@@ -174,7 +174,7 @@ const sliceStories = [
   {
     mock: mockFrontLeadTwoNoPicAndTwoSlice(),
     name: "Front Lead Two No Pic And Two",
-    Slice: LeadTwoNoPicandTwoFrontSlice,
+    Slice: LeadTwoNoPicAndTwoFrontSlice,
     scroll: false,
   },
 ];

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -37,6 +37,7 @@ import {
   StandardSlice,
   LeadTwoNoPicandTwoFrontSlice,
 } from "./src/slices";
+import { mockFrontLeadTwoNoPicAndTwoSlice } from "@times-components-native/fixture-generator/src/mock-slice";
 
 const preventDefaultedAction = (decorateAction) =>
   decorateAction([
@@ -171,7 +172,7 @@ const sliceStories = [
     Slice: CommentLeadAndCartoonSlice,
   },
   {
-    mock: mockLeadTwoNoPicAndTwoSlice(),
+    mock: mockFrontLeadTwoNoPicAndTwoSlice(),
     name: "Front Lead Two No Pic And Two",
     Slice: LeadTwoNoPicandTwoFrontSlice,
     scroll: false,

--- a/packages/edition-slices/src/edition-slices.js
+++ b/packages/edition-slices/src/edition-slices.js
@@ -17,7 +17,7 @@ import {
   SecondaryOneSlice,
   SecondaryTwoAndTwoSlice,
   SecondaryTwoNoPicAndTwoSlice,
-  LeadTwoNoPicandTwoFrontSlice,
+  LeadTwoNoPicAndTwoFrontSlice,
   PuzzleSlice,
 } from "./slices";
 
@@ -48,7 +48,8 @@ const sliceMap = {
   SecondaryTwoNoPicAndTwoSlice,
   StandardSlice,
   TwoPicAndSixNoPicSlice: ListTwoAndSixNoPicSlice,
-  LeadTwoNoPicandTwoFrontSlice,
+  LeadTwoNoPicandTwoFrontSlice: LeadTwoNoPicAndTwoFrontSlice, // remove once typo has been addressed from TPA
+  LeadTwoNoPicAndTwoFrontSlice,
 };
 
 export default sliceMap;

--- a/packages/edition-slices/src/slices/index.js
+++ b/packages/edition-slices/src/slices/index.js
@@ -14,4 +14,4 @@ export { default as SecondaryOneAndFourSlice } from "./secondaryoneandfour";
 export { default as SecondaryTwoAndTwoSlice } from "./secondarytwoandtwo";
 export { default as PuzzleSlice } from "./puzzle";
 export { default as SecondaryTwoNoPicAndTwoSlice } from "./secondarytwonopicandtwo";
-export { default as LeadTwoNoPicandTwoFrontSlice } from "./frontleadtwoandtwo";
+export { default as LeadTwoNoPicAndTwoFrontSlice } from "./frontleadtwoandtwo";

--- a/packages/fixture-generator/src/mock-edition.ts
+++ b/packages/fixture-generator/src/mock-edition.ts
@@ -4,6 +4,7 @@ import {
   mockPuzzleSection,
   mockStandardSection,
   mockStandardSectionWithSecondaryTwoSlices,
+  mockFrontSection,
 } from "./mock-section";
 
 class MockEdition {
@@ -33,6 +34,7 @@ class MockEdition {
       mockPuzzleSection("Puzzles"),
       mockMagazineSection("Culture"),
       mockStandardSectionWithSecondaryTwoSlices("Comment"),
+      mockFrontSection(),
     ];
   }
 

--- a/packages/fixture-generator/src/mock-section.ts
+++ b/packages/fixture-generator/src/mock-section.ts
@@ -18,6 +18,7 @@ import {
   mockSecondaryTwoNoPicAndTwoSlice,
   mockStandardSlice,
   mockListTwoAndSixNoPicSlice,
+  mockFrontLeadTwoNoPicAndTwoSlice,
 } from "./mock-slice";
 
 function getSlices(): Array<ArticleSlice> {
@@ -145,10 +146,29 @@ function mockMagazineSection(title: string): MagazineSectionWithName {
   };
 }
 
+function mockFrontSection(): StandardSectionWithName {
+  return {
+    colour: {
+      rgba: {
+        alpha: 1,
+        blue: 255,
+        green: 255,
+        red: 255,
+      },
+    },
+    id: "front-page-section",
+    name: "FrontPageSection",
+    slices: [mockFrontLeadTwoNoPicAndTwoSlice()],
+    slug: "dummy-section-slug",
+    title: "some-title",
+  };
+}
+
 export {
   getPuzzleSlices,
   mockMagazineSection,
   mockPuzzleSection,
   mockStandardSection,
   mockStandardSectionWithSecondaryTwoSlices,
+  mockFrontSection,
 };

--- a/packages/fixture-generator/src/mock-slice.ts
+++ b/packages/fixture-generator/src/mock-slice.ts
@@ -204,6 +204,18 @@ function mockLeadTwoNoPicAndTwoSlice(): LeadTwoNoPicAndTwoSliceWithName {
   };
 }
 
+function mockFrontLeadTwoNoPicAndTwoSlice(): LeadTwoNoPicAndTwoSliceWithName {
+  const tiles = getTiles(4);
+  return <LeadTwoNoPicAndTwoSliceWithName>{
+    name: "LeadTwoNoPicandTwoFrontSlice",
+    lead1: tiles[0],
+    lead2: tiles[1],
+    support1: tiles[2],
+    support2: tiles[3],
+    items: tiles,
+  };
+}
+
 function mockSecondaryOneSlice(): SecondaryOneSliceWithName {
   const tiles = getTiles(1);
   return <SecondaryOneSliceWithName>{
@@ -375,4 +387,5 @@ export {
   mockSecondaryTwoAndTwoSlice,
   mockSecondaryTwoNoPicAndTwoSlice,
   mockPuzzleSlice,
+  mockFrontLeadTwoNoPicAndTwoSlice,
 };

--- a/packages/front-page/__tests__/__snapshots__/front-renderer.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-renderer.test.js.snap
@@ -16,7 +16,7 @@ exports[`front renderers paragraph renderer renders paragraph 1`] = `
 
 exports[`front renderers paragraph renderer renders paragraph with tab 1`] = `
 <Text>
-  　　
+  　
   Some Text
   
 

--- a/packages/front-page/front-renderer.js
+++ b/packages/front-page/front-renderer.js
@@ -2,7 +2,7 @@ import React from "react";
 import coreRenderers from "@times-components-native/markup";
 import { Text } from "react-native";
 
-export const PARAGRAPH_INDENT = `\u3000\u3000`; // approximates a tab
+export const PARAGRAPH_INDENT = `\u3000`; // approximates a tab
 
 export default {
   ...coreRenderers,

--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Front Page section 1`] = `<FrontLeadTwoAndTwo />`;
+
 exports[`Sunday Times magazine section 1`] = `
 <RCTScrollView>
   <View>

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Front Page section 1`] = `<FrontLeadTwoAndTwo />`;
+
 exports[`Sunday Times magazine section 1`] = `
 <RCTScrollView>
   <View>

--- a/packages/section/__tests__/shared.js
+++ b/packages/section/__tests__/shared.js
@@ -188,6 +188,25 @@ export default () => {
     ).toMatchSnapshot();
   });
 
+  it("Front Page section", () => {
+    const edition = new MockEdition().get();
+
+    expect(
+      TestRenderer.create(
+        <Section
+          analyticsStream={() => null}
+          onArticlePress={() => null}
+          onPuzzleBarPress={() => null}
+          onPuzzlePress={() => null}
+          publicationName="TIMES"
+          recentlyOpenedPuzzleCount={1}
+          section={edition.sections[6]}
+          debug
+        />,
+      ).toJSON(),
+    ).toMatchSnapshot();
+  });
+
   it("section item separator - small", () => {
     expect(
       TestRenderer.create(

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -102,6 +102,10 @@ class Section extends Component {
       <Responsive>
         <ResponsiveContext.Consumer>
           {({ isTablet, editionBreakpoint }) => {
+            if (name === "FrontPageSection") {
+              return this.renderItem({ index: 0, item: slices[0] });
+            }
+
             const data = isPuzzle
               ? createPuzzleData(slices, editionBreakpoint)
               : prepareSlicesForRender(slices);


### PR DESCRIPTION
We don't need to render a FlatList for the front page as it's a full-screen slice with no scrolling enabled.

Also reduces paragraph indentation