### PR TITLE
feat(TNLT-4283): Update error boundaries text for articles

### DIFF
--- a/packages/pages/src/article/index.js
+++ b/packages/pages/src/article/index.js
@@ -17,7 +17,8 @@ const ArticlePage = (props) => {
     ? () => Linking.openURL(data.url)
     : undefined;
   const errorBoundaryOptions = {
-    message: "We can't load the article you have requested.",
+    title: "View online",
+    message: "This article will display on the web",
     buttonText: "Open in browser",
     onAction: openInBrowser,
   };

--- a/packages/pages/src/with-error-boundaries.js
+++ b/packages/pages/src/with-error-boundaries.js
@@ -25,6 +25,7 @@ export const withErrorBoundaries = (WrappedComponent, extras = {}) =>
 
       return hasError ? (
         <ArticleError
+          title={extras.title}
           message={extras.message}
           buttonText={extras.buttonText}
           refetch={extras.onAction}


### PR DESCRIPTION
### Summary

Updated the text for the error boundary (only for articles). 

![image](https://user-images.githubusercontent.com/6333409/90419827-0837e180-e0af-11ea-98b2-0866bda7afd9.png)
