### PR TITLE
fix: (TNLT-4746) Add support for lead asset in tablet comment template

### DIFF
--- a/packages/article-comment-tablet/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-comment-tablet/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -1,6 +1,181 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. article comment tablet 1`] = `
+exports[`1. article comment tablet - magazinecomment template 1`] = `
+<View
+  style={
+    Object {
+      "marginLeft": "auto",
+      "marginRight": "auto",
+      "maxWidth": 800,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "paddingTop": 40,
+        "position": "absolute",
+        "width": "25%",
+        "zIndex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "maxWidth": 200,
+          "paddingLeft": 35,
+          "paddingRight": 15,
+          "width": "100%",
+        }
+      }
+    >
+      <Image />
+      <View
+        style={
+          Object {
+            "paddingTop": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <ArticleBylineWithLinks />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "bottom": 60,
+          "paddingLeft": 25,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <ArticleTopics
+        style={
+          Object {
+            "justifyContent": "flex-start",
+          }
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "marginLeft": "25%",
+        "position": "relative",
+      }
+    }
+  >
+    <ArticleSkeleton>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderLeftWidth": 1,
+            "marginTop": 40,
+            "paddingBottom": 20,
+            "paddingRight": 25,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 10,
+              }
+            }
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 44,
+                "lineHeight": 44,
+                "marginBottom": 13.75,
+              }
+            }
+          >
+            Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+          </Text>
+          <ArticleFlags />
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "marginBottom": 15,
+              }
+            }
+          >
+            How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+          </Text>
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "flexDirection": "row",
+                "marginTop": 5,
+                "paddingVertical": 10,
+                "width": "100%",
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                    "marginTop": "auto",
+                  }
+                }
+              >
+                Friday March 13 2015, 6.54pm, The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <ArticleLeadAsset
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderLeftWidth": 1,
+            "paddingBottom": 20,
+            "paddingLeft": 10,
+            "paddingRight": 35,
+          }
+        }
+      />
+    </ArticleSkeleton>
+  </View>
+</View>
+`;
+
+exports[`2. article comment tablet - maincomment template 1`] = `
 <View
   style={
     Object {

--- a/packages/article-comment-tablet/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-comment-tablet/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -1,6 +1,181 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. article comment tablet 1`] = `
+exports[`1. article comment tablet - magazinecomment template 1`] = `
+<View
+  style={
+    Object {
+      "marginLeft": "auto",
+      "marginRight": "auto",
+      "maxWidth": 800,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "paddingTop": 40,
+        "position": "absolute",
+        "width": "25%",
+        "zIndex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "maxWidth": 200,
+          "paddingLeft": 35,
+          "paddingRight": 15,
+          "width": "100%",
+        }
+      }
+    >
+      <Image />
+      <View
+        style={
+          Object {
+            "paddingTop": 10,
+            "width": "100%",
+          }
+        }
+      >
+        <ArticleBylineWithLinks />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "bottom": 60,
+          "paddingLeft": 25,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <ArticleTopics
+        style={
+          Object {
+            "justifyContent": "flex-start",
+          }
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "marginLeft": "25%",
+        "position": "relative",
+      }
+    }
+  >
+    <ArticleSkeleton>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderLeftWidth": 1,
+            "marginTop": 40,
+            "paddingBottom": 20,
+            "paddingRight": 25,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginBottom": 10,
+              }
+            }
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 44,
+                "lineHeight": 44,
+                "marginBottom": 13.75,
+              }
+            }
+          >
+            Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+          </Text>
+          <ArticleFlags />
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "marginBottom": 15,
+              }
+            }
+          >
+            How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+          </Text>
+          <View
+            style={
+              Object {
+                "borderBottomColor": "#DBDBDB",
+                "borderBottomWidth": 1,
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "flexDirection": "row",
+                "marginTop": 5,
+                "paddingVertical": 10,
+                "width": "100%",
+              }
+            }
+          >
+            <View>
+              <Text
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                    "marginTop": "auto",
+                  }
+                }
+              >
+                Friday March 13 2015, 6.54pm, The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <ArticleLeadAsset
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderLeftWidth": 1,
+            "paddingBottom": 20,
+            "paddingLeft": 10,
+            "paddingRight": 35,
+          }
+        }
+      />
+    </ArticleSkeleton>
+  </View>
+</View>
+`;
+
+exports[`2. article comment tablet - maincomment template 1`] = `
 <View
   style={
     Object {

--- a/packages/article-comment-tablet/__tests__/mocks.native.js
+++ b/packages/article-comment-tablet/__tests__/mocks.native.js
@@ -22,6 +22,10 @@ jest.mock("@times-components-native/article-image", () => "ArticleImage");
 jest.mock("@times-components-native/article-label", () => "ArticleLabel");
 jest.mock("@times-components-native/article-topics", () => "ArticleTopics");
 jest.mock(
+  "@times-components-native/article-lead-asset",
+  () => "ArticleLeadAsset",
+);
+jest.mock(
   "@times-components-native/article-skeleton",
   () => MockArticleSkeleton,
 );

--- a/packages/article-comment-tablet/__tests__/shared-tablet.native.js
+++ b/packages/article-comment-tablet/__tests__/shared-tablet.native.js
@@ -29,13 +29,34 @@ export default () => {
 
   const tests = [
     {
-      name: "Article Comment Tablet",
+      name: "Article Comment Tablet - magazinecomment template",
       test() {
         const testInstance = TestRenderer.create(
           withTabletContext(
             <ArticleCommentTablet
               {...sharedProps}
-              article={articleFixture()}
+              article={{
+                template: "magazinecomment",
+                ...articleFixture(),
+              }}
+            />,
+          ),
+        );
+
+        expect(testInstance).toMatchSnapshot();
+      },
+    },
+    {
+      name: "Article Comment Tablet - maincomment template",
+      test() {
+        const testInstance = TestRenderer.create(
+          withTabletContext(
+            <ArticleCommentTablet
+              {...sharedProps}
+              article={{
+                template: "maincomment",
+                ...articleFixture(),
+              }}
             />,
           ),
         );

--- a/packages/article-comment-tablet/__tests__/shared-tablet.native.js
+++ b/packages/article-comment-tablet/__tests__/shared-tablet.native.js
@@ -36,8 +36,8 @@ export default () => {
             <ArticleCommentTablet
               {...sharedProps}
               article={{
-                template: "magazinecomment",
                 ...articleFixture(),
+                template: "magazinecomment",
               }}
             />,
           ),
@@ -54,8 +54,8 @@ export default () => {
             <ArticleCommentTablet
               {...sharedProps}
               article={{
-                template: "maincomment",
                 ...articleFixture(),
+                template: "maincomment",
               }}
             />,
           ),

--- a/packages/article-comment-tablet/src/article-comment-tablet.js
+++ b/packages/article-comment-tablet/src/article-comment-tablet.js
@@ -70,7 +70,6 @@ class ArticlePage extends Component {
           />
         )}
       </Fragment>
-
     );
   }
 

--- a/packages/article-comment-tablet/src/article-comment-tablet.js
+++ b/packages/article-comment-tablet/src/article-comment-tablet.js
@@ -1,11 +1,17 @@
 /* eslint-disable consistent-return */
 
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import { View } from "react-native";
 import ArticleError from "@times-components-native/article-error";
 import ArticleSkeleton from "@times-components-native/article-skeleton";
-import { getHeadline } from "@times-components-native/utils";
+import {
+  getHeadline,
+  getLeadAsset,
+  getStandardTemplateCrop,
+} from "@times-components-native/utils";
+import ArticleLeadAsset from "@times-components-native/article-lead-asset";
 import { ResponsiveContext } from "@times-components-native/responsive";
+import Caption from "@times-components-native/caption";
 import Context from "@times-components-native/context";
 import ArticleHeader from "./article-header/article-header";
 import ArticleLeftColumn from "./article-left-column/article-left-column";
@@ -22,7 +28,7 @@ class ArticlePage extends Component {
   }
 
   renderHeader() {
-    const { article, onAuthorPress, onImagePress } = this.props;
+    const { article, onAuthorPress, onImagePress, onVideoPress } = this.props;
     const {
       expirableFlags,
       hasVideo,
@@ -33,21 +39,38 @@ class ArticlePage extends Component {
       publishedTime,
       shortHeadline,
       standfirst,
+      template,
     } = article;
+    const showLeadAsset = template === "magazinecomment";
 
     return (
-      <ArticleHeader
-        flags={expirableFlags}
-        hasVideo={hasVideo}
-        headline={getHeadline(headline, shortHeadline)}
-        label={label}
-        longRead={longRead}
-        onAuthorPress={onAuthorPress}
-        onImagePress={onImagePress}
-        publicationName={publicationName}
-        publishedTime={publishedTime}
-        standfirst={standfirst}
-      />
+      <Fragment>
+        <ArticleHeader
+          flags={expirableFlags}
+          hasVideo={hasVideo}
+          headline={getHeadline(headline, shortHeadline)}
+          label={label}
+          longRead={longRead}
+          onAuthorPress={onAuthorPress}
+          onImagePress={onImagePress}
+          publicationName={publicationName}
+          publishedTime={publishedTime}
+          standfirst={standfirst}
+        />
+        {showLeadAsset && (
+          <ArticleLeadAsset
+            {...getLeadAsset(article)}
+            getImageCrop={getStandardTemplateCrop}
+            onImagePress={onImagePress}
+            onVideoPress={onVideoPress}
+            renderCaption={({ caption }) => (
+              <Caption {...caption} style={styles.captionContainer} />
+            )}
+            style={styles.leadAssetContainer}
+          />
+        )}
+      </Fragment>
+
     );
   }
 

--- a/packages/article-comment-tablet/src/article-comment-tablet.js
+++ b/packages/article-comment-tablet/src/article-comment-tablet.js
@@ -1,6 +1,6 @@
 /* eslint-disable consistent-return */
 
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import { View } from "react-native";
 import ArticleError from "@times-components-native/article-error";
 import ArticleSkeleton from "@times-components-native/article-skeleton";
@@ -44,7 +44,7 @@ class ArticlePage extends Component {
     const showLeadAsset = template === "magazinecomment";
 
     return (
-      <Fragment>
+      <>
         <ArticleHeader
           flags={expirableFlags}
           hasVideo={hasVideo}
@@ -69,7 +69,7 @@ class ArticlePage extends Component {
             style={styles.leadAssetContainer}
           />
         )}
-      </Fragment>
+      </>
     );
   }
 

--- a/packages/article-comment-tablet/src/styles/index.js
+++ b/packages/article-comment-tablet/src/styles/index.js
@@ -84,6 +84,13 @@ const Styles = {
     paddingLeft: spacing(5),
     width: "100%",
   },
+  leadAssetContainer: {
+    paddingLeft: spacing(2),
+    paddingBottom: spacing(4),
+    paddingRight: spacing(7),
+    borderLeftWidth: 1,
+    borderColor: colours.functional.keyline,
+  },
 };
 
 const styles = StyleSheet.create(Styles);


### PR DESCRIPTION
- Added support for lead asset in the comment tablet template but only for articles with the `magazinecomment` templateid to avoid duplicate author images being displayed.

### iPad
<img width="750" alt="Screenshot 2020-09-10 at 15 34 33" src="https://user-images.githubusercontent.com/1736782/92761846-f71a8180-f389-11ea-856d-24380b24c72e.png">

<img width="1032" alt="Screenshot 2020-09-10 at 15 53 10" src="https://user-images.githubusercontent.com/1736782/92761310-765b8580-f389-11ea-80b2-8764e1627c18.png">



### iPad Pro
<img width="784" alt="Screenshot 2020-09-10 at 16 14 44" src="https://user-images.githubusercontent.com/1736782/92761279-6cd21d80-f389-11ea-8d19-b7d6e6b57dc0.png">


<img width="1030" alt="Screenshot 2020-09-10 at 16 15 09" src="https://user-images.githubusercontent.com/1736782/92761177-52983f80-f389-11ea-8253-9a87ef78f60e.png">
