### PR TITLE
chore: fix comment article widths on huge screens

### DIFF
--- a/packages/styleguide/src/breakpoints/index.js
+++ b/packages/styleguide/src/breakpoints/index.js
@@ -36,10 +36,7 @@ const getNarrowArticleBreakpoint = (width) => {
   if (width < editionBreakpointWidths.wide) {
     return narrowArticleWidths.medium;
   }
-  if (width < editionBreakpointWidths.huge) {
-    return narrowArticleWidths.wide;
-  }
-  return narrowArticleWidths.huge;
+  return narrowArticleWidths.wide;
 };
 
 export {


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-4286

Apply wide breakpoint container width on narrow comment articles to wide and above.

iPad Pro (12.3) - Landscape
![Screenshot 2020-09-21 at 12 13 11](https://user-images.githubusercontent.com/5103512/93760681-6bfc7f80-fc04-11ea-8971-bf8edee74233.png)
