### PR TITLE
fix: fixes front section on android to not flow under navbar.

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1385,7 +1385,7 @@ exports[`17. front lead two no pic and two - landscape - medium 1`] = `
         "alignSelf": "center",
         "flex": 1,
         "flexDirection": "row",
-        "paddingBottom": 50,
+        "paddingBottom": 100,
         "paddingTop": 15,
         "width": 1000,
       }
@@ -1497,6 +1497,7 @@ exports[`18. front lead two no pic and two - portrait - medium 1`] = `
         "flexDirection": "row",
         "marginHorizontal": 20,
         "marginTop": 20,
+        "paddingBottom": 100,
       }
     }
   >
@@ -1595,7 +1596,7 @@ exports[`19. front lead one and one - portrait - medium 1`] = `
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 30,
-        "paddingBottom": 50,
+        "paddingBottom": 100,
         "paddingTop": 20,
       }
     }
@@ -1651,7 +1652,7 @@ exports[`20. front lead one and one - landscape - medium 1`] = `
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 30,
-        "paddingBottom": 50,
+        "paddingBottom": 100,
         "paddingTop": 20,
       }
     }
@@ -3490,7 +3491,7 @@ exports[`43. front lead two no pic and two - landscape - wide 1`] = `
         "alignSelf": "center",
         "flex": 1,
         "flexDirection": "row",
-        "paddingBottom": 50,
+        "paddingBottom": 100,
         "paddingTop": 15,
         "width": 1000,
       }
@@ -3602,6 +3603,7 @@ exports[`44. front lead two no pic and two - portrait - wide 1`] = `
         "flexDirection": "row",
         "marginHorizontal": 20,
         "marginTop": 20,
+        "paddingBottom": 100,
       }
     }
   >
@@ -3700,7 +3702,7 @@ exports[`45. front lead one and one - portrait - wide 1`] = `
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 30,
-        "paddingBottom": 50,
+        "paddingBottom": 100,
         "paddingTop": 20,
       }
     }
@@ -3756,7 +3758,7 @@ exports[`46. front lead one and one - landscape - wide 1`] = `
         "flex": 1,
         "flexDirection": "row",
         "marginHorizontal": 30,
-        "paddingBottom": 50,
+        "paddingBottom": 100,
         "paddingTop": 20,
       }
     }
@@ -5764,7 +5766,7 @@ exports[`69. front lead two no pic and two - landscape - huge 1`] = `
           "alignSelf": "center",
           "flex": 1,
           "flexDirection": "row",
-          "paddingBottom": 50,
+          "paddingBottom": 100,
           "paddingTop": 15,
           "width": 1000,
         }
@@ -5886,6 +5888,7 @@ exports[`70. front lead two no pic and two - portrait - huge 1`] = `
           "flexDirection": "row",
           "marginHorizontal": 20,
           "marginTop": 20,
+          "paddingBottom": 100,
         }
       }
     >
@@ -5994,7 +5997,7 @@ exports[`71. front lead one and one - portrait - huge 1`] = `
           "flex": 1,
           "flexDirection": "row",
           "marginHorizontal": 30,
-          "paddingBottom": 50,
+          "paddingBottom": 100,
           "paddingTop": 20,
         }
       }
@@ -6060,7 +6063,7 @@ exports[`72. front lead one and one - landscape - huge 1`] = `
           "flex": 1,
           "flexDirection": "row",
           "marginHorizontal": 30,
-          "paddingBottom": 50,
+          "paddingBottom": 100,
           "paddingTop": 20,
         }
       }

--- a/packages/slice-layout/__tests__/android/__snapshots__/front-l2np2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/front-l2np2-with-style.ios.test.js.snap
@@ -51,7 +51,7 @@ exports[`2. front lead two no pic and two - medium - landscape 1`] = `
       "alignSelf": "center",
       "flex": 1,
       "flexDirection": "row",
-      "paddingBottom": 50,
+      "paddingBottom": 100,
       "paddingTop": 15,
       "width": 1000,
     }
@@ -158,7 +158,7 @@ exports[`3. front lead two no pic and two - wide - landscape 1`] = `
       "alignSelf": "center",
       "flex": 1,
       "flexDirection": "row",
-      "paddingBottom": 50,
+      "paddingBottom": 100,
       "paddingTop": 15,
       "width": 1000,
     }
@@ -265,7 +265,7 @@ exports[`4. front lead two no pic and two - huge - landscape 1`] = `
       "alignSelf": "center",
       "flex": 1,
       "flexDirection": "row",
-      "paddingBottom": 50,
+      "paddingBottom": 100,
       "paddingTop": 15,
       "width": 1000,
     }
@@ -417,6 +417,7 @@ exports[`6. front lead two no pic and two - medium - portrait 1`] = `
       "flexDirection": "row",
       "marginHorizontal": 20,
       "marginTop": 20,
+      "paddingBottom": 100,
     }
   }
 >
@@ -512,6 +513,7 @@ exports[`7. front lead two no pic and two - wide - portrait 1`] = `
       "flexDirection": "row",
       "marginHorizontal": 20,
       "marginTop": 20,
+      "paddingBottom": 100,
     }
   }
 >
@@ -607,6 +609,7 @@ exports[`8. front lead two no pic and two - huge - portrait 1`] = `
       "flexDirection": "row",
       "marginHorizontal": 20,
       "marginTop": 20,
+      "paddingBottom": 100,
     }
   }
 >

--- a/packages/slice-layout/src/templates/frontleadoneandone/styles.android.js
+++ b/packages/slice-layout/src/templates/frontleadoneandone/styles.android.js
@@ -8,7 +8,7 @@ export default (breakpoint) => {
     ...styles,
     container: {
       ...styles.container,
-      paddingBottom: spacing(10), // ensures content sits on top of bottom-nav bar
+      paddingBottom: spacing(20), // ensures content sits on top of bottom-nav bar
     },
   };
 };

--- a/packages/slice-layout/src/templates/frontleadtwoandtwo/styles.android.js
+++ b/packages/slice-layout/src/templates/frontleadtwoandtwo/styles.android.js
@@ -2,13 +2,18 @@ import { spacing } from "@times-components-native/styleguide";
 
 import stylesFactory from "./styles.js";
 
+const bottomNavBarHeight = spacing(20); // ensures content sits on top of bottom-nav bar
 export default (breakpoint) => {
   let styles = stylesFactory(breakpoint);
   return {
     ...styles,
     containerLandscape: {
       ...styles.containerLandscape,
-      paddingBottom: spacing(10), // ensures content sits on top of bottom-nav bar
+      paddingBottom: bottomNavBarHeight,
+    },
+    containerPortrait: {
+      ...styles.containerPortrait,
+      paddingBottom: bottomNavBarHeight, // ensures content sits on top of bottom-nav bar
     },
   };
 };


### PR DESCRIPTION
Adds extra padding at the bottom of a front on android to factor in bottom nav height.

BEFORE:
![image](https://user-images.githubusercontent.com/6280629/91320101-0f4ca700-e7b5-11ea-9c1a-3675ef5dda8b.png)

AFTER:
![image](https://user-images.githubusercontent.com/6280629/91319913-d7ddfa80-e7b4-11ea-869b-01ff3381b3d5.png)
