### PR TITLE
fix: (TNLT-4760) Inline image layout with narrow content

### DIFF
--- a/packages/article-image/src/article-image.js
+++ b/packages/article-image/src/article-image.js
@@ -21,7 +21,10 @@ const ArticleImageNative = (props) => {
             narrowContent && [
               styles[`${display}ContainerNarrow`],
               {
-                width: narrowArticleBreakpoint.content,
+                width:
+                  display !== "inline"
+                    ? narrowArticleBreakpoint.content
+                    : "auto",
               },
             ],
           ]}


### PR DESCRIPTION
- Fixes Inline image layout with narrow content templates

### Before
<img width="1039" alt="Screenshot 2020-09-11 at 15 54 27" src="https://user-images.githubusercontent.com/1736782/92940629-3a86f580-f447-11ea-92e4-80341d78a2d3.png">


### After
<img width="1058" alt="Screenshot 2020-09-11 at 15 48 04" src="https://user-images.githubusercontent.com/1736782/92940649-3eb31300-f447-11ea-9295-993b7c02b0aa.png">
