### PR TITLE
feat(TNLT-5525): Dynamic front tiles 

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -779,8 +779,6 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View>
         <TileGFront
           orientation="portrait"
-          showByline={false}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -808,8 +806,6 @@ exports[`24. front lead two - landscape - medium 1`] = `
       <View>
         <TileGFront
           orientation="landscape"
-          showByline={false}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -1885,8 +1881,6 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View>
         <TileGFront
           orientation="portrait"
-          showByline={true}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -1914,8 +1908,6 @@ exports[`58. front lead two - landscape - wide 1`] = `
       <View>
         <TileGFront
           orientation="landscape"
-          showByline={false}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -3030,8 +3022,6 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View>
           <TileGFront
             orientation="portrait"
-            showByline={true}
-            showSummary={false}
             tileName="lead2"
           />
         </View>
@@ -3061,8 +3051,6 @@ exports[`92. front lead two - landscape - huge 1`] = `
         <View>
           <TileGFront
             orientation="landscape"
-            showByline={true}
-            showSummary={true}
             tileName="lead2"
           />
         </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -23,6 +23,7 @@ exports[`tile a front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -65,15 +66,80 @@ exports[`tile a front landscape 1024 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 42,
         "lineHeight": 42,
-        "marginBottom": 10,
       }
     }
-    summary={false}
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -560,6 +626,7 @@ exports[`tile a front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -602,15 +669,80 @@ exports[`tile a front landscape 1080 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
-    summary={false}
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -1097,6 +1229,7 @@ exports[`tile a front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1139,12 +1272,22 @@ exports[`tile a front landscape 1194 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 15,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -1194,6 +1337,14 @@ exports[`tile a front landscape 1194 1`] = `
           "name": "ad",
         },
       ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
     }
     template="mainstandard"
     tile={
@@ -1681,6 +1832,7 @@ exports[`tile a front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1723,15 +1875,80 @@ exports[`tile a front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 15,
       }
     }
-    summary={false}
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -2218,6 +2435,7 @@ exports[`tile a front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2260,12 +2478,22 @@ exports[`tile a front portrait 768 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -2316,6 +2544,7 @@ exports[`tile a front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2809,6 +3038,7 @@ exports[`tile a front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2851,12 +3081,22 @@ exports[`tile a front portrait 810 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -2907,6 +3147,7 @@ exports[`tile a front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3400,6 +3641,7 @@ exports[`tile a front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -3442,12 +3684,22 @@ exports[`tile a front portrait 834 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -3498,6 +3750,7 @@ exports[`tile a front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3991,6 +4244,7 @@ exports[`tile a front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -4033,12 +4287,22 @@ exports[`tile a front portrait 1024 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -4089,6 +4353,7 @@ exports[`tile a front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -23,6 +23,7 @@ exports[`tile b front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -64,15 +65,16 @@ exports[`tile b front landscape 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -121,6 +123,7 @@ exports[`tile b front landscape 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -614,6 +617,7 @@ exports[`tile b front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -655,15 +659,16 @@ exports[`tile b front landscape 1080 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -712,6 +717,7 @@ exports[`tile b front landscape 1080 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1205,6 +1211,7 @@ exports[`tile b front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -1246,15 +1253,16 @@ exports[`tile b front landscape 1194 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -1303,6 +1311,7 @@ exports[`tile b front landscape 1194 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1796,6 +1805,7 @@ exports[`tile b front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -1837,15 +1847,16 @@ exports[`tile b front landscape 1366 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -1894,6 +1905,7 @@ exports[`tile b front landscape 1366 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2387,6 +2399,7 @@ exports[`tile b front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -2428,15 +2441,16 @@ exports[`tile b front portrait 768 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -2485,6 +2499,7 @@ exports[`tile b front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2977,6 +2992,7 @@ exports[`tile b front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -3018,15 +3034,16 @@ exports[`tile b front portrait 810 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -3075,6 +3092,7 @@ exports[`tile b front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3567,6 +3585,7 @@ exports[`tile b front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -3608,15 +3627,16 @@ exports[`tile b front portrait 834 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -3665,6 +3685,7 @@ exports[`tile b front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4157,6 +4178,7 @@ exports[`tile b front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -4198,15 +4220,16 @@ exports[`tile b front portrait 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -4255,6 +4278,7 @@ exports[`tile b front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -23,22 +23,59 @@ exports[`tile f front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
     }
-    bylines={false}
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -48,6 +85,14 @@ exports[`tile f front landscape 1024 1`] = `
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -534,22 +579,59 @@ exports[`tile f front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
     }
-    bylines={false}
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -559,6 +641,14 @@ exports[`tile f front landscape 1080 1`] = `
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -1045,22 +1135,59 @@ exports[`tile f front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
     }
-    bylines={false}
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 50,
         "lineHeight": 50,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1070,6 +1197,14 @@ exports[`tile f front landscape 1194 1`] = `
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -1556,11 +1691,7 @@ exports[`tile f front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1603,25 +1734,33 @@ exports[`tile f front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -2108,11 +2247,7 @@ exports[`tile f front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2155,22 +2290,22 @@ exports[`tile f front portrait 768 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -2221,6 +2356,7 @@ exports[`tile f front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2714,11 +2850,7 @@ exports[`tile f front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2761,22 +2893,22 @@ exports[`tile f front portrait 810 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -2827,6 +2959,7 @@ exports[`tile f front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3320,11 +3453,7 @@ exports[`tile f front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -3367,22 +3496,22 @@ exports[`tile f front portrait 834 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -3433,6 +3562,7 @@ exports[`tile f front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3926,11 +4056,7 @@ exports[`tile f front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -3973,22 +4099,22 @@ exports[`tile f front portrait 1024 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -4039,6 +4165,7 @@ exports[`tile f front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -5,7 +5,6 @@ exports[`tile g front landscape 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -598,7 +597,6 @@ exports[`tile g front landscape 1080 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -1191,7 +1189,6 @@ exports[`tile g front landscape 1112 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -1784,7 +1781,6 @@ exports[`tile g front landscape 1194 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -2377,7 +2373,6 @@ exports[`tile g front landscape 1366 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -2970,7 +2965,6 @@ exports[`tile g front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -3562,7 +3556,6 @@ exports[`tile g front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4154,7 +4147,6 @@ exports[`tile g front portrait 834 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4746,7 +4738,6 @@ exports[`tile g front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -24,14 +24,106 @@ exports[`tile g front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -525,14 +617,106 @@ exports[`tile g front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1026,14 +1210,106 @@ exports[`tile g front landscape 1112 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1527,14 +1803,106 @@ exports[`tile g front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -2028,14 +2396,106 @@ exports[`tile g front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 35,
         "lineHeight": 35,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2528,14 +2988,106 @@ exports[`tile g front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3028,14 +3580,106 @@ exports[`tile g front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3528,14 +4172,106 @@ exports[`tile g front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4028,14 +4764,106 @@ exports[`tile g front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -12,6 +12,7 @@ exports[`tile h front landscape 1024 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -53,22 +54,22 @@ exports[`tile h front landscape 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 42,
         "lineHeight": 42,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 20,
         "lineHeight": 20,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -119,6 +120,7 @@ exports[`tile h front landscape 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -600,6 +602,7 @@ exports[`tile h front landscape 1080 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -641,22 +644,22 @@ exports[`tile h front landscape 1080 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -707,6 +710,7 @@ exports[`tile h front landscape 1080 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1188,6 +1192,7 @@ exports[`tile h front landscape 1112 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1229,22 +1234,22 @@ exports[`tile h front landscape 1112 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -1295,6 +1300,7 @@ exports[`tile h front landscape 1112 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1776,6 +1782,7 @@ exports[`tile h front landscape 1194 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1817,22 +1824,22 @@ exports[`tile h front landscape 1194 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 48,
         "lineHeight": 48,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -1883,6 +1890,7 @@ exports[`tile h front landscape 1194 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -2364,6 +2372,7 @@ exports[`tile h front landscape 1366 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -2405,22 +2414,22 @@ exports[`tile h front landscape 1366 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 15,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -2471,6 +2480,7 @@ exports[`tile h front landscape 1366 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2952,6 +2962,7 @@ exports[`tile h front portrait 768 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -2993,22 +3004,22 @@ exports[`tile h front portrait 768 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -3059,6 +3070,7 @@ exports[`tile h front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3540,6 +3552,7 @@ exports[`tile h front portrait 810 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -3581,22 +3594,22 @@ exports[`tile h front portrait 810 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -3647,6 +3660,7 @@ exports[`tile h front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4128,6 +4142,7 @@ exports[`tile h front portrait 834 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -4169,22 +4184,22 @@ exports[`tile h front portrait 834 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -4235,6 +4250,7 @@ exports[`tile h front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4716,6 +4732,7 @@ exports[`tile h front portrait 1024 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -4757,22 +4774,22 @@ exports[`tile h front portrait 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -4823,6 +4840,7 @@ exports[`tile h front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -779,8 +779,6 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View>
         <TileGFront
           orientation="portrait"
-          showByline={false}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -808,8 +806,6 @@ exports[`24. front lead two - landscape - medium 1`] = `
       <View>
         <TileGFront
           orientation="landscape"
-          showByline={false}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -1885,8 +1881,6 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View>
         <TileGFront
           orientation="portrait"
-          showByline={true}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -1914,8 +1908,6 @@ exports[`58. front lead two - landscape - wide 1`] = `
       <View>
         <TileGFront
           orientation="landscape"
-          showByline={false}
-          showSummary={false}
           tileName="lead2"
         />
       </View>
@@ -3030,8 +3022,6 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View>
           <TileGFront
             orientation="portrait"
-            showByline={true}
-            showSummary={false}
             tileName="lead2"
           />
         </View>
@@ -3061,8 +3051,6 @@ exports[`92. front lead two - landscape - huge 1`] = `
         <View>
           <TileGFront
             orientation="landscape"
-            showByline={true}
-            showSummary={true}
             tileName="lead2"
           />
         </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -23,6 +23,7 @@ exports[`tile a front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -65,15 +66,80 @@ exports[`tile a front landscape 1024 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 42,
         "lineHeight": 42,
-        "marginBottom": 10,
       }
     }
-    summary={false}
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -560,6 +626,7 @@ exports[`tile a front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -602,15 +669,80 @@ exports[`tile a front landscape 1080 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
-    summary={false}
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -1097,6 +1229,7 @@ exports[`tile a front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1139,12 +1272,22 @@ exports[`tile a front landscape 1194 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 15,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -1194,6 +1337,14 @@ exports[`tile a front landscape 1194 1`] = `
           "name": "ad",
         },
       ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
     }
     template="mainstandard"
     tile={
@@ -1681,6 +1832,7 @@ exports[`tile a front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1723,15 +1875,80 @@ exports[`tile a front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 15,
       }
     }
-    summary={false}
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -2218,6 +2435,7 @@ exports[`tile a front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2260,12 +2478,22 @@ exports[`tile a front portrait 768 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -2316,6 +2544,7 @@ exports[`tile a front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2809,6 +3038,7 @@ exports[`tile a front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2851,12 +3081,22 @@ exports[`tile a front portrait 810 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -2907,6 +3147,7 @@ exports[`tile a front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3400,6 +3641,7 @@ exports[`tile a front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -3442,12 +3684,22 @@ exports[`tile a front portrait 834 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -3498,6 +3750,7 @@ exports[`tile a front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3991,6 +4244,7 @@ exports[`tile a front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -4033,12 +4287,22 @@ exports[`tile a front portrait 1024 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 20,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 24,
+        "lineHeight": 24,
       }
     }
     summary={
@@ -4089,6 +4353,7 @@ exports[`tile a front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -23,6 +23,7 @@ exports[`tile b front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -64,15 +65,16 @@ exports[`tile b front landscape 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -121,6 +123,7 @@ exports[`tile b front landscape 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -614,6 +617,7 @@ exports[`tile b front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -655,15 +659,16 @@ exports[`tile b front landscape 1080 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -712,6 +717,7 @@ exports[`tile b front landscape 1080 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1205,6 +1211,7 @@ exports[`tile b front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -1246,15 +1253,16 @@ exports[`tile b front landscape 1194 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -1303,6 +1311,7 @@ exports[`tile b front landscape 1194 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1796,6 +1805,7 @@ exports[`tile b front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={10}
     bylines={
       Array [
         Object {
@@ -1837,15 +1847,16 @@ exports[`tile b front landscape 1366 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 10,
       }
     }
     showKeyline={false}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -1894,6 +1905,7 @@ exports[`tile b front landscape 1366 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2387,6 +2399,7 @@ exports[`tile b front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -2428,15 +2441,16 @@ exports[`tile b front portrait 768 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -2485,6 +2499,7 @@ exports[`tile b front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2977,6 +2992,7 @@ exports[`tile b front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -3018,15 +3034,16 @@ exports[`tile b front portrait 810 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -3075,6 +3092,7 @@ exports[`tile b front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3567,6 +3585,7 @@ exports[`tile b front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -3608,15 +3627,16 @@ exports[`tile b front portrait 834 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -3665,6 +3685,7 @@ exports[`tile b front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4157,6 +4178,7 @@ exports[`tile b front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -4198,15 +4220,16 @@ exports[`tile b front portrait 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     showKeyline={true}
+    straplineMarginBottom={0}
     summary={
       Array [
         Object {
@@ -4255,6 +4278,7 @@ exports[`tile b front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -23,22 +23,59 @@ exports[`tile f front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
     }
-    bylines={false}
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -48,6 +85,14 @@ exports[`tile f front landscape 1024 1`] = `
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -534,22 +579,59 @@ exports[`tile f front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
     }
-    bylines={false}
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -559,6 +641,14 @@ exports[`tile f front landscape 1080 1`] = `
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -1045,22 +1135,59 @@ exports[`tile f front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
     }
-    bylines={false}
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 50,
         "lineHeight": 50,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1070,6 +1197,14 @@ exports[`tile f front landscape 1194 1`] = `
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -1556,11 +1691,7 @@ exports[`tile f front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1603,25 +1734,33 @@ exports[`tile f front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 26,
         "lineHeight": 26,
-        "marginBottom": 15,
       }
     }
     summary={false}
+    summaryLineHeight={18}
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
     template="mainstandard"
     tile={
       Object {
@@ -2108,11 +2247,7 @@ exports[`tile f front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2155,22 +2290,22 @@ exports[`tile f front portrait 768 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -2221,6 +2356,7 @@ exports[`tile f front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2714,11 +2850,7 @@ exports[`tile f front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -2761,22 +2893,22 @@ exports[`tile f front portrait 810 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -2827,6 +2959,7 @@ exports[`tile f front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3320,11 +3453,7 @@ exports[`tile f front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -3367,22 +3496,22 @@ exports[`tile f front portrait 834 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -3433,6 +3562,7 @@ exports[`tile f front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3926,11 +4056,7 @@ exports[`tile f front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
-    bylineContainerStyle={
-      Object {
-        "marginBottom": 15,
-      }
-    }
+    bylineMarginBottom={0}
     bylines={
       Array [
         Object {
@@ -3973,22 +4099,22 @@ exports[`tile f front portrait 1024 1`] = `
       ]
     }
     columnCount={3}
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 5,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={25}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 30,
         "lineHeight": 30,
-        "marginBottom": 25,
       }
     }
     summary={
@@ -4039,6 +4165,7 @@ exports[`tile f front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={18}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -5,7 +5,6 @@ exports[`tile g front landscape 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -598,7 +597,6 @@ exports[`tile g front landscape 1080 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -1191,7 +1189,6 @@ exports[`tile g front landscape 1112 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -1784,7 +1781,6 @@ exports[`tile g front landscape 1194 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -2377,7 +2373,6 @@ exports[`tile g front landscape 1366 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
       "paddingRight": 10,
     }
@@ -2970,7 +2965,6 @@ exports[`tile g front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -3562,7 +3556,6 @@ exports[`tile g front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4154,7 +4147,6 @@ exports[`tile g front portrait 834 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4746,7 +4738,6 @@ exports[`tile g front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -24,14 +24,106 @@ exports[`tile g front landscape 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -525,14 +617,106 @@ exports[`tile g front landscape 1080 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1026,14 +1210,106 @@ exports[`tile g front landscape 1112 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1527,14 +1803,106 @@ exports[`tile g front landscape 1194 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={5}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 25,
         "lineHeight": 25,
-        "marginBottom": 5,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -2028,14 +2396,106 @@ exports[`tile g front landscape 1366 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 35,
         "lineHeight": 35,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2528,14 +2988,106 @@ exports[`tile g front portrait 768 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3028,14 +3580,106 @@ exports[`tile g front portrait 810 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3528,14 +4172,106 @@ exports[`tile g front portrait 834 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4028,14 +4764,106 @@ exports[`tile g front portrait 1024 1`] = `
     uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
   />
   <FrontTileSummary
+    bylineMarginBottom={15}
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 15,
       }
     }
+    straplineMarginBottom={0}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -12,6 +12,7 @@ exports[`tile h front landscape 1024 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -53,22 +54,22 @@ exports[`tile h front landscape 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 42,
         "lineHeight": 42,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 20,
         "lineHeight": 20,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -119,6 +120,7 @@ exports[`tile h front landscape 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -600,6 +602,7 @@ exports[`tile h front landscape 1080 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -641,22 +644,22 @@ exports[`tile h front landscape 1080 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -707,6 +710,7 @@ exports[`tile h front landscape 1080 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1188,6 +1192,7 @@ exports[`tile h front landscape 1112 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1229,22 +1234,22 @@ exports[`tile h front landscape 1112 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 45,
         "lineHeight": 45,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -1295,6 +1300,7 @@ exports[`tile h front landscape 1112 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -1776,6 +1782,7 @@ exports[`tile h front landscape 1194 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -1817,22 +1824,22 @@ exports[`tile h front landscape 1194 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 48,
         "lineHeight": 48,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 22,
         "lineHeight": 22,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -1883,6 +1890,7 @@ exports[`tile h front landscape 1194 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
@@ -2364,6 +2372,7 @@ exports[`tile h front landscape 1366 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -2405,22 +2414,22 @@ exports[`tile h front landscape 1366 1`] = `
         },
       ]
     }
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 55,
         "lineHeight": 55,
-        "marginBottom": 15,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -2471,6 +2480,7 @@ exports[`tile h front landscape 1366 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -2952,6 +2962,7 @@ exports[`tile h front portrait 768 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -2993,22 +3004,22 @@ exports[`tile h front portrait 768 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -3059,6 +3070,7 @@ exports[`tile h front portrait 768 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -3540,6 +3552,7 @@ exports[`tile h front portrait 810 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -3581,22 +3594,22 @@ exports[`tile h front portrait 810 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -3647,6 +3660,7 @@ exports[`tile h front portrait 810 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4128,6 +4142,7 @@ exports[`tile h front portrait 834 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -4169,22 +4184,22 @@ exports[`tile h front portrait 834 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -4235,6 +4250,7 @@ exports[`tile h front portrait 834 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,
@@ -4716,6 +4732,7 @@ exports[`tile h front portrait 1024 1`] = `
   url="/article/123"
 >
   <FrontTileSummary
+    bylineMarginBottom={15}
     bylines={
       Array [
         Object {
@@ -4757,22 +4774,22 @@ exports[`tile h front portrait 1024 1`] = `
         },
       ]
     }
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
         "fontSize": 40,
         "lineHeight": 40,
-        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
+    straplineMarginBottom={15}
     straplineStyle={
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
         "fontSize": 24,
         "lineHeight": 24,
-        "marginBottom": 15,
       }
     }
     summary={
@@ -4823,6 +4840,7 @@ exports[`tile h front portrait 1024 1`] = `
         },
       ]
     }
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 15,

--- a/packages/edition-slices/edition-front.showcase.js
+++ b/packages/edition-slices/edition-front.showcase.js
@@ -12,11 +12,20 @@ import {
   LeadTwoFrontSlice,
   LeadOneFullWidthFrontSlice,
 } from "./src/slices";
+import { getDimensions } from "@times-components-native/utils";
 
+const topNavHeight = 178;
+const bottomNavHeight = 48;
 const renderSlice = (Component, data) => () => {
+  const { height } = getDimensions("window");
   return (
     <Responsive>
-      <View style={{ flex: 1 }}>
+      <View
+        style={{
+          width: "100%",
+          height: height - topNavHeight - bottomNavHeight,
+        }}
+      >
         {
           <Component
             onPress={() => null}

--- a/packages/edition-slices/src/slices/frontleadtwo/index.js
+++ b/packages/edition-slices/src/slices/frontleadtwo/index.js
@@ -1,29 +1,19 @@
 import React from "react";
 import { ResponsiveSlice } from "@times-components-native/edition-slices/src/slices/shared";
 import { FrontLeadTwoSlice } from "@times-components-native/slice-layout";
-import { editionBreakpoints } from "@times-components-native/styleguide";
 import {
   TileGFront,
   TileHFront,
 } from "@times-components-native/edition-slices/src/tiles";
 import InTodaysEdition from "@times-components-native/in-todays-edition";
-import { getDimensions } from "@times-components-native/utils";
 
-function renderMedium(props, breakpoint, orientation) {
-  const { width: windowWidth } = getDimensions();
+function renderMedium(props, orientation) {
   const {
     onPress,
     onLinkPress,
     slice: { lead1, lead2 },
     inTodaysEditionSlice: { items: inTodaysEditionItems },
   } = props;
-
-  const showSummary =
-    breakpoint === editionBreakpoints.huge && orientation === "landscape";
-
-  const showByline =
-    (breakpoint === editionBreakpoints.huge && orientation === "landscape") ||
-    (orientation === "portrait" && windowWidth >= 834);
 
   return (
     <FrontLeadTwoSlice
@@ -41,8 +31,6 @@ function renderMedium(props, breakpoint, orientation) {
           tile={lead2}
           tileName="lead2"
           orientation={orientation}
-          showSummary={showSummary}
-          showByline={showByline}
         />
       }
       inTodaysEdition={
@@ -53,15 +41,14 @@ function renderMedium(props, breakpoint, orientation) {
           orientation={orientation}
         />
       }
-      breakpoint={breakpoint}
       orientation={orientation}
     />
   );
 }
 
 const FrontLeadTwo = (props) => {
-  const renderSlice = (breakpoint, orientation) =>
-    renderMedium(props, breakpoint, orientation);
+  const renderSlice = (_breakpoint, orientation) =>
+    renderMedium(props, orientation);
 
   return (
     <ResponsiveSlice

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -2,7 +2,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FrontTileSummary } from "@times-components-native/front-page";
-import { getTileImage, TileLink, withTileTracking, TileImage } from "../shared";
+import {
+  getTileImage,
+  TileLink,
+  withTileTracking,
+  TileImage,
+  getTileStrapline,
+} from "../shared";
 import { getStyle } from "./styles";
 import { getDimensions } from "@times-components-native/utils";
 
@@ -13,7 +19,6 @@ const TileAFront = ({ onPress, tile, orientation }) => {
   const isPortrait = orientation === "portrait";
   const columnCount = isPortrait ? 3 : 1;
   const crop = isPortrait ? "crop32" : "crop54";
-  const showSummary = isPortrait || (1080 < windowWidth && windowWidth < 1366);
   const imageCrop = getTileImage(tile, crop);
   const styles = getStyle(orientation, windowWidth);
 
@@ -21,6 +26,7 @@ const TileAFront = ({ onPress, tile, orientation }) => {
 
   const { article } = tile;
 
+  let strapline = getTileStrapline(tile);
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <TileImage
@@ -36,12 +42,18 @@ const TileAFront = ({ onPress, tile, orientation }) => {
       />
       <FrontTileSummary
         headlineStyle={styles.headline}
-        summary={showSummary && article.content}
+        summary={article.content}
         summaryStyle={styles.summary}
+        strapline={strapline}
+        straplineStyle={styles.strapline}
         tile={tile}
         template={article.template}
         columnCount={columnCount}
         bylines={article.bylines}
+        bylineMarginBottom={styles.bylineMarginBottom}
+        straplineMarginBottom={strapline ? styles.straplineMarginBottom : 0}
+        headlineMarginBottom={styles.headlineMarginBottom}
+        summaryLineHeight={styles.summary.lineHeight}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -51,7 +51,7 @@ const TileAFront = ({ onPress, tile, orientation }) => {
         columnCount={columnCount}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}
-        straplineMarginBottom={strapline ? styles.straplineMarginBottom : 0}
+        straplineMarginBottom={styles.straplineMarginBottom}
         headlineMarginBottom={styles.headlineMarginBottom}
         summaryLineHeight={styles.summary.lineHeight}
       />

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -2,6 +2,7 @@ import {
   fonts,
   spacing,
   globalSpacingStyles,
+  colours,
 } from "@times-components-native/styleguide";
 import { getStyleByDeviceSize } from "@times-components-native/styleguide/src/styleguide";
 
@@ -13,12 +14,13 @@ const summary = {
 const headline = {
   ...globalSpacingStyles.tabletHeadline,
   fontFamily: fonts.headline,
-  marginBottom: spacing(2),
 };
 
-const headlinePortrait = {
-  ...headline,
-  marginBottom: spacing(4),
+const strapline = {
+  fontFamily: fonts.headlineRegular,
+  color: colours.functional.primary,
+  fontSize: 24,
+  lineHeight: 24,
 };
 
 const sharedStyles = {
@@ -31,12 +33,32 @@ const sharedStyles = {
     width: "100%",
     marginBottom: spacing(2),
   },
+  summary: {
+    ...summary,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  strapline,
+};
+
+const sharedLandscapeStyles = {
+  ...sharedStyles,
+  headlineMarginBottom: spacing(2),
+  straplineMarginBottom: spacing(3),
+  bylineMarginBottom: spacing(3),
+};
+
+const sharedPortraitStyles = {
+  ...sharedStyles,
+  headlineMarginBottom: spacing(4),
+  straplineMarginBottom: spacing(3),
+  bylineMarginBottom: 0,
 };
 
 const styles = {
   landscape: {
     "1024": {
-      ...sharedStyles,
+      ...sharedLandscapeStyles,
       headline: {
         ...headline,
         fontSize: 42,
@@ -44,7 +66,7 @@ const styles = {
       },
     },
     "1080": {
-      ...sharedStyles,
+      ...sharedLandscapeStyles,
       headline: {
         ...headline,
         fontSize: 45,
@@ -52,59 +74,47 @@ const styles = {
       },
     },
     "1112": {
-      ...sharedStyles,
+      ...sharedLandscapeStyles,
       headline: {
         ...headline,
         fontSize: 45,
         lineHeight: 45,
-        marginBottom: spacing(3),
       },
     },
     "1366": {
-      ...sharedStyles,
+      ...sharedLandscapeStyles,
       headline: {
         ...headline,
         fontSize: 55,
         lineHeight: 55,
-        marginBottom: spacing(3),
       },
     },
   },
   portrait: {
     "768": {
-      ...sharedStyles,
+      ...sharedPortraitStyles,
       headline: {
-        ...headlinePortrait,
+        ...headline,
         fontSize: 42,
         lineHeight: 42,
       },
-      summary: {
-        ...summary,
-        fontSize: 14,
-        lineHeight: 18,
-      },
     },
     "810": {
-      ...sharedStyles,
+      ...sharedPortraitStyles,
       headline: {
-        ...headlinePortrait,
+        ...headline,
         fontSize: 45,
         lineHeight: 45,
       },
-      summary: {
-        ...summary,
-        fontSize: 14,
-        lineHeight: 18,
-      },
     },
     "1024": {
-      ...sharedStyles,
+      ...sharedPortraitStyles,
       imageContainer: {
-        ...sharedStyles.imageContainer,
+        ...sharedPortraitStyles.imageContainer,
         marginBottom: spacing(3),
       },
       headline: {
-        ...headlinePortrait,
+        ...headline,
         fontSize: 55,
         lineHeight: 55,
       },

--- a/packages/edition-slices/src/tiles/tile-b-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/index.js
@@ -33,6 +33,10 @@ const TileBFront = ({ onPress, tile, orientation }) => {
       />
       <FrontTileSummary
         headlineStyle={styles.headline}
+        headlineMarginBottom={styles.headlineMarginBottom}
+        bylineMarginBottom={styles.bylineMarginBottom}
+        straplineMarginBottom={0}
+        summaryLineHeight={styles.summary.lineHeight}
         summary={article.content}
         summaryStyle={
           article.template === "maincomment"

--- a/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
@@ -18,13 +18,11 @@ const commentSummary = {
 const headlineLandscape = {
   ...globalSpacingStyles.tabletHeadline,
   fontFamily: fonts.headline,
-  marginBottom: spacing(2),
 };
 
 const headlinePortrait = {
   ...globalSpacingStyles.tabletHeadline,
   fontFamily: fonts.headline,
-  marginBottom: spacing(3),
 };
 
 const sharedLandscapeStyles = {
@@ -37,6 +35,8 @@ const sharedLandscapeStyles = {
     width: "100%",
     marginBottom: spacing(2),
   },
+  headlineMarginBottom: spacing(2),
+  bylineMarginBottom: spacing(2),
 };
 
 const sharedPortraitStyles = {
@@ -49,6 +49,8 @@ const sharedPortraitStyles = {
     width: "100%",
     marginBottom: spacing(1),
   },
+  headlineMarginBottom: spacing(3),
+  bylineMarginBottom: spacing(3),
 };
 
 const styles = {

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from "react";
 import PropTypes from "prop-types";
-import { editionBreakpointWidths } from "@times-components-native/styleguide";
 import { FrontTileSummary } from "@times-components-native/front-page";
 import {
   getTileImage,
@@ -19,7 +18,6 @@ const TileFFront = ({ onPress, tile, orientation }) => {
   const columnCount = isLandscape ? 1 : 3;
   const hideSummary = isLandscape;
 
-  const isHugeLandscape = windowWidth >= editionBreakpointWidths.huge;
   const imageCrop = getTileImage(tile, "crop169");
   const styles = getStyle(orientation, windowWidth);
 
@@ -49,7 +47,7 @@ const TileFFront = ({ onPress, tile, orientation }) => {
         tile={tile}
         template={article.template}
         columnCount={columnCount}
-        bylines={(!isLandscape || isHugeLandscape) && article.bylines}
+        bylines={article.bylines}
         bylineContainerStyle={styles.bylineContainer}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -40,15 +40,18 @@ const TileFFront = ({ onPress, tile, orientation }) => {
       />
       <FrontTileSummary
         headlineStyle={styles.headline}
+        headlineMarginBottom={styles.headlineMarginBottom}
         summary={!hideSummary && article.content}
         summaryStyle={styles.summary}
+        summaryLineHeight={styles.summary.lineHeight}
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
+        straplineMarginBottom={styles.straplineMarginBottom}
         tile={tile}
         template={article.template}
         columnCount={columnCount}
         bylines={article.bylines}
-        bylineContainerStyle={styles.bylineContainer}
+        bylineMarginBottom={styles.bylineMarginBottom}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
@@ -19,6 +19,7 @@ const summary = {
 const strapline = {
   fontFamily: fonts.headlineRegular,
   color: colours.functional.primary,
+  marginBottom: spacing(3),
 };
 
 const sharedLandscapeStyles = {

--- a/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
@@ -19,7 +19,6 @@ const summary = {
 const strapline = {
   fontFamily: fonts.headlineRegular,
   color: colours.functional.primary,
-  marginBottom: spacing(3),
 };
 
 const sharedLandscapeStyles = {
@@ -28,13 +27,18 @@ const sharedLandscapeStyles = {
     paddingRight: spacing(2),
     flex: 1,
   },
-  bylineContainer: {
-    marginBottom: spacing(3),
-  },
   imageContainer: {
     width: "100%",
     marginBottom: spacing(1),
   },
+  summary: {
+    ...summary,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  straplineMarginBottom: spacing(3),
+  headlineMarginBottom: spacing(2),
+  bylineMarginBottom: spacing(3),
 };
 
 const sharedPortraitStyles = {
@@ -43,9 +47,9 @@ const sharedPortraitStyles = {
     flex: 1,
     flexDirection: "column",
   },
-  bylineContainer: {
-    marginBottom: spacing(3),
-  },
+  headlineMarginBottom: spacing(1),
+  straplineMarginBottom: spacing(3),
+  bylineMarginBottom: 0,
 };
 
 const styles = {
@@ -56,7 +60,6 @@ const styles = {
         ...headline,
         fontSize: 40,
         lineHeight: 40,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...strapline,
@@ -70,7 +73,6 @@ const styles = {
         ...headline,
         fontSize: 45,
         lineHeight: 45,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...strapline,
@@ -84,7 +86,6 @@ const styles = {
         ...headline,
         fontSize: 50,
         lineHeight: 50,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...strapline,
@@ -102,13 +103,11 @@ const styles = {
         ...headline,
         fontSize: 55,
         lineHeight: 55,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...strapline,
         fontSize: 26,
         lineHeight: 26,
-        marginBottom: spacing(3),
       },
     },
   },
@@ -119,7 +118,6 @@ const styles = {
         ...headline,
         fontSize: 42,
         lineHeight: 42,
-        marginBottom: spacing(1),
       },
       imageContainer: {
         width: "100%",
@@ -129,8 +127,8 @@ const styles = {
         ...strapline,
         fontSize: 24,
         lineHeight: 24,
-        marginBottom: spacing(2),
       },
+      straplineMarginBottom: spacing(2),
       summary: {
         ...summary,
         fontSize: 14,
@@ -143,7 +141,6 @@ const styles = {
         ...headline,
         fontSize: 45,
         lineHeight: 45,
-        marginBottom: spacing(1),
       },
       imageContainer: {
         width: "100%",
@@ -153,8 +150,8 @@ const styles = {
         ...strapline,
         fontSize: 24,
         lineHeight: 24,
-        marginBottom: spacing(3),
       },
+      straplineMarginBottom: spacing(3),
       summary: {
         ...summary,
         fontSize: 14,
@@ -167,7 +164,6 @@ const styles = {
         ...headline,
         fontSize: 45,
         lineHeight: 45,
-        marginBottom: spacing(2),
       },
       imageContainer: {
         width: "100%",
@@ -177,8 +173,8 @@ const styles = {
         ...strapline,
         fontSize: 24,
         lineHeight: 24,
-        marginBottom: spacing(3),
       },
+      straplineMarginBottom: spacing(3),
       summary: {
         ...summary,
         fontSize: 14,
@@ -191,7 +187,6 @@ const styles = {
         ...headline,
         fontSize: 55,
         lineHeight: 55,
-        marginBottom: spacing(1),
       },
       imageContainer: {
         width: "100%",
@@ -201,8 +196,8 @@ const styles = {
         ...strapline,
         fontSize: 30,
         lineHeight: 30,
-        marginBottom: spacing(5),
       },
+      straplineMarginBottom: spacing(5),
       summary: {
         ...summary,
         fontSize: 15,

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -39,7 +39,10 @@ const TileGFront = ({ onPress, tile, orientation }) => {
         tile={tile}
         bylines={article.bylines}
         template={article.template}
-        bylineContainerStyle={styles.bylineContainerStyle}
+        bylineMarginBottom={styles.bylineMarginBottom}
+        headlineMarginBottom={styles.headlineMarginBottom}
+        straplineMarginBottom={0}
+        summaryLineHeight={styles.summary.lineHeight}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -8,11 +8,7 @@ import { getDimensions } from "@times-components-native/utils";
 import { getTileImage, TileLink, withTileTracking, TileImage } from "../shared";
 import { getStyle } from "./styles";
 
-const TileGFront = ({
-  onPress,
-  tile,
-  orientation,
-}) => {
+const TileGFront = ({ onPress, tile, orientation }) => {
   const { width: windowWidth, height: windowHeight } = getDimensions();
   const crop = getTileImage(tile, "crop45");
   const styles = getStyle(orientation, windowWidth, windowHeight);

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -8,13 +8,7 @@ import { getDimensions } from "@times-components-native/utils";
 import { getTileImage, TileLink, withTileTracking, TileImage } from "../shared";
 import { getStyle } from "./styles";
 
-const TileGFront = ({
-  onPress,
-  tile,
-  orientation,
-  showSummary,
-  showByline,
-}) => {
+const TileGFront = ({ onPress, tile, orientation }) => {
   const { width: windowWidth } = getDimensions();
   const crop = getTileImage(tile, "crop45");
   const styles = getStyle(orientation, windowWidth);
@@ -40,11 +34,12 @@ const TileGFront = ({
       />
       <FrontTileSummary
         headlineStyle={styles.headline}
-        summary={showSummary && article.content}
+        summary={article.content}
         summaryStyle={styles.summary}
         tile={tile}
-        bylines={showByline && article.bylines}
+        bylines={article.bylines}
         template={article.template}
+        bylineContainerStyle={styles.bylineContainerStyle}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -22,7 +22,7 @@ const sharedStyles = {
     marginBottom: spacing(1),
   },
   summary: { ...sharedSummary },
-  bylineContainerStyle: { marginBottom: spacing(3) },
+  bylineMarginBottom: spacing(3),
 };
 
 const sharedLandscapeStyles = {
@@ -33,6 +33,7 @@ const sharedLandscapeStyles = {
     paddingRight: spacing(2),
     flex: 1,
   },
+  headlineMarginBottom: spacing(1),
 };
 
 const sharedPortraitStyles = {
@@ -42,6 +43,7 @@ const sharedPortraitStyles = {
     paddingLeft: spacing(2),
     flex: 1,
   },
+  headlineMarginBottom: spacing(2),
 };
 
 const styles = {
@@ -52,7 +54,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 22,
         lineHeight: 22,
-        marginBottom: spacing(1),
       },
     },
     "1080": {
@@ -61,7 +62,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 25,
         lineHeight: 25,
-        marginBottom: spacing(1),
       },
     },
     "1112": {
@@ -70,7 +70,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 25,
         lineHeight: 25,
-        marginBottom: spacing(1),
       },
     },
     "1194": {
@@ -79,7 +78,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 25,
         lineHeight: 25,
-        marginBottom: spacing(1),
       },
     },
     "1366": {
@@ -88,8 +86,8 @@ const styles = {
         ...sharedHeadline,
         fontSize: 35,
         lineHeight: 35,
-        marginBottom: spacing(3),
       },
+      headlineMarginBottom: spacing(3),
       summary: {
         ...sharedSummary,
         fontSize: 15,
@@ -103,7 +101,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 28,
         lineHeight: 28,
-        marginBottom: spacing(2),
       },
     },
     "810": {
@@ -112,7 +109,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 28,
         lineHeight: 28,
-        marginBottom: spacing(2),
       },
     },
     "834": {
@@ -121,7 +117,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 30,
         lineHeight: 30,
-        marginBottom: spacing(2),
       },
     },
     "1024": {
@@ -134,8 +129,8 @@ const styles = {
         ...sharedHeadline,
         fontSize: 40,
         lineHeight: 40,
-        marginBottom: spacing(3),
       },
+      headlineMarginBottom: spacing(3),
       summary: {
         ...sharedSummary,
         fontSize: 15,

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -22,6 +22,7 @@ const sharedStyles = {
     marginBottom: spacing(1),
   },
   summary: { ...sharedSummary },
+  bylineContainerStyle: { marginBottom: spacing(3) },
 };
 
 const sharedLandscapeStyles = {

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -28,7 +28,6 @@ const sharedStyles = {
 const sharedLandscapeStyles = {
   ...sharedStyles,
   container: {
-    paddingBottom: spacing(2),
     paddingLeft: spacing(2),
     paddingRight: spacing(2),
     flex: 1,
@@ -39,7 +38,6 @@ const sharedLandscapeStyles = {
 const sharedPortraitStyles = {
   ...sharedStyles,
   container: {
-    paddingBottom: spacing(2),
     paddingLeft: spacing(2),
     flex: 1,
   },

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -12,18 +12,26 @@ const TileHFront = ({ onPress, tile, orientation }) => {
 
   const { article } = tile;
 
+  let strapline = getTileStrapline(tile);
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <FrontTileSummary
         headlineStyle={styles.headline}
-        strapline={getTileStrapline(tile)}
+        headlineMarginBottom={styles.headlineMarginBottom}
+        strapline={strapline}
         straplineStyle={styles.strapline}
+        straplineMarginBottom={strapline ? styles.straplineMarginBottom : 0}
         summary={article.content}
         summaryStyle={styles.summary}
-        tile={tile}
+        summaryLineHeight={styles.summary.lineHeight}
         bylines={article.bylines}
+        bylineMarginBottom={
+          article.bylines && article.bylines.length
+            ? styles.bylineMarginBottom
+            : 0
+        }
+        tile={tile}
         template={article.template}
-        bylineContainerStyle={styles.bylineContainerStyle}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -20,16 +20,12 @@ const TileHFront = ({ onPress, tile, orientation }) => {
         headlineMarginBottom={styles.headlineMarginBottom}
         strapline={strapline}
         straplineStyle={styles.strapline}
-        straplineMarginBottom={strapline ? styles.straplineMarginBottom : 0}
+        straplineMarginBottom={styles.straplineMarginBottom}
         summary={article.content}
         summaryStyle={styles.summary}
         summaryLineHeight={styles.summary.lineHeight}
         bylines={article.bylines}
-        bylineMarginBottom={
-          article.bylines && article.bylines.length
-            ? styles.bylineMarginBottom
-            : 0
-        }
+        bylineMarginBottom={styles.bylineMarginBottom}
         tile={tile}
         template={article.template}
       />

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -23,6 +23,7 @@ const TileHFront = ({ onPress, tile, orientation }) => {
         tile={tile}
         bylines={article.bylines}
         template={article.template}
+        bylineContainerStyle={styles.bylineContainerStyle}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -25,6 +25,9 @@ const sharedSummary = {
 
 const sharedStyles = {
   summary: { ...sharedSummary },
+  bylineContainerStyle: {
+    marginBottom: spacing(3),
+  },
 };
 
 const sharedLandscapeStyles = {

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -14,7 +14,6 @@ const sharedHeadline = {
 const sharedStrapline = {
   fontFamily: fonts.headlineRegular,
   color: colours.functional.primary,
-  marginBottom: spacing(3),
 };
 
 const sharedSummary = {
@@ -25,9 +24,9 @@ const sharedSummary = {
 
 const sharedStyles = {
   summary: { ...sharedSummary },
-  bylineContainerStyle: {
-    marginBottom: spacing(3),
-  },
+  bylineMarginBottom: spacing(3),
+  headlineMarginBottom: spacing(2),
+  straplineMarginBottom: spacing(3),
 };
 
 const sharedLandscapeStyles = {
@@ -56,7 +55,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 42,
         lineHeight: 42,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -70,7 +68,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 45,
         lineHeight: 45,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -84,7 +81,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 45,
         lineHeight: 45,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -98,7 +94,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 48,
         lineHeight: 48,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -112,8 +107,8 @@ const styles = {
         ...sharedHeadline,
         fontSize: 55,
         lineHeight: 55,
-        marginBottom: spacing(3),
       },
+      headlineMarginBottom: spacing(3),
       strapline: {
         ...sharedStrapline,
         fontSize: 24,
@@ -132,7 +127,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 28,
         lineHeight: 28,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -146,7 +140,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 28,
         lineHeight: 28,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -164,7 +157,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 30,
         lineHeight: 30,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,
@@ -182,7 +174,6 @@ const styles = {
         ...sharedHeadline,
         fontSize: 40,
         lineHeight: 40,
-        marginBottom: spacing(2),
       },
       strapline: {
         ...sharedStrapline,

--- a/packages/fixture-generator/src/mock-tile.ts
+++ b/packages/fixture-generator/src/mock-tile.ts
@@ -10,7 +10,7 @@ class MockTile {
     this.tile = {
       articleId: "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
       article,
-      headline: "Three Conservative MPs resign Three Conservative MPs resign",
+      headline: "Three Conservative MPs resign",
       leadAsset: article.leadAsset,
       strapline: "Three Conservative MPs resign",
     };

--- a/packages/fixture-generator/src/mock-tile.ts
+++ b/packages/fixture-generator/src/mock-tile.ts
@@ -10,7 +10,7 @@ class MockTile {
     this.tile = {
       articleId: "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
       article,
-      headline: "This is tile headline",
+      headline: "Three Conservative MPs resign Three Conservative MPs resign",
       leadAsset: article.leadAsset,
       strapline: "Three Conservative MPs resign",
     };

--- a/packages/fixture-generator/src/mock-tile.ts
+++ b/packages/fixture-generator/src/mock-tile.ts
@@ -10,7 +10,7 @@ class MockTile {
     this.tile = {
       articleId: "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
       article,
-      headline: "Three Conservative MPs resign",
+      headline: "This is tile headline",
       leadAsset: article.leadAsset,
       strapline: "Three Conservative MPs resign",
     };

--- a/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
@@ -10,74 +10,88 @@ exports[`FrontTileSummary renders correctly 1`] = `
       Object {
         "flex": 1,
       },
+      Object {
+        "opacity": 0,
+      },
     ]
   }
 >
-  <ArticleSummaryHeadline
-    headline="This is tile headline"
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "blue",
+        "marginBottom": 0,
       }
     }
-  />
-  <ArticleSummaryStrapline
-    strapline="Strapline Text"
+  >
+    <ArticleSummaryHeadline
+      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "green",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-  />
-  <FrontPageByline
-    byline={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 0,
+        "opacity": 0,
+      }
     }
-  />
-  <FrontArticleSummaryContent
-    bylines={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
-    }
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Test",
+  >
+    <FrontPageByline
+      byline={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "foo": "bar",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ]
-    }
-    summaryStyle={
-      Object {
-        "backgroundColor": "orange",
+            ],
+          },
+        ]
       }
-    }
-    template="mainstandard"
-  />
+      containerStyle={
+        Array [
+          undefined,
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;
 
@@ -91,75 +105,89 @@ exports[`FrontTileSummary renders with keyline 1`] = `
       Object {
         "flex": 1,
       },
+      Object {
+        "opacity": 0,
+      },
     ]
   }
 >
-  <ArticleSummaryHeadline
-    headline="This is tile headline"
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "blue",
+        "marginBottom": 0,
       }
     }
-  />
-  <ArticleSummaryStrapline
-    strapline="Strapline Text"
+  >
+    <ArticleSummaryHeadline
+      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "green",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-  />
-  <FrontPageByline
-    byline={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 0,
+        "opacity": 0,
+      }
     }
-    showKeyline={true}
-  />
-  <FrontArticleSummaryContent
-    bylines={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
-    }
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Test",
+  >
+    <FrontPageByline
+      byline={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "foo": "bar",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ]
-    }
-    summaryStyle={
-      Object {
-        "backgroundColor": "orange",
+            ],
+          },
+        ]
       }
-    }
-    template="mainstandard"
-  />
+      containerStyle={
+        Array [
+          undefined,
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+      showKeyline={true}
+    />
+  </View>
 </View>
 `;
 
@@ -173,61 +201,65 @@ exports[`FrontTileSummary renders with more than 1 columns 1`] = `
       Object {
         "flex": 1,
       },
+      Object {
+        "opacity": 0,
+      },
     ]
   }
 >
-  <ArticleSummaryHeadline
-    headline="This is tile headline"
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "blue",
+        "marginBottom": 0,
       }
     }
-  />
-  <ArticleSummaryStrapline
-    strapline="Strapline Text"
+  >
+    <ArticleSummaryHeadline
+      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "green",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-  />
-  <FrontArticleSummaryContent
-    bylines={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
-    }
-    columnCount={2}
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Test",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ]
-    }
-    summaryStyle={
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
       Object {
-        "backgroundColor": "orange",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-    template="mainstandard"
   />
 </View>
 `;
@@ -242,49 +274,65 @@ exports[`FrontTileSummary renders without byline 1`] = `
       Object {
         "flex": 1,
       },
+      Object {
+        "opacity": 0,
+      },
     ]
   }
 >
-  <ArticleSummaryHeadline
-    headline="This is tile headline"
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "blue",
+        "marginBottom": 0,
       }
     }
-  />
-  <ArticleSummaryStrapline
-    strapline="Strapline Text"
+  >
+    <ArticleSummaryHeadline
+      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "green",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-  />
-  <FrontArticleSummaryContent
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Test",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ]
-    }
-    summaryStyle={
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
       Object {
-        "backgroundColor": "orange",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-    template="mainstandard"
   />
 </View>
 `;
@@ -299,65 +347,73 @@ exports[`FrontTileSummary renders without strapline 1`] = `
       Object {
         "flex": 1,
       },
+      Object {
+        "opacity": 0,
+      },
     ]
   }
 >
-  <ArticleSummaryHeadline
-    headline="This is tile headline"
+  <View
+    onLayout={[Function]}
     style={
       Object {
-        "backgroundColor": "blue",
+        "marginBottom": 0,
       }
     }
-  />
-  <FrontPageByline
-    byline={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
-    }
-  />
-  <FrontArticleSummaryContent
-    bylines={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "foo": "bar",
-            },
-          ],
-        },
-      ]
-    }
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Test",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ]
-    }
-    summaryStyle={
+  >
+    <ArticleSummaryHeadline
+      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
       Object {
-        "backgroundColor": "orange",
+        "marginBottom": 0,
+        "opacity": 0,
       }
     }
-    template="mainstandard"
   />
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 0,
+        "opacity": 0,
+      }
+    }
+  >
+    <FrontPageByline
+      byline={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "foo": "bar",
+              },
+            ],
+          },
+        ]
+      }
+      containerStyle={
+        Array [
+          undefined,
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;

--- a/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
@@ -23,9 +23,10 @@ exports[`FrontTileSummary renders correctly 1`] = `
         "marginBottom": 0,
       }
     }
+    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
-      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      headline="This is tile headline"
       style={
         Array [
           Object {
@@ -46,6 +47,7 @@ exports[`FrontTileSummary renders correctly 1`] = `
         "opacity": 0,
       }
     }
+    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -69,6 +71,7 @@ exports[`FrontTileSummary renders correctly 1`] = `
         "opacity": 0,
       }
     }
+    testID="bylineWrapper"
   >
     <FrontPageByline
       byline={
@@ -118,9 +121,10 @@ exports[`FrontTileSummary renders with keyline 1`] = `
         "marginBottom": 0,
       }
     }
+    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
-      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      headline="This is tile headline"
       style={
         Array [
           Object {
@@ -141,6 +145,7 @@ exports[`FrontTileSummary renders with keyline 1`] = `
         "opacity": 0,
       }
     }
+    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -164,6 +169,7 @@ exports[`FrontTileSummary renders with keyline 1`] = `
         "opacity": 0,
       }
     }
+    testID="bylineWrapper"
   >
     <FrontPageByline
       byline={
@@ -214,9 +220,10 @@ exports[`FrontTileSummary renders with more than 1 columns 1`] = `
         "marginBottom": 0,
       }
     }
+    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
-      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      headline="This is tile headline"
       style={
         Array [
           Object {
@@ -237,6 +244,7 @@ exports[`FrontTileSummary renders with more than 1 columns 1`] = `
         "opacity": 0,
       }
     }
+    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -260,6 +268,7 @@ exports[`FrontTileSummary renders with more than 1 columns 1`] = `
         "opacity": 0,
       }
     }
+    testID="bylineWrapper"
   />
 </View>
 `;
@@ -287,9 +296,10 @@ exports[`FrontTileSummary renders without byline 1`] = `
         "marginBottom": 0,
       }
     }
+    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
-      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      headline="This is tile headline"
       style={
         Array [
           Object {
@@ -310,6 +320,7 @@ exports[`FrontTileSummary renders without byline 1`] = `
         "opacity": 0,
       }
     }
+    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -333,6 +344,7 @@ exports[`FrontTileSummary renders without byline 1`] = `
         "opacity": 0,
       }
     }
+    testID="bylineWrapper"
   />
 </View>
 `;
@@ -360,9 +372,10 @@ exports[`FrontTileSummary renders without strapline 1`] = `
         "marginBottom": 0,
       }
     }
+    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
-      headline="Three Conservative MPs resign Three Conservative MPs resign"
+      headline="This is tile headline"
       style={
         Array [
           Object {
@@ -383,6 +396,7 @@ exports[`FrontTileSummary renders without strapline 1`] = `
         "opacity": 0,
       }
     }
+    testID="straplineWrapper"
   />
   <View
     onLayout={[Function]}
@@ -392,6 +406,239 @@ exports[`FrontTileSummary renders without strapline 1`] = `
         "opacity": 0,
       }
     }
+    testID="bylineWrapper"
+  >
+    <FrontPageByline
+      byline={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "foo": "bar",
+              },
+            ],
+          },
+        ]
+      }
+      containerStyle={
+        Array [
+          undefined,
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`FrontTileSummary shows front tile summary with content once headline/strapline/byline are measured 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "opacity": 1,
+      },
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+    testID="headlineWrapper"
+  >
+    <ArticleSummaryHeadline
+      headline="This is tile headline"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 20,
+        "opacity": 1,
+      }
+    }
+    testID="straplineWrapper"
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 15,
+        "opacity": 1,
+      }
+    }
+    testID="bylineWrapper"
+  >
+    <FrontPageByline
+      byline={
+        Array [
+          Object {
+            "byline": Array [
+              Object {
+                "foo": "bar",
+              },
+            ],
+          },
+        ]
+      }
+      containerStyle={
+        Array [
+          undefined,
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <FrontArticleSummaryContent
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "foo": "bar",
+            },
+          ],
+        },
+      ]
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Test",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "backgroundColor": "orange",
+      }
+    }
+    template="mainstandard"
+  />
+</View>
+`;
+
+exports[`FrontTileSummary shows front tile summary without content once headline/strapline/byline are measured 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "opacity": 1,
+      },
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+    testID="headlineWrapper"
+  >
+    <ArticleSummaryHeadline
+      headline="This is tile headline"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 0,
+        "opacity": 1,
+      }
+    }
+    testID="straplineWrapper"
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 0,
+        "opacity": 0,
+      }
+    }
+    testID="bylineWrapper"
   >
     <FrontPageByline
       byline={

--- a/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FrontTileSummary renders correctly 1`] = `
+exports[`FrontTileSummary performs measurements before rendering front tile summary 1`] = `
 <View
   style={
     Array [
@@ -18,11 +18,6 @@ exports[`FrontTileSummary renders correctly 1`] = `
 >
   <View
     onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-      }
-    }
     testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
@@ -41,12 +36,6 @@ exports[`FrontTileSummary renders correctly 1`] = `
   </View>
   <View
     onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
     testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
@@ -65,12 +54,6 @@ exports[`FrontTileSummary renders correctly 1`] = `
   </View>
   <View
     onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
     testID="bylineWrapper"
   >
     <FrontPageByline
@@ -98,7 +81,7 @@ exports[`FrontTileSummary renders correctly 1`] = `
 </View>
 `;
 
-exports[`FrontTileSummary renders with keyline 1`] = `
+exports[`FrontTileSummary renders byline with keyline 1`] = `
 <View
   style={
     Array [
@@ -109,19 +92,17 @@ exports[`FrontTileSummary renders with keyline 1`] = `
         "flex": 1,
       },
       Object {
-        "opacity": 0,
+        "opacity": 1,
       },
     ]
   }
 >
   <View
-    onLayout={[Function]}
     style={
       Object {
-        "marginBottom": 0,
+        "marginBottom": 10,
       }
     }
-    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
       headline="This is tile headline"
@@ -138,14 +119,11 @@ exports[`FrontTileSummary renders with keyline 1`] = `
     />
   </View>
   <View
-    onLayout={[Function]}
     style={
       Object {
-        "marginBottom": 0,
-        "opacity": 0,
+        "marginBottom": 20,
       }
     }
-    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -162,14 +140,11 @@ exports[`FrontTileSummary renders with keyline 1`] = `
     />
   </View>
   <View
-    onLayout={[Function]}
     style={
       Object {
-        "marginBottom": 0,
-        "opacity": 0,
+        "marginBottom": 15,
       }
     }
-    testID="bylineWrapper"
   >
     <FrontPageByline
       byline={
@@ -194,246 +169,46 @@ exports[`FrontTileSummary renders with keyline 1`] = `
       showKeyline={true}
     />
   </View>
-</View>
-`;
-
-exports[`FrontTileSummary renders with more than 1 columns 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "red",
-      },
-      Object {
-        "flex": 1,
-      },
-      Object {
-        "opacity": 0,
-      },
-    ]
-  }
->
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-      }
+  <FrontArticleSummaryContent
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "foo": "bar",
+            },
+          ],
+        },
+      ]
     }
-    testID="headlineWrapper"
-  >
-    <ArticleSummaryHeadline
-      headline="This is tile headline"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "blue",
-          },
-          Object {
-            "marginBottom": 0,
-          },
-        ]
-      }
-    />
-  </View>
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
-    testID="straplineWrapper"
-  >
-    <ArticleSummaryStrapline
-      strapline="Strapline Text"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "green",
-          },
-          Object {
-            "marginBottom": 0,
-          },
-        ]
-      }
-    />
-  </View>
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
-    testID="bylineWrapper"
-  />
-</View>
-`;
-
-exports[`FrontTileSummary renders without byline 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "red",
-      },
-      Object {
-        "flex": 1,
-      },
-      Object {
-        "opacity": 0,
-      },
-    ]
-  }
->
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-      }
-    }
-    testID="headlineWrapper"
-  >
-    <ArticleSummaryHeadline
-      headline="This is tile headline"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "blue",
-          },
-          Object {
-            "marginBottom": 0,
-          },
-        ]
-      }
-    />
-  </View>
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
-    testID="straplineWrapper"
-  >
-    <ArticleSummaryStrapline
-      strapline="Strapline Text"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "green",
-          },
-          Object {
-            "marginBottom": 0,
-          },
-        ]
-      }
-    />
-  </View>
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
-    testID="bylineWrapper"
-  />
-</View>
-`;
-
-exports[`FrontTileSummary renders without strapline 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "red",
-      },
-      Object {
-        "flex": 1,
-      },
-      Object {
-        "opacity": 0,
-      },
-    ]
-  }
->
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-      }
-    }
-    testID="headlineWrapper"
-  >
-    <ArticleSummaryHeadline
-      headline="This is tile headline"
-      style={
-        Array [
-          Object {
-            "backgroundColor": "blue",
-          },
-          Object {
-            "marginBottom": 0,
-          },
-        ]
-      }
-    />
-  </View>
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
-    testID="straplineWrapper"
-  />
-  <View
-    onLayout={[Function]}
-    style={
-      Object {
-        "marginBottom": 0,
-        "opacity": 0,
-      }
-    }
-    testID="bylineWrapper"
-  >
-    <FrontPageByline
-      byline={
-        Array [
-          Object {
-            "byline": Array [
-              Object {
-                "foo": "bar",
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Test",
               },
-            ],
-          },
-        ]
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "backgroundColor": "orange",
       }
-      containerStyle={
-        Array [
-          undefined,
-          Object {
-            "marginBottom": 0,
-          },
-        ]
-      }
-    />
-  </View>
+    }
+    template="mainstandard"
+  />
 </View>
 `;
 
-exports[`FrontTileSummary shows front tile summary with content once headline/strapline/byline are measured 1`] = `
+exports[`FrontTileSummary renders with 2 columns 1`] = `
 <View
   style={
     Array [
@@ -450,13 +225,11 @@ exports[`FrontTileSummary shows front tile summary with content once headline/st
   }
 >
   <View
-    onLayout={[Function]}
     style={
       Object {
         "marginBottom": 10,
       }
     }
-    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
       headline="This is tile headline"
@@ -473,14 +246,11 @@ exports[`FrontTileSummary shows front tile summary with content once headline/st
     />
   </View>
   <View
-    onLayout={[Function]}
     style={
       Object {
         "marginBottom": 20,
-        "opacity": 1,
       }
     }
-    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -497,14 +267,181 @@ exports[`FrontTileSummary shows front tile summary with content once headline/st
     />
   </View>
   <View
-    onLayout={[Function]}
     style={
       Object {
         "marginBottom": 15,
-        "opacity": 1,
       }
     }
-    testID="bylineWrapper"
+  />
+  <FrontArticleSummaryContent
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "foo": "bar",
+            },
+          ],
+        },
+      ]
+    }
+    columnCount={2}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Test",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "backgroundColor": "orange",
+      }
+    }
+    template="mainstandard"
+  />
+</View>
+`;
+
+exports[`FrontTileSummary renders with a missing byline 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "opacity": 1,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
+    <ArticleSummaryHeadline
+      headline="This is tile headline"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 20,
+      }
+    }
+  >
+    <ArticleSummaryStrapline
+      strapline="Strapline Text"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "green",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <FrontArticleSummaryContent
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Test",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "backgroundColor": "orange",
+      }
+    }
+    template="mainstandard"
+  />
+</View>
+`;
+
+exports[`FrontTileSummary renders with a missing strapline 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "opacity": 1,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  >
+    <ArticleSummaryHeadline
+      headline="This is tile headline"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <FrontPageByline
       byline={
@@ -567,7 +504,7 @@ exports[`FrontTileSummary shows front tile summary with content once headline/st
 </View>
 `;
 
-exports[`FrontTileSummary shows front tile summary without content once headline/strapline/byline are measured 1`] = `
+exports[`FrontTileSummary shows front tile summary with headline only after measurement has been taken 1`] = `
 <View
   style={
     Array [
@@ -584,13 +521,51 @@ exports[`FrontTileSummary shows front tile summary without content once headline
   }
 >
   <View
-    onLayout={[Function]}
+    style={
+      Object {
+        "marginBottom": 0,
+      }
+    }
+  >
+    <ArticleSummaryHeadline
+      headline="This is tile headline"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "blue",
+          },
+          Object {
+            "marginBottom": 0,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`FrontTileSummary shows front tile summary with headline/strapline/byline/content after measurement has been taken 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "opacity": 1,
+      },
+    ]
+  }
+>
+  <View
     style={
       Object {
         "marginBottom": 10,
       }
     }
-    testID="headlineWrapper"
   >
     <ArticleSummaryHeadline
       headline="This is tile headline"
@@ -607,14 +582,11 @@ exports[`FrontTileSummary shows front tile summary without content once headline
     />
   </View>
   <View
-    onLayout={[Function]}
     style={
       Object {
-        "marginBottom": 0,
-        "opacity": 1,
+        "marginBottom": 20,
       }
     }
-    testID="straplineWrapper"
   >
     <ArticleSummaryStrapline
       strapline="Strapline Text"
@@ -631,14 +603,11 @@ exports[`FrontTileSummary shows front tile summary without content once headline
     />
   </View>
   <View
-    onLayout={[Function]}
     style={
       Object {
-        "marginBottom": 0,
-        "opacity": 0,
+        "marginBottom": 15,
       }
     }
-    testID="bylineWrapper"
   >
     <FrontPageByline
       byline={
@@ -662,5 +631,41 @@ exports[`FrontTileSummary shows front tile summary without content once headline
       }
     />
   </View>
+  <FrontArticleSummaryContent
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "foo": "bar",
+            },
+          ],
+        },
+      ]
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Test",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "backgroundColor": "orange",
+      }
+    }
+    template="mainstandard"
+  />
 </View>
 `;

--- a/packages/front-page/__tests__/front-tile-summary.test.js
+++ b/packages/front-page/__tests__/front-tile-summary.test.js
@@ -1,6 +1,6 @@
 import ReactTestRenderer from "react-test-renderer";
 import React from "react";
-import { FrontTileSummary } from "@times-components-native/front-page";
+import FrontTileSummary from "../front-tile-summary";
 import { MockTile } from "@times-components-native/fixture-generator";
 
 jest.mock(
@@ -16,6 +16,13 @@ jest.mock("@times-components-native/article-byline", () => "ArticleByline");
 jest.mock("@times-components-native/front-page/front-page-byline", () => ({
   FrontPageByline: "FrontPageByline",
 }));
+
+jest.mock("@times-components-native/front-page/MeasureContainer", () => {
+  const MockMeasureContainer = ({ render }) => {
+    return render({ height: 180, width: 200 });
+  };
+  return { MeasureContainer: MockMeasureContainer };
+});
 
 const summaryContent = [
   {

--- a/packages/front-page/__tests__/front-tile-summary.test.js
+++ b/packages/front-page/__tests__/front-tile-summary.test.js
@@ -19,7 +19,7 @@ jest.mock("@times-components-native/front-page/front-page-byline", () => ({
 
 jest.mock("@times-components-native/front-page/MeasureContainer", () => {
   const MockMeasureContainer = ({ render }) => {
-    return render({ height: 180, width: 200 });
+    return render({ height: 200, width: 200 });
   };
   return { MeasureContainer: MockMeasureContainer };
 });
@@ -62,6 +62,10 @@ const props = {
   strapline: "Strapline Text",
   template: "mainstandard",
   summaryStyle: { backgroundColor: "orange" },
+  headlineMarginBottom: 10,
+  straplineMarginBottom: 20,
+  bylineMarginBottom: 15,
+  summaryLineHeight: 20,
 };
 
 describe("FrontTileSummary", () => {
@@ -100,6 +104,56 @@ describe("FrontTileSummary", () => {
       <FrontTileSummary {...props} showKeyline={true} />,
     );
 
+    expect(renderer.toJSON()).toMatchSnapshot();
+  });
+
+  it("shows front tile summary without content once headline/strapline/byline are measured", () => {
+    let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
+
+    ReactTestRenderer.act(() => {
+      renderer.root
+        .findByProps({
+          testID: "headlineWrapper",
+        })
+        .props["onLayout"]({ nativeEvent: { layout: { height: 120 } } });
+
+      renderer.root
+        .findByProps({
+          testID: "straplineWrapper",
+        })
+        .props["onLayout"]({ nativeEvent: { layout: { height: 40 } } });
+
+      renderer.root
+        .findByProps({
+          testID: "bylineWrapper",
+        })
+        .props["onLayout"]({ nativeEvent: { layout: { height: 40 } } });
+    });
+    expect(renderer.toJSON()).toMatchSnapshot();
+  });
+
+  it("shows front tile summary with content once headline/strapline/byline are measured", () => {
+    let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
+
+    ReactTestRenderer.act(() => {
+      renderer.root
+        .findByProps({
+          testID: "headlineWrapper",
+        })
+        .props["onLayout"]({ nativeEvent: { layout: { height: 10 } } });
+
+      renderer.root
+        .findByProps({
+          testID: "straplineWrapper",
+        })
+        .props["onLayout"]({ nativeEvent: { layout: { height: 10 } } });
+
+      renderer.root
+        .findByProps({
+          testID: "bylineWrapper",
+        })
+        .props["onLayout"]({ nativeEvent: { layout: { height: 10 } } });
+    });
     expect(renderer.toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/front-page/__tests__/front-tile-summary.test.js
+++ b/packages/front-page/__tests__/front-tile-summary.test.js
@@ -17,9 +17,10 @@ jest.mock("@times-components-native/front-page/front-page-byline", () => ({
   FrontPageByline: "FrontPageByline",
 }));
 
+const mockContainerHeight = 200;
 jest.mock("@times-components-native/front-page/MeasureContainer", () => {
   const MockMeasureContainer = ({ render }) => {
-    return render({ height: 200, width: 200 });
+    return render({ height: mockContainerHeight, width: 200 });
   };
   return { MeasureContainer: MockMeasureContainer };
 });
@@ -68,92 +69,116 @@ const props = {
   summaryLineHeight: 20,
 };
 
+const simulateMeasurement = (
+  renderer,
+  { headlineHeight = 20, straplineHeight = 20, bylineHeight = 20 },
+) => {
+  ReactTestRenderer.act(() => {
+    renderer.root
+      .findByProps({
+        testID: "headlineWrapper",
+      })
+      .props["onLayout"]({
+        nativeEvent: { layout: { height: headlineHeight } },
+      });
+
+    renderer.root
+      .findByProps({
+        testID: "straplineWrapper",
+      })
+      .props["onLayout"]({
+        nativeEvent: { layout: { height: straplineHeight } },
+      });
+
+    renderer.root
+      .findByProps({
+        testID: "bylineWrapper",
+      })
+      .props["onLayout"]({ nativeEvent: { layout: { height: bylineHeight } } });
+  });
+};
+
 describe("FrontTileSummary", () => {
-  it("renders correctly", () => {
+  it("performs measurements before rendering front tile summary", () => {
     let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
 
     expect(renderer.toJSON()).toMatchSnapshot();
   });
 
-  it("renders without byline", () => {
+  it("shows front tile summary with headline only after measurement has been taken", () => {
+    let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
+    simulateMeasurement(renderer, {
+      headlineHeight: mockContainerHeight,
+      bylineHeight: 20,
+      straplineHeight: 20,
+    });
+
+    expect(renderer.toJSON()).toMatchSnapshot();
+  });
+
+  it("shows front tile summary with headline/strapline/byline/content after measurement has been taken", () => {
+    let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
+    simulateMeasurement(renderer, {
+      headlineHeight: 20,
+      bylineHeight: 20,
+      straplineHeight: 20,
+    });
+    expect(renderer.toJSON()).toMatchSnapshot();
+  });
+
+  it("renders with a missing byline", () => {
     let renderer = ReactTestRenderer.create(
       <FrontTileSummary {...props} bylines={undefined} />,
     );
 
+    simulateMeasurement(renderer, {
+      headlineHeight: 20,
+      bylineHeight: 0,
+      straplineHeight: 20,
+    });
+
     expect(renderer.toJSON()).toMatchSnapshot();
   });
 
-  it("renders without strapline", () => {
+  it("renders with a missing strapline", () => {
     let renderer = ReactTestRenderer.create(
       <FrontTileSummary {...props} strapline={undefined} />,
     );
 
+    simulateMeasurement(renderer, {
+      headlineHeight: 20,
+      bylineHeight: 20,
+      straplineHeight: 0,
+    });
+
     expect(renderer.toJSON()).toMatchSnapshot();
   });
 
-  it("renders with more than 1 columns", () => {
+  it("renders with 2 columns", () => {
     let renderer = ReactTestRenderer.create(
       <FrontTileSummary {...props} columnCount={2} />,
     );
 
+    simulateMeasurement(renderer, {
+      headlineHeight: 20,
+      bylineHeight: 20,
+      straplineHeight: 20,
+    });
+
     expect(renderer.toJSON()).toMatchSnapshot();
   });
 
-  it("renders with keyline", () => {
+  it("renders byline with keyline", () => {
     let renderer = ReactTestRenderer.create(
       <FrontTileSummary {...props} showKeyline={true} />,
     );
 
-    expect(renderer.toJSON()).toMatchSnapshot();
-  });
-
-  it("shows front tile summary without content once headline/strapline/byline are measured", () => {
-    let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
-
-    ReactTestRenderer.act(() => {
-      renderer.root
-        .findByProps({
-          testID: "headlineWrapper",
-        })
-        .props["onLayout"]({ nativeEvent: { layout: { height: 120 } } });
-
-      renderer.root
-        .findByProps({
-          testID: "straplineWrapper",
-        })
-        .props["onLayout"]({ nativeEvent: { layout: { height: 40 } } });
-
-      renderer.root
-        .findByProps({
-          testID: "bylineWrapper",
-        })
-        .props["onLayout"]({ nativeEvent: { layout: { height: 40 } } });
+    simulateMeasurement(renderer, {
+      headlineHeight: 20,
+      bylineHeight: 20,
+      straplineHeight: 20,
     });
-    expect(renderer.toJSON()).toMatchSnapshot();
-  });
 
-  it("shows front tile summary with content once headline/strapline/byline are measured", () => {
-    let renderer = ReactTestRenderer.create(<FrontTileSummary {...props} />);
-
-    ReactTestRenderer.act(() => {
-      renderer.root
-        .findByProps({
-          testID: "headlineWrapper",
-        })
-        .props["onLayout"]({ nativeEvent: { layout: { height: 10 } } });
-
-      renderer.root
-        .findByProps({
-          testID: "straplineWrapper",
-        })
-        .props["onLayout"]({ nativeEvent: { layout: { height: 10 } } });
-
-      renderer.root
-        .findByProps({
-          testID: "bylineWrapper",
-        })
-        .props["onLayout"]({ nativeEvent: { layout: { height: 10 } } });
-    });
     expect(renderer.toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -1,0 +1,297 @@
+import { getFrontTileConfig } from "../utils/get-front-tile-config";
+
+describe("getFrontTileConfig", () => {
+  it("fits headline only", () => {
+    const summaryConfig = {
+      container: {
+        height: 100,
+      },
+      headline: {
+        height: 100,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 100,
+        marginBottom: 20,
+      },
+      bylines: {
+        height: 100,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 0,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: false,
+      },
+      content: {
+        marginBottom: 0,
+        show: false,
+      },
+      strapline: {
+        marginBottom: 0,
+        show: false,
+      },
+    });
+  });
+
+  it("fits headline and strapline", () => {
+    const summaryConfig = {
+      container: {
+        height: 200,
+      },
+      headline: {
+        height: 100,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      bylines: {
+        height: 100,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 20,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: false,
+      },
+      content: {
+        marginBottom: 0,
+        show: false,
+      },
+      strapline: {
+        marginBottom: 0,
+        show: true,
+      },
+    });
+  });
+
+  it("fits headline, strapline and byline", () => {
+    const summaryConfig = {
+      container: {
+        height: 300,
+      },
+      headline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      bylines: {
+        height: 100,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 20,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: true,
+      },
+      strapline: {
+        marginBottom: 20,
+        show: true,
+      },
+      content: {
+        marginBottom: 0,
+        show: false,
+      },
+    });
+  });
+
+  it("fits headline, strapline, byline and 2 lines of content", () => {
+    const summaryConfig = {
+      container: {
+        height: 340,
+      },
+      headline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      bylines: {
+        height: 80,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 20,
+        show: true,
+      },
+      byline: {
+        marginBottom: 20,
+        show: true,
+      },
+      strapline: {
+        marginBottom: 20,
+        show: true,
+      },
+      content: {
+        marginBottom: 0,
+        show: true,
+      },
+    });
+  });
+
+  it("fits headline, strapline, byline and hides content if only 1 line fits", () => {
+    const summaryConfig = {
+      container: {
+        height: 320,
+      },
+      headline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      bylines: {
+        height: 80,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 20,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: true,
+      },
+      strapline: {
+        marginBottom: 20,
+        show: true,
+      },
+      content: {
+        marginBottom: 0,
+        show: false,
+      },
+    });
+  });
+
+  it("fits headline and byline (when strapline is missing)", () => {
+    const summaryConfig = {
+      container: {
+        height: 200,
+      },
+      headline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 0,
+        marginBottom: 0,
+      },
+      bylines: {
+        height: 100,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 20,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: true,
+      },
+      strapline: {
+        marginBottom: 0,
+        show: true,
+      },
+      content: {
+        marginBottom: 0,
+        show: false,
+      },
+    });
+  });
+
+  it("fits headline and content (when strapline and byline are missing)", () => {
+    const summaryConfig = {
+      container: {
+        height: 200,
+      },
+      headline: {
+        height: 80,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 0,
+        marginBottom: 0,
+      },
+      bylines: {
+        height: 0,
+        marginBottom: 0,
+      },
+      content: {
+        lineHeight: 20,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 20,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: true,
+      },
+      strapline: {
+        marginBottom: 0,
+        show: true,
+      },
+      content: {
+        marginBottom: 0,
+        show: true,
+      },
+    });
+  });
+});

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -222,7 +222,7 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 0,
-        marginBottom: 0,
+        marginBottom: 20,
       },
       bylines: {
         height: 100,
@@ -243,7 +243,7 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 0,
+        marginBottom: 20,
         show: false,
       },
       content: {
@@ -264,11 +264,11 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 0,
-        marginBottom: 0,
+        marginBottom: 20,
       },
       bylines: {
         height: 0,
-        marginBottom: 0,
+        marginBottom: 20,
       },
       content: {
         lineHeight: 20,
@@ -281,11 +281,11 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       byline: {
-        marginBottom: 0,
+        marginBottom: 20,
         show: false,
       },
       strapline: {
-        marginBottom: 0,
+        marginBottom: 20,
         show: false,
       },
       content: {

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -244,7 +244,7 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         marginBottom: 0,
-        show: true,
+        show: false,
       },
       content: {
         marginBottom: 0,
@@ -282,11 +282,11 @@ describe("getFrontTileConfig", () => {
       },
       byline: {
         marginBottom: 0,
-        show: true,
+        show: false,
       },
       strapline: {
         marginBottom: 0,
-        show: true,
+        show: false,
       },
       content: {
         marginBottom: 0,

--- a/packages/front-page/front-page-byline/index.tsx
+++ b/packages/front-page/front-page-byline/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, View, ViewStyle } from "react-native";
+import { StyleProp, Text, View, ViewStyle } from "react-native";
 import ArticleByline from "@times-components-native/article-byline";
 import styleFactory from "./styles";
 import { Markup } from "@times-components-native/fixture-generator/src/types";
@@ -7,7 +7,7 @@ import { Markup } from "@times-components-native/fixture-generator/src/types";
 interface Props {
   byline: Markup;
   showKeyline?: boolean;
-  containerStyle?: ViewStyle;
+  containerStyle?: StyleProp<ViewStyle>;
 }
 export const FrontPageByline: React.FC<Props> = ({
   byline,

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -122,7 +122,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
             marginBottom: props.bylineMarginBottom,
           },
           content: {
-            lineHeight: props.summaryStyle.lineHeight,
+            lineHeight: props.summaryLineHeight,
           },
         });
 

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -92,6 +92,12 @@ const renderByline = (props: Props) => {
 };
 
 const FrontTileSummary: React.FC<Props> = (props) => {
+  const {
+    bylineMarginBottom,
+    straplineMarginBottom,
+    headlineMarginBottom,
+    summaryLineHeight,
+  } = props;
   const styles = styleFactory();
   const [headlineHeight, setHeadlineHeight] = useState();
   const [straplineHeight, setStraplineHeight] = useState();
@@ -102,73 +108,103 @@ const FrontTileSummary: React.FC<Props> = (props) => {
     straplineHeight !== undefined &&
     bylineHeight !== undefined;
 
-  return (
-    <MeasureContainer
-      render={({ height }) => {
-        const frontTileConfig = getFrontTileConfig({
-          container: {
-            height,
-          },
-          headline: {
-            height: headlineHeight,
-            marginBottom: props.headlineMarginBottom,
-          },
-          strapline: {
-            height: straplineHeight,
-            marginBottom: props.straplineMarginBottom,
-          },
-          bylines: {
-            height: bylineHeight,
-            marginBottom: props.bylineMarginBottom,
-          },
-          content: {
-            lineHeight: props.summaryLineHeight,
-          },
-        });
-
-        return (
-          <View
-            style={[
-              props.containerStyle,
-              styles.container,
-              { opacity: allMeasured ? 1 : 0 },
-            ]}
-          >
-            <View
-              testID={"headlineWrapper"}
-              onLayout={(e) => setHeadlineHeight(e.nativeEvent.layout.height)}
-              style={{
-                marginBottom: frontTileConfig.headline.marginBottom,
-              }}
-            >
-              {renderHeadline(props)}
-            </View>
-            <View
-              testID={"straplineWrapper"}
-              onLayout={(e) => setStraplineHeight(e.nativeEvent.layout.height)}
-              style={{
-                opacity: frontTileConfig.strapline.show ? 1 : 0,
-                marginBottom: frontTileConfig.strapline.marginBottom,
-              }}
-            >
-              {renderStrapline(props)}
-            </View>
-            <View
-              testID={"bylineWrapper"}
-              style={{
-                opacity: frontTileConfig.byline.show ? 1 : 0,
-                marginBottom: frontTileConfig.byline.marginBottom,
-              }}
-              onLayout={(e) => setBylineHeight(e.nativeEvent.layout.height)}
-            >
-              {renderByline(props)}
-            </View>
-            {frontTileConfig.content.show && renderContent(props)}
-          </View>
-        );
-      }}
-    />
+  const TileSummaryContainer: React.FC<{ hidden: boolean }> = ({
+    children,
+    hidden,
+  }) => (
+    <View
+      style={[
+        props.containerStyle,
+        styles.container,
+        { opacity: hidden ? 0 : 1 },
+      ]}
+    >
+      {children}
+    </View>
   );
+
+  return [
+    !allMeasured && (
+      <TileSummaryContainer hidden key={"unmeasured"}>
+        <View
+          testID={"headlineWrapper"}
+          onLayout={(e) => setHeadlineHeight(e.nativeEvent.layout.height)}
+        >
+          {renderHeadline(props)}
+        </View>
+        <View
+          testID={"straplineWrapper"}
+          onLayout={(e) => setStraplineHeight(e.nativeEvent.layout.height)}
+        >
+          {renderStrapline(props)}
+        </View>
+        <View
+          testID={"bylineWrapper"}
+          onLayout={(e) => setBylineHeight(e.nativeEvent.layout.height)}
+        >
+          {renderByline(props)}
+        </View>
+      </TileSummaryContainer>
+    ),
+    allMeasured && (
+      <MeasureContainer
+        key={"measured"}
+        render={({ height }) => {
+          const frontTileConfig = getFrontTileConfig({
+            container: {
+              height,
+            },
+            headline: {
+              height: headlineHeight,
+              marginBottom: headlineMarginBottom,
+            },
+            strapline: {
+              height: straplineHeight,
+              marginBottom: straplineMarginBottom,
+            },
+            bylines: {
+              height: bylineHeight,
+              marginBottom: bylineMarginBottom,
+            },
+            content: {
+              lineHeight: summaryLineHeight,
+            },
+          });
+
+          return (
+            <TileSummaryContainer hidden={false}>
+              <View
+                style={{
+                  marginBottom: frontTileConfig.headline.marginBottom,
+                }}
+              >
+                {renderHeadline(props)}
+              </View>
+              {frontTileConfig.strapline.show && (
+                <View
+                  style={{
+                    marginBottom: frontTileConfig.strapline.marginBottom,
+                  }}
+                >
+                  {renderStrapline(props)}
+                </View>
+              )}
+              {frontTileConfig.byline.show && (
+                <View
+                  style={{
+                    marginBottom: frontTileConfig.byline.marginBottom,
+                  }}
+                >
+                  {renderByline(props)}
+                </View>
+              )}
+              {frontTileConfig.content.show && renderContent(props)}
+            </TileSummaryContainer>
+          );
+        }}
+      />
+    ),
+  ];
 };
 
 export default FrontTileSummary;

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -135,6 +135,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
             ]}
           >
             <View
+              testID={"headlineWrapper"}
               onLayout={(e) => setHeadlineHeight(e.nativeEvent.layout.height)}
               style={{
                 marginBottom: frontTileConfig.headline.marginBottom,
@@ -143,6 +144,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
               {renderHeadline(props)}
             </View>
             <View
+              testID={"straplineWrapper"}
               onLayout={(e) => setStraplineHeight(e.nativeEvent.layout.height)}
               style={{
                 opacity: frontTileConfig.strapline.show ? 1 : 0,
@@ -152,6 +154,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
               {renderStrapline(props)}
             </View>
             <View
+              testID={"bylineWrapper"}
               style={{
                 opacity: frontTileConfig.byline.show ? 1 : 0,
                 marginBottom: frontTileConfig.byline.marginBottom,

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -5,14 +5,15 @@ import {
 } from "@times-components-native/article-summary";
 
 import { View } from "react-native";
-import styleFactory from "@times-components-native/front-page/styles";
+import styleFactory from "./styles";
 import FrontArticleSummaryContent from "./front-article-summary-content";
 import {
   Markup,
   TemplateType,
 } from "@times-components-native/fixture-generator/src/types";
-import { FrontPageByline } from "@times-components-native/front-page/front-page-byline";
-import { MeasureContainer } from "@times-components-native/front-page/MeasureContainer";
+import { FrontPageByline } from "./front-page-byline";
+import { MeasureContainer } from "./MeasureContainer";
+import { getFrontTileConfig } from "./utils/get-front-tile-config";
 
 interface Props {
   columnCount?: number;
@@ -27,6 +28,10 @@ interface Props {
   bylines?: Markup;
   showKeyline?: boolean;
   bylineContainerStyle?: any;
+  headlineMarginBottom: number;
+  straplineMarginBottom: number;
+  bylineMarginBottom: number;
+  summaryLineHeight: number;
 }
 
 const renderContent = (props: Props) => {
@@ -86,48 +91,6 @@ const renderByline = (props: Props) => {
   );
 };
 
-const getFrontTileConfig = (
-  props: Props,
-  height: number,
-  headlineHeight: any,
-  straplineHeight: any,
-  bylineHeight: any,
-) => {
-  const roomForStrapline = height > headlineHeight + straplineHeight;
-
-  const roomForByline =
-    height > headlineHeight + straplineHeight + bylineHeight;
-
-  const roomForContent =
-    height - (headlineHeight + straplineHeight + bylineHeight) >
-    props.summaryStyle.lineHeight * 2;
-
-  return {
-    headline: {
-      show: true,
-      marginBottom:
-        roomForStrapline || roomForByline || roomForContent
-          ? props.headlineStyle.marginBottom
-          : 0,
-    },
-    strapline: {
-      show: roomForStrapline,
-      marginBottom:
-        props.strapline && (roomForByline || roomForContent)
-          ? props.straplineStyle.marginBottom
-          : 0,
-    },
-    byline: {
-      show: roomForByline,
-      marginBottom:
-        props.bylines && props.bylines.length && roomForContent
-          ? props.bylineContainerStyle.marginBottom
-          : 0,
-    },
-    content: { show: roomForContent, marginBottom: 0 },
-  };
-};
-
 const FrontTileSummary: React.FC<Props> = (props) => {
   const styles = styleFactory();
   const [headlineHeight, setHeadlineHeight] = useState();
@@ -142,13 +105,26 @@ const FrontTileSummary: React.FC<Props> = (props) => {
   return (
     <MeasureContainer
       render={({ height }) => {
-        const frontTileConfig = getFrontTileConfig(
-          props,
-          height,
-          headlineHeight,
-          straplineHeight,
-          bylineHeight,
-        );
+        const frontTileConfig = getFrontTileConfig({
+          container: {
+            height,
+          },
+          headline: {
+            height: headlineHeight,
+            marginBottom: props.headlineMarginBottom,
+          },
+          strapline: {
+            height: straplineHeight,
+            marginBottom: props.straplineMarginBottom,
+          },
+          bylines: {
+            height: bylineHeight,
+            marginBottom: props.bylineMarginBottom,
+          },
+          content: {
+            lineHeight: props.summaryStyle.lineHeight,
+          },
+        });
 
         return (
           <View

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -123,88 +123,90 @@ const FrontTileSummary: React.FC<Props> = (props) => {
     </View>
   );
 
-  return [
-    !allMeasured && (
-      <TileSummaryContainer hidden key={"unmeasured"}>
-        <View
-          testID={"headlineWrapper"}
-          onLayout={(e) => setHeadlineHeight(e.nativeEvent.layout.height)}
-        >
-          {renderHeadline(props)}
-        </View>
-        <View
-          testID={"straplineWrapper"}
-          onLayout={(e) => setStraplineHeight(e.nativeEvent.layout.height)}
-        >
-          {renderStrapline(props)}
-        </View>
-        <View
-          testID={"bylineWrapper"}
-          onLayout={(e) => setBylineHeight(e.nativeEvent.layout.height)}
-        >
-          {renderByline(props)}
-        </View>
-      </TileSummaryContainer>
-    ),
-    allMeasured && (
-      <MeasureContainer
-        key={"measured"}
-        render={({ height }) => {
-          const frontTileConfig = getFrontTileConfig({
-            container: {
-              height,
-            },
-            headline: {
-              height: headlineHeight,
-              marginBottom: headlineMarginBottom,
-            },
-            strapline: {
-              height: straplineHeight,
-              marginBottom: straplineMarginBottom,
-            },
-            bylines: {
-              height: bylineHeight,
-              marginBottom: bylineMarginBottom,
-            },
-            content: {
-              lineHeight: summaryLineHeight,
-            },
-          });
+  return (
+    <>
+      {!allMeasured && (
+        <TileSummaryContainer hidden key={"unmeasured"}>
+          <View
+            testID={"headlineWrapper"}
+            onLayout={(e) => setHeadlineHeight(e.nativeEvent.layout.height)}
+          >
+            {renderHeadline(props)}
+          </View>
+          <View
+            testID={"straplineWrapper"}
+            onLayout={(e) => setStraplineHeight(e.nativeEvent.layout.height)}
+          >
+            {renderStrapline(props)}
+          </View>
+          <View
+            testID={"bylineWrapper"}
+            onLayout={(e) => setBylineHeight(e.nativeEvent.layout.height)}
+          >
+            {renderByline(props)}
+          </View>
+        </TileSummaryContainer>
+      )}
+      {allMeasured && (
+        <MeasureContainer
+          key={"measured"}
+          render={({ height }) => {
+            const frontTileConfig = getFrontTileConfig({
+              container: {
+                height,
+              },
+              headline: {
+                height: headlineHeight,
+                marginBottom: headlineMarginBottom,
+              },
+              strapline: {
+                height: straplineHeight,
+                marginBottom: straplineMarginBottom,
+              },
+              bylines: {
+                height: bylineHeight,
+                marginBottom: bylineMarginBottom,
+              },
+              content: {
+                lineHeight: summaryLineHeight,
+              },
+            });
 
-          return (
-            <TileSummaryContainer hidden={false}>
-              <View
-                style={{
-                  marginBottom: frontTileConfig.headline.marginBottom,
-                }}
-              >
-                {renderHeadline(props)}
-              </View>
-              {frontTileConfig.strapline.show && (
+            return (
+              <TileSummaryContainer hidden={false}>
                 <View
                   style={{
-                    marginBottom: frontTileConfig.strapline.marginBottom,
+                    marginBottom: frontTileConfig.headline.marginBottom,
                   }}
                 >
-                  {renderStrapline(props)}
+                  {renderHeadline(props)}
                 </View>
-              )}
-              {frontTileConfig.byline.show && (
-                <View
-                  style={{
-                    marginBottom: frontTileConfig.byline.marginBottom,
-                  }}
-                >
-                  {renderByline(props)}
-                </View>
-              )}
-              {frontTileConfig.content.show && renderContent(props)}
-            </TileSummaryContainer>
-          );
-        }}
-      />
-    ),
-  ];
+                {frontTileConfig.strapline.show && (
+                  <View
+                    style={{
+                      marginBottom: frontTileConfig.strapline.marginBottom,
+                    }}
+                  >
+                    {renderStrapline(props)}
+                  </View>
+                )}
+                {frontTileConfig.byline.show && (
+                  <View
+                    style={{
+                      marginBottom: frontTileConfig.byline.marginBottom,
+                    }}
+                  >
+                    {renderByline(props)}
+                  </View>
+                )}
+                {frontTileConfig.content.show && renderContent(props)}
+              </TileSummaryContainer>
+            );
+          }}
+        />
+      )}
+    </>
+  );
 };
 
 export default FrontTileSummary;

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -24,26 +24,24 @@ interface SummaryConfig {
 export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
   const { container, headline, strapline, bylines, content } = summaryConfig;
 
+  const headlineWithMargin = headline.height + headline.marginBottom;
+
+  const straplineWithMargin =
+    strapline.height > 0 ? strapline.height + strapline.marginBottom : 0;
+
+  const bylineWithMargin =
+    bylines.height > 0 ? bylines.height + bylines.marginBottom : 0;
+
   const canAccommodateStrapline =
-    container.height >=
-    headline.height + headline.marginBottom + strapline.height;
+    container.height >= headlineWithMargin + strapline.height;
 
   const canAccommodateByline =
     container.height >=
-    headline.height +
-      headline.marginBottom +
-      strapline.height +
-      strapline.marginBottom +
-      bylines.height;
+    headlineWithMargin + straplineWithMargin + bylines.height;
 
   const canAccommodateContent =
     container.height -
-      (headline.height +
-        headline.marginBottom +
-        strapline.height +
-        strapline.marginBottom +
-        bylines.height +
-        bylines.marginBottom) >=
+      (headlineWithMargin + straplineWithMargin + bylineWithMargin) >=
     content.lineHeight * minimumNumberOfTeaserTextLines;
 
   return {

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -55,14 +55,14 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
           : 0,
     },
     strapline: {
-      show: canAccommodateStrapline,
+      show: strapline.height > 0 && canAccommodateStrapline,
       marginBottom:
         canAccommodateByline || canAccommodateContent
           ? strapline.marginBottom
           : 0,
     },
     byline: {
-      show: canAccommodateByline,
+      show: bylines.height > 0 && canAccommodateByline,
       marginBottom: canAccommodateContent ? bylines.marginBottom : 0,
     },
     content: { show: canAccommodateContent, marginBottom: 0 },

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -1,0 +1,70 @@
+const minimumNumberOfTeaserTextLines = 2;
+
+interface SummaryConfig {
+  container: {
+    height: number;
+  };
+  headline: {
+    height: number;
+    marginBottom: number;
+  };
+  strapline: {
+    height: number;
+    marginBottom: number;
+  };
+  bylines: {
+    height: number;
+    marginBottom: number;
+  };
+  content: {
+    lineHeight: number;
+  };
+}
+
+export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
+  const { container, headline, strapline, bylines, content } = summaryConfig;
+
+  const canAccommodateStrapline =
+    container.height >=
+    headline.height + headline.marginBottom + strapline.height;
+
+  const canAccommodateByline =
+    container.height >=
+    headline.height +
+      headline.marginBottom +
+      strapline.height +
+      strapline.marginBottom +
+      bylines.height;
+
+  const canAccommodateContent =
+    container.height -
+      (headline.height +
+        headline.marginBottom +
+        strapline.height +
+        strapline.marginBottom +
+        bylines.height +
+        bylines.marginBottom) >=
+    content.lineHeight * minimumNumberOfTeaserTextLines;
+
+  return {
+    headline: {
+      show: true,
+      marginBottom:
+        canAccommodateStrapline || canAccommodateByline || canAccommodateContent
+          ? headline.marginBottom
+          : 0,
+    },
+    strapline: {
+      show: canAccommodateStrapline,
+      marginBottom:
+        canAccommodateByline || canAccommodateContent
+          ? strapline.marginBottom
+          : 0,
+    },
+    byline: {
+      show: canAccommodateByline,
+      marginBottom: canAccommodateContent ? bylines.marginBottom : 0,
+    },
+    content: { show: canAccommodateContent, marginBottom: 0 },
+  };
+};

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -16,15 +16,6 @@ import {
   createPuzzleData,
   isSupplementSection,
 } from "./utils";
-// import {
-//   mockInTodaysEditionSlice,
-//   mockLeadOneAndOneFrontSlice,
-//   mockLeadOneFullWidthFrontSlice,
-//   mockLeadTwoFrontSlice,
-// } from "@times-components-native/fixture-generator";
-// import FrontLeadTwo from "@times-components-native/edition-slices/src/slices/frontleadtwo";
-// import FrontLeadOne from "@times-components-native/edition-slices/src/slices/frontleadone";
-// import FrontLeadOneAndOne from "@times-components-native/edition-slices/src/slices/frontleadoneandone";
 
 const styles = styleFactory();
 
@@ -118,26 +109,6 @@ class Section extends Component {
       <Responsive>
         <ResponsiveContext.Consumer>
           {({ isTablet, editionBreakpoint }) => {
-            // return (
-            //   <FrontLeadOneAndOne
-            //     slice={mockLeadOneAndOneFrontSlice()}
-            //     inTodaysEditionSlice={mockInTodaysEditionSlice()}
-            //   />
-            // );
-
-            // return (
-            //   <FrontLeadOne
-            //     slice={mockLeadOneFullWidthFrontSlice()}
-            //     inTodaysEditionSlice={mockInTodaysEditionSlice()}
-            //   />
-            // );
-            //
-            // return (
-            //   <FrontLeadTwo
-            //     slice={mockLeadTwoFrontSlice()}
-            //     inTodaysEditionSlice={mockInTodaysEditionSlice()}
-            //   />
-            // );
             if (name === "FrontPageSection") {
               return this.renderItem({ index: 0, item: slices[0] });
             }

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -16,15 +16,15 @@ import {
   createPuzzleData,
   isSupplementSection,
 } from "./utils";
-import {
-  mockInTodaysEditionSlice,
-  mockLeadOneAndOneFrontSlice,
-  mockLeadOneFullWidthFrontSlice,
-  mockLeadTwoFrontSlice,
-} from "@times-components-native/fixture-generator";
-import FrontLeadTwo from "@times-components-native/edition-slices/src/slices/frontleadtwo";
-import FrontLeadOne from "@times-components-native/edition-slices/src/slices/frontleadone";
-import FrontLeadOneAndOne from "@times-components-native/edition-slices/src/slices/frontleadoneandone";
+// import {
+//   mockInTodaysEditionSlice,
+//   mockLeadOneAndOneFrontSlice,
+//   mockLeadOneFullWidthFrontSlice,
+//   mockLeadTwoFrontSlice,
+// } from "@times-components-native/fixture-generator";
+// import FrontLeadTwo from "@times-components-native/edition-slices/src/slices/frontleadtwo";
+// import FrontLeadOne from "@times-components-native/edition-slices/src/slices/frontleadone";
+// import FrontLeadOneAndOne from "@times-components-native/edition-slices/src/slices/frontleadoneandone";
 
 const styles = styleFactory();
 
@@ -132,12 +132,12 @@ class Section extends Component {
             //   />
             // );
             //
-            return (
-              <FrontLeadTwo
-                slice={mockLeadTwoFrontSlice()}
-                inTodaysEditionSlice={mockInTodaysEditionSlice()}
-              />
-            );
+            // return (
+            //   <FrontLeadTwo
+            //     slice={mockLeadTwoFrontSlice()}
+            //     inTodaysEditionSlice={mockInTodaysEditionSlice()}
+            //   />
+            // );
             if (name === "FrontPageSection") {
               return this.renderItem({ index: 0, item: slices[0] });
             }

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -16,6 +16,15 @@ import {
   createPuzzleData,
   isSupplementSection,
 } from "./utils";
+import {
+  mockInTodaysEditionSlice,
+  mockLeadOneAndOneFrontSlice,
+  mockLeadOneFullWidthFrontSlice,
+  mockLeadTwoFrontSlice,
+} from "@times-components-native/fixture-generator";
+import FrontLeadTwo from "@times-components-native/edition-slices/src/slices/frontleadtwo";
+import FrontLeadOne from "@times-components-native/edition-slices/src/slices/frontleadone";
+import FrontLeadOneAndOne from "@times-components-native/edition-slices/src/slices/frontleadoneandone";
 
 const styles = styleFactory();
 
@@ -109,6 +118,26 @@ class Section extends Component {
       <Responsive>
         <ResponsiveContext.Consumer>
           {({ isTablet, editionBreakpoint }) => {
+            // return (
+            //   <FrontLeadOneAndOne
+            //     slice={mockLeadOneAndOneFrontSlice()}
+            //     inTodaysEditionSlice={mockInTodaysEditionSlice()}
+            //   />
+            // );
+
+            // return (
+            //   <FrontLeadOne
+            //     slice={mockLeadOneFullWidthFrontSlice()}
+            //     inTodaysEditionSlice={mockInTodaysEditionSlice()}
+            //   />
+            // );
+            //
+            return (
+              <FrontLeadTwo
+                slice={mockLeadTwoFrontSlice()}
+                inTodaysEditionSlice={mockInTodaysEditionSlice()}
+              />
+            );
             if (name === "FrontPageSection") {
               return this.renderItem({ index: 0, item: slices[0] });
             }


### PR DESCRIPTION
When rendering the front page summary, we now do the following:
1. Pre-render the headline/strapline/byline into the tile container to check how high each will be.
2. Measure the height of the tile container
3. Work out which text strings can fit into the container based on their priority - this information is worked out by the `getFrontTileConfig` helper
4. Render text strings.  The last text string in the tile summary will have its marginBottom set to 0, which is to ensure that text can use up all available space.

**Order of priority**
Headline > Strapline > Byline > Content

**With strapline**
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-10-16 at 11 16 52](https://user-images.githubusercontent.com/6280629/96248469-8b888d00-0fa3-11eb-8568-afea701deb16.png)
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-10-16 at 11 17 04](https://user-images.githubusercontent.com/6280629/96248455-87f50600-0fa3-11eb-8a5e-8ea3e788db40.png)

**Without strapline**
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-10-16 at 11 14 20](https://user-images.githubusercontent.com/6280629/96248481-8d525080-0fa3-11eb-9461-fda579835562.png)
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-10-16 at 11 15 18](https://user-images.githubusercontent.com/6280629/96248479-8d525080-0fa3-11eb-9dd0-4590ab56d726.png)
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-10-16 at 11 15 34](https://user-images.githubusercontent.com/6280629/96248476-8cb9ba00-0fa3-11eb-889a-eb6a5ad765c2.png)
