### PR TITLE
fix: control group ad slotName and testgroup

### DIFF
--- a/packages/article-skeleton/__tests__/body-utils.native.js
+++ b/packages/article-skeleton/__tests__/body-utils.native.js
@@ -105,22 +105,35 @@ export default () => {
       ).toEqual(content);
     });
 
-    it("setupAd should return content untouched if articleMpu group is control group A", () => {
-      expect(
-        setupAd(true, { articleMpu: { group: "A" } }, "mainstandard", content),
-      ).toEqual(content);
-    });
-
     it("setupAd should return content untouched if template is not mainstandard", () => {
       expect(
         setupAd(true, { articleMpu: { group: "B" } }, "maincomment", content),
       ).toEqual(content);
     });
 
-    it("setupAd should return content untouched if template is not mainstandard", () => {
+    it("setupAd should return content with the slotName overriden if articleMpu group is control group A", () => {
       expect(
-        setupAd(true, { articleMpu: { group: "B" } }, "maincomment", content),
-      ).toEqual(content);
+        setupAd(
+          true,
+          { articleMpu: { group: "A", slotName: "native-inline-ad-a" } },
+          "mainstandard",
+          content,
+        ),
+      ).toEqual([
+        { name: "paragraph", children: [] },
+        { name: "paragraph", children: [] },
+        { name: "paragraph", children: [] },
+        { name: "paragraph", children: [] },
+        { name: "paragraph", children: [] },
+        {
+          name: "ad",
+          attributes: {
+            slotName: "native-inline-ad-a",
+          },
+          children: [],
+        },
+        { name: "paragraph", children: [] },
+      ]);
     });
 
     it("setupAd should return content with the ad present and attributes overriden", () => {

--- a/packages/article-skeleton/src/body-utils.js
+++ b/packages/article-skeleton/src/body-utils.js
@@ -48,22 +48,26 @@ export const collapsed = (isTablet, content) =>
         return [node, ...acc];
       }, []);
 
-const setupArticleMpuTestAd = (articleMpu, contentWithoutAdSlot) => {
-  const { adPosition, width, height, slotName } = articleMpu;
+const setupArticleMpuTestAd = (
+  articleMpu,
+  currentAdSlotIndex,
+  contentWithoutAdSlot,
+) => {
+  const { adPosition, group, width, height, slotName } = articleMpu;
+  const isControlGroup = group === "A";
+  const adSlotIndex = isControlGroup ? currentAdSlotIndex : adPosition - 1;
 
   return [
-    ...contentWithoutAdSlot.slice(0, adPosition - 1),
+    ...contentWithoutAdSlot.slice(0, adSlotIndex),
     {
       name: "ad",
       attributes: {
-        display: "inline",
-        width,
-        height,
         slotName,
+        ...(!isControlGroup && { display: "inline", width, height }),
       },
       children: [],
     },
-    ...contentWithoutAdSlot.slice(adPosition - 1),
+    ...contentWithoutAdSlot.slice(adSlotIndex),
   ];
 };
 
@@ -82,14 +86,14 @@ export const setupAd = (isTablet, variants, template, content) => {
 
   const { articleMpu } = variants;
 
-  if (
-    !articleMpu ||
-    articleMpu.group === "A" ||
-    (articleMpu && template !== "mainstandard")
-  )
+  if (!articleMpu || (articleMpu && template !== "mainstandard"))
     return content;
 
-  return setupArticleMpuTestAd(articleMpu, contentWithoutAdSlot);
+  return setupArticleMpuTestAd(
+    articleMpu,
+    currentAdSlotIndex,
+    contentWithoutAdSlot,
+  );
 };
 
 export const getStringBounds = (fontSettings, string) => {


### PR DESCRIPTION
Fix to correctly override the slotName of an ad when in the control group