### PR TITLE
fix: Set value passed into setTargeting to a string

### DIFF
--- a/packages/ad/src/utils/ad-init.js
+++ b/packages/ad/src/utils/ad-init.js
@@ -229,7 +229,7 @@ export default ({ el, data, platform, eventCallback, window }) => {
             slot.setTargeting("pos", slotName);
             if (/^native-inline-ad-/.test(slotName)) {
               const testGroup = ["a", "b", "c"].indexOf(slotName.slice(-1)) + 1;
-              slot.setTargeting("testgroup", testGroup);
+              slot.setTargeting("testgroup", testGroup.toString());
             }
             googletag.display(slotName);
             eventCallback(


### PR DESCRIPTION
Looks like Google's `setTargeting` requires a `string` value so must have been silently failing. I have converted the value from `number` to a `string` to hopefully fix.