### PR TITLE
fix: fixes line break issue on android when rendering columns

### DIFF
--- a/packages/article-columns/__tests__/measure/__snapshots__/MeasureComponents.test.tsx.snap
+++ b/packages/article-columns/__tests__/measure/__snapshots__/MeasureComponents.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`MeasureContent renders the content 1`] = `
         },
       ]
     }
+    textBreakStrategy="simple"
   >
     abc
   </Text>

--- a/packages/article-columns/__tests__/render/__snapshots__/Columns.test.tsx.snap
+++ b/packages/article-columns/__tests__/render/__snapshots__/Columns.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`SingleColumn renders correctly 1`] = `
           },
         ]
       }
+      textBreakStrategy="simple"
     >
       Paragraph text.
     </Text>

--- a/packages/article-columns/article-columns.showcase.js
+++ b/packages/article-columns/article-columns.showcase.js
@@ -11,7 +11,12 @@ export default {
           containerWidth={500}
           lineHeight={18}
           bylines={article.data.article.bylines}
-          style={{ lineHeight: 18 }}
+          style={{
+            fontSize: 14,
+            lineHeight: 18,
+            textAlign: "justify",
+            fontFamily: "TimesDigitalW04",
+          }}
           columnCount={2}
         />
       ),

--- a/packages/edition-slices/edition-front.showcase.js
+++ b/packages/edition-slices/edition-front.showcase.js
@@ -10,25 +10,11 @@ import {
   LeadTwoNoPicAndTwoFrontSlice,
 } from "./src/slices";
 
-const preventDefaultedAction = (decorateAction) =>
-  decorateAction([
-    ([e, ...args]) => {
-      e.preventDefault();
-      return ["[SyntheticEvent (storybook prevented default)]", ...args];
-    },
-  ]);
-
-/* eslint-disable react/prop-types */
-const renderSlice = (Component, data) => (_, { decorateAction }) => {
+const renderSlice = (Component, data) => () => {
   return (
     <Responsive>
       <View style={{ flex: 1 }}>
-        {
-          <Component
-            onPress={preventDefaultedAction(decorateAction)("onPress")}
-            slice={data}
-          />
-        }
+        {<Component onPress={() => null} slice={data} />}
       </View>
     </Responsive>
   );

--- a/packages/front-page/__tests__/__snapshots__/front-article-summary-content.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-article-summary-content.test.js.snap
@@ -31,6 +31,7 @@ exports[`FrontArticleSummaryContent landscape huge 1`] = `
         false,
       ]
     }
+    textBreakStrategy="simple"
   >
     Test
     
@@ -70,6 +71,7 @@ exports[`FrontArticleSummaryContent landscape medium 1`] = `
         false,
       ]
     }
+    textBreakStrategy="simple"
   >
     Test
     
@@ -109,6 +111,7 @@ exports[`FrontArticleSummaryContent landscape wide 1`] = `
         false,
       ]
     }
+    textBreakStrategy="simple"
   >
     Test
     
@@ -148,6 +151,7 @@ exports[`FrontArticleSummaryContent portrait huge 1`] = `
         false,
       ]
     }
+    textBreakStrategy="simple"
   >
     Test
     
@@ -187,6 +191,7 @@ exports[`FrontArticleSummaryContent portrait medium 1`] = `
         false,
       ]
     }
+    textBreakStrategy="simple"
   >
     Test
     
@@ -226,6 +231,7 @@ exports[`FrontArticleSummaryContent portrait wide 1`] = `
         false,
       ]
     }
+    textBreakStrategy="simple"
   >
     Test
     

--- a/packages/front-page/__tests__/__snapshots__/front-renderer.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-renderer.test.js.snap
@@ -15,6 +15,7 @@ exports[`front renderers paragraph renderer renders paragraph 1`] = `
       },
     ]
   }
+  textBreakStrategy="simple"
 >
   Some Text
 </Text>
@@ -27,6 +28,7 @@ exports[`front renderers paragraph renderer renders paragraph with new line at e
       false,
     ]
   }
+  textBreakStrategy="simple"
 >
   　
   Some Text
@@ -44,6 +46,7 @@ exports[`front renderers paragraph renderer renders paragraph with tab 1`] = `
       },
     ]
   }
+  textBreakStrategy="simple"
 >
   　
   Some Text

--- a/packages/front-page/front-renderer.tsx
+++ b/packages/front-page/front-renderer.tsx
@@ -16,6 +16,7 @@ interface Input {
 }
 type GetRenderers = (input: Input) => { [key: string]: Renderer };
 export const PARAGRAPH_INDENT_CHAR = `\u3000`; // approximates a 2-space tab
+const textBreakStrategy = "simple"; // there are several issues using other text break strategies on Android. When "highQuality"/"balanced" are used, we observed that onTextLayout was showing incorrect line breaks. Furthermore, random line breaks also appeared underneath some paragraphs.
 
 export const getRenderers: GetRenderers = ({
   renderOptions,
@@ -30,6 +31,7 @@ export const getRenderers: GetRenderers = ({
         style={[!!renderOptions && renderOptions]}
         // @ts-ignore onTextLayout does exist on Text component
         onTextLayout={onParagraphTextLayout}
+        textBreakStrategy={textBreakStrategy}
       >
         {attributes?.tab && PARAGRAPH_INDENT_CHAR}
         {renderedChildren}


### PR DESCRIPTION
The `highQuality` text break strategy was causing weird results on android, and was causing random line breaks to appear when rendering columns. Also, we rely on the `onTextLayout` callback providing accurate data on how the text was rendered, and we were seeing line breaks appearing in the wrong place. Setting the text break strategy to `simple` fixed these issues. 

I was only seeing this weird behaviour when rendering justified text AND using `TimesDigitalW04` font family.  

However, setting the text break strategy to `simple` has resulted in text not looking as balanced as it once did. Hopefully, once hyphenation is working on android, we will be able to improve on this.

before:
![image](https://user-images.githubusercontent.com/6280629/91050504-a8918700-e616-11ea-859c-8db65c926318.png)


after:
![image](https://user-images.githubusercontent.com/6280629/91050493-a3ccd300-e616-11ea-9f30-7b42d02e1d1e.png)

