### PR TITLE
fix: Comment tablet template not rendering on android

### DIFF
--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -149,7 +149,7 @@ const ArticleWithContent = (props) => {
           ListFooterComponent={Loading}
           onEndReached={onEndReached}
           showsVerticalScrollIndicator={!!isTablet}
-          renderItem={renderItem(Child)}
+          renderItem={({ item, index }) => renderItem(Child({ item, index }))}
           onViewableItemsChanged={onViewableItemsChanged}
           removeClippedSubviews
           keyExtractor={(item, index) => index.toString()}


### PR DESCRIPTION
- Fix comment tablet template not rendering on android

### Pixel C
<img width="596" alt="Screenshot 2020-09-17 at 17 21 02" src="https://user-images.githubusercontent.com/1736782/93498861-360c8200-f90a-11ea-88dd-3127792cef8c.png">
