### PR TITLE
fix(TNLT-4574): prevents android app from crashing when subscribing to red box

### DIFF
--- a/lib/android/xnative/proguard-rules.pro
+++ b/lib/android/xnative/proguard-rules.pro
@@ -38,3 +38,6 @@
 -keepclassmembers class * {
     @com.facebook.soloader.DoNotOptimize *;
 }
+
+#for react-native-svg
+-keep public class com.horcrux.svg.** {*;}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "1.8.0-beta",
+  "version": "1.8.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.0-beta",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/article-skeleton/article-skeleton.showcase.js
+++ b/packages/article-skeleton/article-skeleton.showcase.js
@@ -79,7 +79,7 @@ export default {
       type: "story",
     },
     {
-      component: () => renderNewsletterPuff(false),
+      component: () => renderNewsletterPuff(),
       name: "Inline Newsletter Puff",
       platform: "native",
       type: "story",

--- a/packages/article-skeleton/article-skeleton.showcase.js
+++ b/packages/article-skeleton/article-skeleton.showcase.js
@@ -1,6 +1,64 @@
 import React from "react";
 import { MockedProvider } from "@times-components-native/provider-test-tools";
 import renderArticleSkeleton from "./showcase-helper";
+import InlineNewsletterPuff from "@times-components-native/article-skeleton/src/article-body/inline-newsletter-puff";
+import {
+  getNewsletter,
+  subscribeNewsletter as subscribeNewsletterMutation,
+} from "@times-components-native/provider-queries";
+import Responsive from "@times-components-native/responsive";
+
+const renderNewsletterPuff = () => {
+  return (
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: getNewsletter,
+            variables: { code: "some-code" },
+          },
+          result: {
+            data: {
+              newsletter: {
+                __typename: "getNewsletter",
+                id: "some-id",
+                isSubscribed: false,
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query: subscribeNewsletterMutation,
+            variables: { code: "some-code" },
+          },
+          result: {
+            data: {
+              subscribeNewsletter: {
+                __typename: "subscribeNewsletterMutation",
+                id: "some-id",
+                isSubscribed: true,
+              },
+            },
+          },
+        },
+      ]}
+    >
+      <Responsive>
+        <InlineNewsletterPuff
+          code={"some-code"}
+          analyticsStream={() => null}
+          copy={"some copy"}
+          headline={"some headline"}
+          label={"some label"}
+          imageUri={
+            "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb5dbb8cd-eec9-4542-a608-b7fa4e28fd4b.jpg?resize=1001"
+          }
+        />
+      </Responsive>
+    </MockedProvider>
+  );
+};
 
 export default {
   children: [
@@ -17,6 +75,12 @@ export default {
         </MockedProvider>
       ),
       name: "Default",
+      platform: "native",
+      type: "story",
+    },
+    {
+      component: () => renderNewsletterPuff(false),
+      name: "Inline Newsletter Puff",
       platform: "native",
       type: "story",
     },


### PR DESCRIPTION
1. Added a story for the newsletter puff - as it's tricky to test locally (you need to find an article with the puff inside, and then need to ensure you're not subscribed so you can see it)
2. Added a rule to the proguard rules file that is required by the react-native-svg library - I've tested a beta AAR with this change and it seems to work - (solution found here: https://github.com/react-native-community/react-native-svg/issues/1061#issuecomment-517031073) - I assume this proguard change is then merged into the other proguard rules on the android production build.