### PR TITLE
feat: (TNLT-5530) Add ratio refinement for getting style by device size

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -2211,7 +2211,7 @@ exports[`tile a front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 15,
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -2263,8 +2263,8 @@ exports[`tile a front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 42,
+        "lineHeight": 42,
         "marginBottom": 20,
       }
     }
@@ -2318,7 +2318,7 @@ exports[`tile a front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -2802,7 +2802,7 @@ exports[`tile a front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 15,
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -2854,8 +2854,8 @@ exports[`tile a front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 45,
+        "lineHeight": 45,
         "marginBottom": 20,
       }
     }
@@ -2909,7 +2909,7 @@ exports[`tile a front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -3377,7 +3377,7 @@ exports[`tile a front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile a front portrait 834 1`] = `
+exports[`tile a front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3393,7 +3393,7 @@ exports[`tile a front portrait 834 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 15,
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -3445,8 +3445,8 @@ exports[`tile a front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 45,
+        "lineHeight": 45,
         "marginBottom": 20,
       }
     }
@@ -3500,7 +3500,598 @@ exports[`tile a front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 10,
+      "paddingRight": 10,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <FrontTileSummary
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    columnCount={3}
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 48,
+        "lineHeight": 48,
+        "marginBottom": 20,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -3617,31 +3617,31 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
           "leadAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3650,31 +3650,31 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
           "listingAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3931,31 +3931,31 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
         "leadAsset": Object {
           "crop": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop11": Object {
             "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
           },
           "crop169": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop23": Object {
             "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
           },
           "crop32": Object {
             "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
           },
           "crop45": Object {
             "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
           },
           "crop54": Object {
             "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
           },
           "crops": Array [],
           "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3988,7 +3988,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
         "width": "100%",
       }
     }
-    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+    uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
     bylines={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -3786,31 +3786,31 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
           "leadAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3819,31 +3819,31 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
           "listingAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -4100,31 +4100,31 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
         "leadAsset": Object {
           "crop": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop11": Object {
             "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
           },
           "crop169": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop23": Object {
             "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
           },
           "crop32": Object {
             "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
           },
           "crop45": Object {
             "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
           },
           "crop54": Object {
             "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
           },
           "crops": Array [],
           "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -4157,7 +4157,7 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
         "width": "100%",
       }
     }
-    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+    uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
     bylines={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -2380,7 +2380,7 @@ exports[`tile b front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -2431,8 +2431,8 @@ exports[`tile b front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 26,
-        "lineHeight": 26,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -2487,8 +2487,9 @@ exports[`tile b front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
+        "textAlign": "justify",
       }
     }
     template="mainstandard"
@@ -2970,7 +2971,7 @@ exports[`tile b front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3021,8 +3022,8 @@ exports[`tile b front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 26,
-        "lineHeight": 26,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -3077,8 +3078,9 @@ exports[`tile b front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
+        "textAlign": "justify",
       }
     }
     template="mainstandard"
@@ -3544,7 +3546,7 @@ exports[`tile b front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile b front portrait 834 1`] = `
+exports[`tile b front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3560,7 +3562,7 @@ exports[`tile b front portrait 834 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3611,8 +3613,8 @@ exports[`tile b front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 26,
-        "lineHeight": 26,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -3667,8 +3669,600 @@ exports[`tile b front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 5,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <FrontTileSummary
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 15,
+      }
+    }
+    showKeyline={true}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
       }
     }
     template="mainstandard"

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -3552,31 +3552,31 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
           "leadAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3585,31 +3585,31 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
           "listingAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3866,31 +3866,31 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
         "leadAsset": Object {
           "crop": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop11": Object {
             "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
           },
           "crop169": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop23": Object {
             "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
           },
           "crop32": Object {
             "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
           },
           "crop45": Object {
             "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
           },
           "crop54": Object {
             "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
           },
           "crops": Array [],
           "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3923,7 +3923,7 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
         "width": "100%",
       }
     }
-    uri="http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
     bylineContainerStyle={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -2101,7 +2101,7 @@ exports[`tile f front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -2158,8 +2158,8 @@ exports[`tile f front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 42,
+        "lineHeight": 42,
         "marginBottom": 5,
       }
     }
@@ -2168,9 +2168,9 @@ exports[`tile f front portrait 768 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 30,
-        "lineHeight": 30,
-        "marginBottom": 25,
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 10,
       }
     }
     summary={
@@ -2223,7 +2223,7 @@ exports[`tile f front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -2764,8 +2764,8 @@ exports[`tile f front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 45,
+        "lineHeight": 45,
         "marginBottom": 5,
       }
     }
@@ -2774,9 +2774,9 @@ exports[`tile f front portrait 810 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 30,
-        "lineHeight": 30,
-        "marginBottom": 25,
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 15,
       }
     }
     summary={
@@ -2829,7 +2829,7 @@ exports[`tile f front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -3297,7 +3297,7 @@ exports[`tile f front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile f front portrait 834 1`] = `
+exports[`tile f front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3370,9 +3370,9 @@ exports[`tile f front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
-        "marginBottom": 5,
+        "fontSize": 45,
+        "lineHeight": 45,
+        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
@@ -3380,9 +3380,9 @@ exports[`tile f front portrait 834 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 30,
-        "lineHeight": 30,
-        "marginBottom": 25,
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 15,
       }
     }
     summary={
@@ -3435,7 +3435,613 @@ exports[`tile f front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "column",
+      "paddingBottom": 0,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <FrontTileSummary
+    bylineContainerStyle={
+      Object {
+        "marginBottom": 15,
+      }
+    }
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    columnCount={3}
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 50,
+        "lineHeight": 50,
+        "marginBottom": 10,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 26,
+        "lineHeight": 26,
+        "marginBottom": 15,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -1002,507 +1002,6 @@ exports[`tile g front landscape 1080 1`] = `
 </Link>
 `;
 
-exports[`tile g front landscape 1112 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingBottom": 10,
-      "paddingLeft": 10,
-      "paddingRight": 10,
-    }
-  }
-  url="/article/123"
->
-  <Image
-    aspectRatio={0.8}
-    fill={true}
-    style={
-      Object {
-        "marginBottom": 5,
-        "width": "100%",
-      }
-    }
-    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
-  />
-  <FrontTileSummary
-    headlineStyle={
-      Object {
-        "fontFamily": "TimesModern-Bold",
-        "fontSize": 25,
-        "lineHeight": 25,
-        "marginBottom": 5,
-      }
-    }
-    summaryStyle={
-      Object {
-        "fontSize": 14,
-        "lineHeight": 20,
-      }
-    }
-    template="mainstandard"
-    tile={
-      Object {
-        "article": Object {
-          "bylines": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {
-                    "slug": "richard-lloyd-parry",
-                  },
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Richard Lloyd Parry",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "author",
-                },
-              ],
-              "image": null,
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": ", Hanoi",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": null,
-            },
-          ],
-          "commentCount": 0,
-          "commentsEnabled": false,
-          "commercialTags": Array [
-            "commercial tag",
-          ],
-          "content": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "expirableFlags": Array [
-            Object {
-              "expiryTime": "2030-03-14T12:00:00.000Z",
-              "type": "EXCLUSIVE",
-            },
-          ],
-          "hasVideo": false,
-          "headline": "Venezuela shows how Corbyn’s socialism works",
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "isBookmarked": false,
-          "isTeased": false,
-          "keywords": Array [
-            "keyword",
-          ],
-          "label": "label",
-          "leadAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "listingAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "longRead": true,
-          "paywalledContent": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": 1970-01-01T00:00:00.000Z,
-          "section": "business",
-          "shortHeadline": "Driving Off",
-          "shortIdentifier": "37b27qd2s",
-          "slug": "british-trio-stopped-on-the-way-to-join-isis",
-          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
-          "summary": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary1000": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary300": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary800": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "synonyms": Object {
-            "edges": Array [],
-            "nodes": Array [],
-            "pageInfo": Object {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-            },
-            "totalCount": 1,
-          },
-          "template": "mainstandard",
-          "title": "title",
-          "topicConnection": Object {
-            "nodes": Array [],
-          },
-          "url": "/article/123",
-        },
-        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
-        "headline": "This is tile headline",
-        "leadAsset": Object {
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop11": Object {
-            "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-          },
-          "crop169": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop23": Object {
-            "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-          },
-          "crop32": Object {
-            "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-          },
-          "crop45": Object {
-            "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-          },
-          "crop54": Object {
-            "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-          },
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "title": "Rise of centenarian drivers as elderly push on",
-        },
-        "strapline": "Three Conservative MPs resign",
-      }
-    }
-  />
-</Link>
-`;
-
 exports[`tile g front landscape 1194 1`] = `
 <Link
   linkStyle={
@@ -2521,7 +2020,7 @@ exports[`tile g front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -2531,14 +2030,14 @@ exports[`tile g front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
-        "marginBottom": 15,
+        "fontSize": 28,
+        "lineHeight": 28,
+        "marginBottom": 10,
       }
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -3021,7 +2520,7 @@ exports[`tile g front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3031,14 +2530,14 @@ exports[`tile g front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
-        "marginBottom": 15,
+        "fontSize": 28,
+        "lineHeight": 28,
+        "marginBottom": 10,
       }
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -3505,7 +3004,7 @@ exports[`tile g front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile g front portrait 834 1`] = `
+exports[`tile g front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3521,7 +3020,7 @@ exports[`tile g front portrait 834 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3531,14 +3030,514 @@ exports[`tile g front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
-        "marginBottom": 15,
+        "fontSize": 30,
+        "lineHeight": 30,
+        "marginBottom": 10,
       }
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 20,
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={0.8}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 5,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
+  />
+  <FrontTileSummary
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 30,
+        "lineHeight": 30,
+        "marginBottom": 10,
+      }
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -1176,594 +1176,6 @@ exports[`tile h front landscape 1080 1`] = `
 </Link>
 `;
 
-exports[`tile h front landscape 1112 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingBottom": 0,
-      "paddingRight": 10,
-    }
-  }
-  url="/article/123"
->
-  <FrontTileSummary
-    bylines={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {
-                "slug": "richard-lloyd-parry",
-              },
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Richard Lloyd Parry",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "author",
-            },
-          ],
-          "image": null,
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": ", Hanoi",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "image": null,
-        },
-      ]
-    }
-    headlineStyle={
-      Object {
-        "fontFamily": "TimesModern-Bold",
-        "fontSize": 45,
-        "lineHeight": 45,
-        "marginBottom": 10,
-      }
-    }
-    strapline="Three Conservative MPs resign"
-    straplineStyle={
-      Object {
-        "color": "#333333",
-        "fontFamily": "TimesModern-Regular",
-        "fontSize": 22,
-        "lineHeight": 22,
-        "marginBottom": 15,
-      }
-    }
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [],
-          "name": "ad",
-        },
-      ]
-    }
-    summaryStyle={
-      Object {
-        "fontSize": 14,
-        "lineHeight": 20,
-      }
-    }
-    template="mainstandard"
-    tile={
-      Object {
-        "article": Object {
-          "bylines": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {
-                    "slug": "richard-lloyd-parry",
-                  },
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Richard Lloyd Parry",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "author",
-                },
-              ],
-              "image": null,
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": ", Hanoi",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": null,
-            },
-          ],
-          "commentCount": 0,
-          "commentsEnabled": false,
-          "commercialTags": Array [
-            "commercial tag",
-          ],
-          "content": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "expirableFlags": Array [
-            Object {
-              "expiryTime": "2030-03-14T12:00:00.000Z",
-              "type": "EXCLUSIVE",
-            },
-          ],
-          "hasVideo": false,
-          "headline": "Venezuela shows how Corbyn’s socialism works",
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "isBookmarked": false,
-          "isTeased": false,
-          "keywords": Array [
-            "keyword",
-          ],
-          "label": "label",
-          "leadAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "listingAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "longRead": true,
-          "paywalledContent": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": 1970-01-01T00:00:00.000Z,
-          "section": "business",
-          "shortHeadline": "Driving Off",
-          "shortIdentifier": "37b27qd2s",
-          "slug": "british-trio-stopped-on-the-way-to-join-isis",
-          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
-          "summary": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary1000": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary300": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary800": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "synonyms": Object {
-            "edges": Array [],
-            "nodes": Array [],
-            "pageInfo": Object {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-            },
-            "totalCount": 1,
-          },
-          "template": "mainstandard",
-          "title": "title",
-          "topicConnection": Object {
-            "nodes": Array [],
-          },
-          "url": "/article/123",
-        },
-        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
-        "headline": "This is tile headline",
-        "leadAsset": Object {
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop11": Object {
-            "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-          },
-          "crop169": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop23": Object {
-            "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-          },
-          "crop32": Object {
-            "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-          },
-          "crop45": Object {
-            "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-          },
-          "crop54": Object {
-            "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-          },
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "title": "Rise of centenarian drivers as elderly push on",
-        },
-        "strapline": "Three Conservative MPs resign",
-      }
-    }
-  />
-</Link>
-`;
-
 exports[`tile h front landscape 1194 1`] = `
 <Link
   linkStyle={
@@ -2945,7 +2357,7 @@ exports[`tile h front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 5,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -2996,8 +2408,8 @@ exports[`tile h front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 28,
+        "lineHeight": 28,
         "marginBottom": 10,
       }
     }
@@ -3006,8 +2418,8 @@ exports[`tile h front portrait 768 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 24,
-        "lineHeight": 24,
+        "fontSize": 20,
+        "lineHeight": 20,
         "marginBottom": 15,
       }
     }
@@ -3061,7 +2473,7 @@ exports[`tile h front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -3533,7 +2945,7 @@ exports[`tile h front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 5,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -3584,8 +2996,8 @@ exports[`tile h front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 28,
+        "lineHeight": 28,
         "marginBottom": 10,
       }
     }
@@ -3594,8 +3006,8 @@ exports[`tile h front portrait 810 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 24,
-        "lineHeight": 24,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -3649,7 +3061,7 @@ exports[`tile h front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -4116,7 +3528,7 @@ exports[`tile h front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile h front portrait 834 1`] = `
+exports[`tile h front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -4172,8 +3584,8 @@ exports[`tile h front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 42,
+        "lineHeight": 42,
         "marginBottom": 10,
       }
     }
@@ -4182,8 +3594,8 @@ exports[`tile h front portrait 834 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 24,
-        "lineHeight": 24,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -4237,7 +3649,595 @@ exports[`tile h front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 20,
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 5,
+      "paddingRight": 10,
+    }
+  }
+  url="/article/123"
+>
+  <FrontTileSummary
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 45,
+        "lineHeight": 45,
+        "marginBottom": 10,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 22,
+        "lineHeight": 22,
+        "marginBottom": 15,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -2211,7 +2211,7 @@ exports[`tile a front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 15,
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -2263,8 +2263,8 @@ exports[`tile a front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 42,
+        "lineHeight": 42,
         "marginBottom": 20,
       }
     }
@@ -2318,7 +2318,7 @@ exports[`tile a front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -2802,7 +2802,7 @@ exports[`tile a front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 15,
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -2854,8 +2854,8 @@ exports[`tile a front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 45,
+        "lineHeight": 45,
         "marginBottom": 20,
       }
     }
@@ -2909,7 +2909,7 @@ exports[`tile a front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -3377,7 +3377,7 @@ exports[`tile a front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile a front portrait 834 1`] = `
+exports[`tile a front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3393,7 +3393,7 @@ exports[`tile a front portrait 834 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 15,
+        "marginBottom": 10,
         "width": "100%",
       }
     }
@@ -3445,8 +3445,8 @@ exports[`tile a front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 45,
+        "lineHeight": 45,
         "marginBottom": 20,
       }
     }
@@ -3500,7 +3500,598 @@ exports[`tile a front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 10,
+      "paddingRight": 10,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <FrontTileSummary
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    columnCount={3}
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 48,
+        "lineHeight": 48,
+        "marginBottom": 20,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -3617,31 +3617,31 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
           "leadAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3650,31 +3650,31 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
           "listingAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3931,31 +3931,31 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
         "leadAsset": Object {
           "crop": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop11": Object {
             "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
           },
           "crop169": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop23": Object {
             "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
           },
           "crop32": Object {
             "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
           },
           "crop45": Object {
             "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
           },
           "crop54": Object {
             "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
           },
           "crops": Array [],
           "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3988,7 +3988,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
         "width": "100%",
       }
     }
-    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+    uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
     bylines={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -3786,31 +3786,31 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
           "leadAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3819,31 +3819,31 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
           "listingAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -4100,31 +4100,31 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
         "leadAsset": Object {
           "crop": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop11": Object {
             "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
           },
           "crop169": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop23": Object {
             "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
           },
           "crop32": Object {
             "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
           },
           "crop45": Object {
             "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
           },
           "crop54": Object {
             "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
           },
           "crops": Array [],
           "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -4157,7 +4157,7 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
         "width": "100%",
       }
     }
-    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+    uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
   />
   <FrontTileSummary
     bylines={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -2380,7 +2380,7 @@ exports[`tile b front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -2431,8 +2431,8 @@ exports[`tile b front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 26,
-        "lineHeight": 26,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -2487,8 +2487,9 @@ exports[`tile b front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
+        "textAlign": "justify",
       }
     }
     template="mainstandard"
@@ -2970,7 +2971,7 @@ exports[`tile b front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3021,8 +3022,8 @@ exports[`tile b front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 26,
-        "lineHeight": 26,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -3077,8 +3078,9 @@ exports[`tile b front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
+        "textAlign": "justify",
       }
     }
     template="mainstandard"
@@ -3544,7 +3546,7 @@ exports[`tile b front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile b front portrait 834 1`] = `
+exports[`tile b front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3560,7 +3562,7 @@ exports[`tile b front portrait 834 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3611,8 +3613,8 @@ exports[`tile b front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 26,
-        "lineHeight": 26,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -3667,8 +3669,600 @@ exports[`tile b front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.5}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 5,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  />
+  <FrontTileSummary
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 15,
+      }
+    }
+    showKeyline={true}
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
       }
     }
     template="mainstandard"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -3552,31 +3552,31 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
           "leadAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3585,31 +3585,31 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
           "listingAsset": Object {
             "crop": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop11": Object {
               "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
             },
             "crop169": Object {
               "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+              "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
             },
             "crop23": Object {
               "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
             },
             "crop32": Object {
               "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
             },
             "crop45": Object {
               "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
             },
             "crop54": Object {
               "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+              "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
             },
             "crops": Array [],
             "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3866,31 +3866,31 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
         "leadAsset": Object {
           "crop": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop11": Object {
             "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
           },
           "crop169": Object {
             "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
           },
           "crop23": Object {
             "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
           },
           "crop32": Object {
             "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
           },
           "crop45": Object {
             "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
           },
           "crop54": Object {
             "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
           },
           "crops": Array [],
           "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
@@ -3923,7 +3923,7 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
         "width": "100%",
       }
     }
-    uri="http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+    uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
   />
   <FrontTileSummary
     bylineContainerStyle={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -2101,7 +2101,7 @@ exports[`tile f front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -2158,8 +2158,8 @@ exports[`tile f front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 42,
+        "lineHeight": 42,
         "marginBottom": 5,
       }
     }
@@ -2168,9 +2168,9 @@ exports[`tile f front portrait 768 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 30,
-        "lineHeight": 30,
-        "marginBottom": 25,
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 10,
       }
     }
     summary={
@@ -2223,7 +2223,7 @@ exports[`tile f front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -2764,8 +2764,8 @@ exports[`tile f front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
+        "fontSize": 45,
+        "lineHeight": 45,
         "marginBottom": 5,
       }
     }
@@ -2774,9 +2774,9 @@ exports[`tile f front portrait 810 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 30,
-        "lineHeight": 30,
-        "marginBottom": 25,
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 15,
       }
     }
     summary={
@@ -2829,7 +2829,7 @@ exports[`tile f front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }
@@ -3297,7 +3297,7 @@ exports[`tile f front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile f front portrait 834 1`] = `
+exports[`tile f front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3370,9 +3370,9 @@ exports[`tile f front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 55,
-        "lineHeight": 55,
-        "marginBottom": 5,
+        "fontSize": 45,
+        "lineHeight": 45,
+        "marginBottom": 10,
       }
     }
     strapline="Three Conservative MPs resign"
@@ -3380,9 +3380,9 @@ exports[`tile f front portrait 834 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 30,
-        "lineHeight": 30,
-        "marginBottom": 25,
+        "fontSize": 24,
+        "lineHeight": 24,
+        "marginBottom": 15,
       }
     }
     summary={
@@ -3435,7 +3435,613 @@ exports[`tile f front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 18,
+        "textAlign": "justify",
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "flexDirection": "column",
+      "paddingBottom": 0,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={1.7777777777777777}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
+  />
+  <FrontTileSummary
+    bylineContainerStyle={
+      Object {
+        "marginBottom": 15,
+      }
+    }
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    columnCount={3}
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 50,
+        "lineHeight": 50,
+        "marginBottom": 10,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 26,
+        "lineHeight": 26,
+        "marginBottom": 15,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 18,
         "textAlign": "justify",
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -1002,507 +1002,6 @@ exports[`tile g front landscape 1080 1`] = `
 </Link>
 `;
 
-exports[`tile g front landscape 1112 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingBottom": 10,
-      "paddingLeft": 10,
-      "paddingRight": 10,
-    }
-  }
-  url="/article/123"
->
-  <Image
-    aspectRatio={0.8}
-    fill={true}
-    style={
-      Object {
-        "marginBottom": 5,
-        "width": "100%",
-      }
-    }
-    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
-  />
-  <FrontTileSummary
-    headlineStyle={
-      Object {
-        "fontFamily": "TimesModern-Bold",
-        "fontSize": 25,
-        "lineHeight": 25,
-        "marginBottom": 5,
-      }
-    }
-    summaryStyle={
-      Object {
-        "fontSize": 14,
-        "lineHeight": 20,
-      }
-    }
-    template="mainstandard"
-    tile={
-      Object {
-        "article": Object {
-          "bylines": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {
-                    "slug": "richard-lloyd-parry",
-                  },
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Richard Lloyd Parry",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "author",
-                },
-              ],
-              "image": null,
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": ", Hanoi",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": null,
-            },
-          ],
-          "commentCount": 0,
-          "commentsEnabled": false,
-          "commercialTags": Array [
-            "commercial tag",
-          ],
-          "content": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "expirableFlags": Array [
-            Object {
-              "expiryTime": "2030-03-14T12:00:00.000Z",
-              "type": "EXCLUSIVE",
-            },
-          ],
-          "hasVideo": false,
-          "headline": "Venezuela shows how Corbyn’s socialism works",
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "isBookmarked": false,
-          "isTeased": false,
-          "keywords": Array [
-            "keyword",
-          ],
-          "label": "label",
-          "leadAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "listingAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "longRead": true,
-          "paywalledContent": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": 1970-01-01T00:00:00.000Z,
-          "section": "business",
-          "shortHeadline": "Driving Off",
-          "shortIdentifier": "37b27qd2s",
-          "slug": "british-trio-stopped-on-the-way-to-join-isis",
-          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
-          "summary": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary1000": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary300": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary800": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "synonyms": Object {
-            "edges": Array [],
-            "nodes": Array [],
-            "pageInfo": Object {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-            },
-            "totalCount": 1,
-          },
-          "template": "mainstandard",
-          "title": "title",
-          "topicConnection": Object {
-            "nodes": Array [],
-          },
-          "url": "/article/123",
-        },
-        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
-        "headline": "This is tile headline",
-        "leadAsset": Object {
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop11": Object {
-            "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-          },
-          "crop169": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop23": Object {
-            "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-          },
-          "crop32": Object {
-            "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-          },
-          "crop45": Object {
-            "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-          },
-          "crop54": Object {
-            "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-          },
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "title": "Rise of centenarian drivers as elderly push on",
-        },
-        "strapline": "Three Conservative MPs resign",
-      }
-    }
-  />
-</Link>
-`;
-
 exports[`tile g front landscape 1194 1`] = `
 <Link
   linkStyle={
@@ -2521,7 +2020,7 @@ exports[`tile g front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -2531,14 +2030,14 @@ exports[`tile g front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
-        "marginBottom": 15,
+        "fontSize": 28,
+        "lineHeight": 28,
+        "marginBottom": 10,
       }
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -3021,7 +2520,7 @@ exports[`tile g front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3031,14 +2530,14 @@ exports[`tile g front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
-        "marginBottom": 15,
+        "fontSize": 28,
+        "lineHeight": 28,
+        "marginBottom": 10,
       }
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -3505,7 +3004,7 @@ exports[`tile g front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile g front portrait 834 1`] = `
+exports[`tile g front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -3521,7 +3020,7 @@ exports[`tile g front portrait 834 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -3531,14 +3030,514 @@ exports[`tile g front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
-        "marginBottom": 15,
+        "fontSize": 30,
+        "lineHeight": 30,
+        "marginBottom": 10,
       }
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 20,
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+    }
+  }
+  url="/article/123"
+>
+  <Image
+    aspectRatio={0.8}
+    fill={true}
+    style={
+      Object {
+        "marginBottom": 5,
+        "width": "100%",
+      }
+    }
+    uri="http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
+  />
+  <FrontTileSummary
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 30,
+        "lineHeight": 30,
+        "marginBottom": 10,
+      }
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -1176,594 +1176,6 @@ exports[`tile h front landscape 1080 1`] = `
 </Link>
 `;
 
-exports[`tile h front landscape 1112 1`] = `
-<Link
-  linkStyle={
-    Object {
-      "flex": 1,
-      "paddingBottom": 0,
-      "paddingRight": 10,
-    }
-  }
-  url="/article/123"
->
-  <FrontTileSummary
-    bylines={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {
-                "slug": "richard-lloyd-parry",
-              },
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Richard Lloyd Parry",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "author",
-            },
-          ],
-          "image": null,
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": ", Hanoi",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "image": null,
-        },
-      ]
-    }
-    headlineStyle={
-      Object {
-        "fontFamily": "TimesModern-Bold",
-        "fontSize": 45,
-        "lineHeight": 45,
-        "marginBottom": 10,
-      }
-    }
-    strapline="Three Conservative MPs resign"
-    straplineStyle={
-      Object {
-        "color": "#333333",
-        "fontFamily": "TimesModern-Regular",
-        "fontSize": 22,
-        "lineHeight": 22,
-        "marginBottom": 15,
-      }
-    }
-    summary={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [],
-          "name": "ad",
-        },
-      ]
-    }
-    summaryStyle={
-      Object {
-        "fontSize": 14,
-        "lineHeight": 20,
-      }
-    }
-    template="mainstandard"
-    tile={
-      Object {
-        "article": Object {
-          "bylines": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {
-                    "slug": "richard-lloyd-parry",
-                  },
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Richard Lloyd Parry",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "author",
-                },
-              ],
-              "image": null,
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": ", Hanoi",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "image": null,
-            },
-          ],
-          "commentCount": 0,
-          "commentsEnabled": false,
-          "commercialTags": Array [
-            "commercial tag",
-          ],
-          "content": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "expirableFlags": Array [
-            Object {
-              "expiryTime": "2030-03-14T12:00:00.000Z",
-              "type": "EXCLUSIVE",
-            },
-          ],
-          "hasVideo": false,
-          "headline": "Venezuela shows how Corbyn’s socialism works",
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "isBookmarked": false,
-          "isTeased": false,
-          "keywords": Array [
-            "keyword",
-          ],
-          "label": "label",
-          "leadAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "listingAsset": Object {
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop11": Object {
-              "ratio": "1:1",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-            },
-            "crop169": Object {
-              "ratio": "16:9",
-              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-            },
-            "crop23": Object {
-              "ratio": "2:3",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-            },
-            "crop32": Object {
-              "ratio": "3:2",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-            },
-            "crop45": Object {
-              "ratio": "4:5",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-            },
-            "crop54": Object {
-              "ratio": "5:4",
-              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-            },
-            "crops": Array [],
-            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "longRead": true,
-          "paywalledContent": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "ad",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": 1970-01-01T00:00:00.000Z,
-          "section": "business",
-          "shortHeadline": "Driving Off",
-          "shortIdentifier": "37b27qd2s",
-          "slug": "british-trio-stopped-on-the-way-to-join-isis",
-          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
-          "summary": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary1000": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary300": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary800": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "synonyms": Object {
-            "edges": Array [],
-            "nodes": Array [],
-            "pageInfo": Object {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-            },
-            "totalCount": 1,
-          },
-          "template": "mainstandard",
-          "title": "title",
-          "topicConnection": Object {
-            "nodes": Array [],
-          },
-          "url": "/article/123",
-        },
-        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
-        "headline": "This is tile headline",
-        "leadAsset": Object {
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop11": Object {
-            "ratio": "1:1",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
-          },
-          "crop169": Object {
-            "ratio": "16:9",
-            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
-          },
-          "crop23": Object {
-            "ratio": "2:3",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
-          },
-          "crop32": Object {
-            "ratio": "3:2",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
-          },
-          "crop45": Object {
-            "ratio": "4:5",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
-          },
-          "crop54": Object {
-            "ratio": "5:4",
-            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
-          },
-          "crops": Array [],
-          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-          "title": "Rise of centenarian drivers as elderly push on",
-        },
-        "strapline": "Three Conservative MPs resign",
-      }
-    }
-  />
-</Link>
-`;
-
 exports[`tile h front landscape 1194 1`] = `
 <Link
   linkStyle={
@@ -2945,7 +2357,7 @@ exports[`tile h front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 5,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -2996,8 +2408,8 @@ exports[`tile h front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 28,
+        "lineHeight": 28,
         "marginBottom": 10,
       }
     }
@@ -3006,8 +2418,8 @@ exports[`tile h front portrait 768 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 24,
-        "lineHeight": 24,
+        "fontSize": 20,
+        "lineHeight": 20,
         "marginBottom": 15,
       }
     }
@@ -3061,7 +2473,7 @@ exports[`tile h front portrait 768 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -3533,7 +2945,7 @@ exports[`tile h front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 5,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -3584,8 +2996,8 @@ exports[`tile h front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 28,
+        "lineHeight": 28,
         "marginBottom": 10,
       }
     }
@@ -3594,8 +3006,8 @@ exports[`tile h front portrait 810 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 24,
-        "lineHeight": 24,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -3649,7 +3061,7 @@ exports[`tile h front portrait 810 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }
@@ -4116,7 +3528,7 @@ exports[`tile h front portrait 810 1`] = `
 </Link>
 `;
 
-exports[`tile h front portrait 834 1`] = `
+exports[`tile h front portrait 834 0.75 ratio 1`] = `
 <Link
   linkStyle={
     Object {
@@ -4172,8 +3584,8 @@ exports[`tile h front portrait 834 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 42,
+        "lineHeight": 42,
         "marginBottom": 10,
       }
     }
@@ -4182,8 +3594,8 @@ exports[`tile h front portrait 834 1`] = `
       Object {
         "color": "#333333",
         "fontFamily": "TimesModern-Regular",
-        "fontSize": 24,
-        "lineHeight": 24,
+        "fontSize": 22,
+        "lineHeight": 22,
         "marginBottom": 15,
       }
     }
@@ -4237,7 +3649,595 @@ exports[`tile h front portrait 834 1`] = `
     }
     summaryStyle={
       Object {
-        "fontSize": 15,
+        "fontSize": 14,
+        "lineHeight": 20,
+      }
+    }
+    template="mainstandard"
+    tile={
+      Object {
+        "article": Object {
+          "bylines": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {
+                    "slug": "richard-lloyd-parry",
+                  },
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Richard Lloyd Parry",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "author",
+                },
+              ],
+              "image": null,
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": ", Hanoi",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "image": null,
+            },
+          ],
+          "commentCount": 0,
+          "commentsEnabled": false,
+          "commercialTags": Array [
+            "commercial tag",
+          ],
+          "content": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "expirableFlags": Array [
+            Object {
+              "expiryTime": "2030-03-14T12:00:00.000Z",
+              "type": "EXCLUSIVE",
+            },
+          ],
+          "hasVideo": false,
+          "headline": "Venezuela shows how Corbyn’s socialism works",
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "isBookmarked": false,
+          "isTeased": false,
+          "keywords": Array [
+            "keyword",
+          ],
+          "label": "label",
+          "leadAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "listingAsset": Object {
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop11": Object {
+              "ratio": "1:1",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+            },
+            "crop169": Object {
+              "ratio": "16:9",
+              "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+            },
+            "crop23": Object {
+              "ratio": "2:3",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+            },
+            "crop32": Object {
+              "ratio": "3:2",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+            },
+            "crop45": Object {
+              "ratio": "4:5",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+            },
+            "crop54": Object {
+              "ratio": "5:4",
+              "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+            },
+            "crops": Array [],
+            "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "longRead": true,
+          "paywalledContent": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "ad",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": 1970-01-01T00:00:00.000Z,
+          "section": "business",
+          "shortHeadline": "Driving Off",
+          "shortIdentifier": "37b27qd2s",
+          "slug": "british-trio-stopped-on-the-way-to-join-isis",
+          "standfirst": "Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all",
+          "summary": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary1000": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit. to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary300": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "‘The prodigal son returns.” So read a banner tied to the wall of the Paul Strank Stand at Kingsmeadow, the home of AFC Wimbledon, on Saturday, alongside the sepia-toned image of a fresh-faced Wally Downes, sporting an 80s haircut and Wimbledon strip, with a mischievous glint in his eye.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary800": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Senior ministers accused Labour today of trying to “frustrate and cancel Brexit” after the party announced plans to hijack Boris Johnson’s deal with amendments for a second referendum and customs union with the EU. Rishi Sunak, the chief secretary to the Treasury, warned that any attempt by MPs to add a customs union to the government’s Brexit deal would be “procedural tricks” intended to frustrate departure. His comments came as ministers announced that they planned to publish the legislation that would formally take Britain out of the European Union today. They will also apply to the Speaker to hold another so-called meaningful vote on the deal following Mr Johnson’s decision to comply with the Benn act, which forces the prime minister to request a Brexit",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "synonyms": Object {
+            "edges": Array [],
+            "nodes": Array [],
+            "pageInfo": Object {
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+            },
+            "totalCount": 1,
+          },
+          "template": "mainstandard",
+          "title": "title",
+          "topicConnection": Object {
+            "nodes": Array [],
+          },
+          "url": "/article/123",
+        },
+        "articleId": "dc4ed2e8-4584-11e9-924d-9729bcd51a7f",
+        "headline": "This is tile headline",
+        "leadAsset": Object {
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop11": Object {
+            "ratio": "1:1",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0",
+          },
+          "crop169": Object {
+            "ratio": "16:9",
+            "url": "http://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32",
+          },
+          "crop23": Object {
+            "ratio": "2:3",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0",
+          },
+          "crop32": Object {
+            "ratio": "3:2",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0",
+          },
+          "crop45": Object {
+            "ratio": "4:5",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0",
+          },
+          "crop54": Object {
+            "ratio": "5:4",
+            "url": "http://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1250%2C1000%2C627%2C0",
+          },
+          "crops": Array [],
+          "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+          "title": "Rise of centenarian drivers as elderly push on",
+        },
+        "strapline": "Three Conservative MPs resign",
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
+<Link
+  linkStyle={
+    Object {
+      "flex": 1,
+      "paddingBottom": 5,
+      "paddingRight": 10,
+    }
+  }
+  url="/article/123"
+>
+  <FrontTileSummary
+    bylines={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {
+                "slug": "richard-lloyd-parry",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Richard Lloyd Parry",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "author",
+            },
+          ],
+          "image": null,
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": ", Hanoi",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "image": null,
+        },
+      ]
+    }
+    headlineStyle={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 45,
+        "lineHeight": 45,
+        "marginBottom": 10,
+      }
+    }
+    strapline="Three Conservative MPs resign"
+    straplineStyle={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Regular",
+        "fontSize": 22,
+        "lineHeight": 22,
+        "marginBottom": 15,
+      }
+    }
+    summary={
+      Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+      ]
+    }
+    summaryStyle={
+      Object {
+        "fontSize": 14,
         "lineHeight": 20,
       }
     }

--- a/packages/edition-slices/__tests__/tile-a-front/shared-tile-a-front.base.js
+++ b/packages/edition-slices/__tests__/tile-a-front/shared-tile-a-front.base.js
@@ -16,10 +16,10 @@ jest.mock("@times-components-native/utils", () => {
 
 export const tile = mockEditionSlice(1).items[0];
 
-const testFrontTile = (width, orientation) => {
+const testFrontTile = (orientation, width, height = 500) => {
   getDimensions.mockImplementation(() => ({
-    width: width,
-    height: 500,
+    width,
+    height,
   }));
 
   const tree = TestRenderer.create(
@@ -32,37 +32,42 @@ export default () => {
   describe("tile a front", () => {
     describe("landscape", () => {
       it("1024", () => {
-        testFrontTile("1024", "landscape");
+        testFrontTile("landscape", 1024);
       });
 
       it("1080", () => {
-        testFrontTile("1080", "landscape");
+        testFrontTile("landscape", 1080);
       });
 
       it("1194", () => {
-        testFrontTile("1194", "landscape");
+        testFrontTile("landscape", 1194);
       });
 
       it("1366", () => {
-        testFrontTile("1366", "landscape");
+        testFrontTile("landscape", 1366);
       });
     });
 
     describe("portrait", () => {
       it("768", () => {
-        testFrontTile("768", "portrait");
+        testFrontTile("portrait", 768);
       });
 
       it("810", () => {
-        testFrontTile("810", "portrait");
+        testFrontTile("portrait", 810);
       });
 
-      it("834", () => {
-        testFrontTile("834", "portrait");
+      describe("834", () => {
+        it("0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1112);
+        });
+        it("less than 0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1194);
+        });
       });
 
       it("1024", () => {
-        testFrontTile("1024", "portrait");
+        testFrontTile("portrait", 1024);
       });
     });
   });

--- a/packages/edition-slices/__tests__/tile-b-front/shared-tile-b-front.base.js
+++ b/packages/edition-slices/__tests__/tile-b-front/shared-tile-b-front.base.js
@@ -16,10 +16,10 @@ jest.mock("@times-components-native/utils", () => {
 
 export const tile = mockEditionSlice(1).items[0];
 
-const testFrontTile = (width, orientation) => {
+const testFrontTile = (orientation, width, height = 500) => {
   getDimensions.mockImplementation(() => ({
-    width: width,
-    height: 500,
+    width,
+    height,
   }));
 
   const tree = TestRenderer.create(
@@ -32,37 +32,42 @@ export default () => {
   describe("tile b front", () => {
     describe("landscape", () => {
       it("1024", () => {
-        testFrontTile("1024", "landscape");
+        testFrontTile("landscape", 1024);
       });
 
       it("1080", () => {
-        testFrontTile("1080", "landscape");
+        testFrontTile("landscape", 1080);
       });
 
       it("1194", () => {
-        testFrontTile("1194", "landscape");
+        testFrontTile("landscape", 1194);
       });
 
       it("1366", () => {
-        testFrontTile("1366", "landscape");
+        testFrontTile("landscape", 1366);
       });
     });
 
     describe("portrait", () => {
       it("768", () => {
-        testFrontTile("768", "portrait");
+        testFrontTile("portrait", 768);
       });
 
       it("810", () => {
-        testFrontTile("810", "portrait");
+        testFrontTile("portrait", 810);
       });
 
-      it("834", () => {
-        testFrontTile("834", "portrait");
+      describe("834", () => {
+        it("0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1112);
+        });
+        it("less than 0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1194);
+        });
       });
 
       it("1024", () => {
-        testFrontTile("1024", "portrait");
+        testFrontTile("portrait", 1024);
       });
     });
   });

--- a/packages/edition-slices/__tests__/tile-f-front/shared-tile-f-front.base.js
+++ b/packages/edition-slices/__tests__/tile-f-front/shared-tile-f-front.base.js
@@ -16,10 +16,10 @@ jest.mock("@times-components-native/utils", () => {
 
 export const tile = mockEditionSlice(1).items[0];
 
-const testFrontTile = (width, orientation) => {
+const testFrontTile = (orientation, width, height = 500) => {
   getDimensions.mockImplementation(() => ({
-    width: width,
-    height: 500,
+    width,
+    height,
   }));
 
   const tree = TestRenderer.create(
@@ -32,37 +32,42 @@ export default () => {
   describe("tile f front", () => {
     describe("landscape", () => {
       it("1024", () => {
-        testFrontTile("1024", "landscape");
+        testFrontTile("landscape", 1024);
       });
 
       it("1080", () => {
-        testFrontTile("1080", "landscape");
+        testFrontTile("landscape", 1080);
       });
 
       it("1194", () => {
-        testFrontTile("1194", "landscape");
+        testFrontTile("landscape", 1194);
       });
 
       it("1366", () => {
-        testFrontTile("1366", "landscape");
+        testFrontTile("landscape", 1366);
       });
     });
 
     describe("portrait", () => {
       it("768", () => {
-        testFrontTile("768", "portrait");
+        testFrontTile("portrait", 768);
       });
 
       it("810", () => {
-        testFrontTile("810", "portrait");
+        testFrontTile("portrait", 810);
       });
 
-      it("834", () => {
-        testFrontTile("834", "portrait");
+      describe("834", () => {
+        it("0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1112);
+        });
+        it("less than 0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1194);
+        });
       });
 
       it("1024", () => {
-        testFrontTile("1024", "portrait");
+        testFrontTile("portrait", 1024);
       });
     });
   });

--- a/packages/edition-slices/__tests__/tile-g-front/shared-tile-g-front.base.js
+++ b/packages/edition-slices/__tests__/tile-g-front/shared-tile-g-front.base.js
@@ -1,10 +1,9 @@
 import "../mocks-tiles";
+import { TileGFront } from "../../src/tiles";
 import TestRenderer from "react-test-renderer";
 import React from "react";
-
 import { mockEditionSlice } from "@times-components-native/fixture-generator";
 import { getDimensions } from "@times-components-native/utils";
-import { TileGFront } from "../../src/tiles";
 
 jest.mock("@times-components-native/utils", () => {
   const actualUtils = jest.requireActual("../../../utils");
@@ -17,10 +16,10 @@ jest.mock("@times-components-native/utils", () => {
 
 export const tile = mockEditionSlice(1).items[0];
 
-const testFrontTile = (width, orientation) => {
+const testFrontTile = (orientation, width, height = 500) => {
   getDimensions.mockImplementation(() => ({
-    width: width,
-    height: 500,
+    width,
+    height,
   }));
 
   const tree = TestRenderer.create(
@@ -33,41 +32,42 @@ export default () => {
   describe("tile g front", () => {
     describe("landscape", () => {
       it("1024", () => {
-        testFrontTile("1024", "landscape");
+        testFrontTile("landscape", 1024);
       });
 
       it("1080", () => {
-        testFrontTile("1080", "landscape");
-      });
-
-      it("1112", () => {
-        testFrontTile("1112", "landscape");
+        testFrontTile("landscape", 1080);
       });
 
       it("1194", () => {
-        testFrontTile("1194", "landscape");
+        testFrontTile("landscape", 1194);
       });
 
       it("1366", () => {
-        testFrontTile("1366", "landscape");
+        testFrontTile("landscape", 1366);
       });
     });
 
     describe("portrait", () => {
       it("768", () => {
-        testFrontTile("768", "portrait");
+        testFrontTile("portrait", 768);
       });
 
       it("810", () => {
-        testFrontTile("810", "portrait");
+        testFrontTile("portrait", 810);
       });
 
-      it("834", () => {
-        testFrontTile("834", "portrait");
+      describe("834", () => {
+        it("0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1112);
+        });
+        it("less than 0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1194);
+        });
       });
 
       it("1024", () => {
-        testFrontTile("1024", "portrait");
+        testFrontTile("portrait", 1024);
       });
     });
   });

--- a/packages/edition-slices/__tests__/tile-h-front/shared-tile-h-front.base.js
+++ b/packages/edition-slices/__tests__/tile-h-front/shared-tile-h-front.base.js
@@ -1,10 +1,9 @@
 import "../mocks-tiles";
+import { TileHFront } from "../../src/tiles";
 import TestRenderer from "react-test-renderer";
 import React from "react";
-
 import { mockEditionSlice } from "@times-components-native/fixture-generator";
 import { getDimensions } from "@times-components-native/utils";
-import { TileHFront } from "../../src/tiles";
 
 jest.mock("@times-components-native/utils", () => {
   const actualUtils = jest.requireActual("../../../utils");
@@ -17,10 +16,10 @@ jest.mock("@times-components-native/utils", () => {
 
 export const tile = mockEditionSlice(1).items[0];
 
-const testFrontTile = (width, orientation) => {
+const testFrontTile = (orientation, width, height = 500) => {
   getDimensions.mockImplementation(() => ({
-    width: width,
-    height: 500,
+    width,
+    height,
   }));
 
   const tree = TestRenderer.create(
@@ -33,41 +32,42 @@ export default () => {
   describe("tile h front", () => {
     describe("landscape", () => {
       it("1024", () => {
-        testFrontTile("1024", "landscape");
+        testFrontTile("landscape", 1024);
       });
 
       it("1080", () => {
-        testFrontTile("1080", "landscape");
-      });
-
-      it("1112", () => {
-        testFrontTile("1112", "landscape");
+        testFrontTile("landscape", 1080);
       });
 
       it("1194", () => {
-        testFrontTile("1194", "landscape");
+        testFrontTile("landscape", 1194);
       });
 
       it("1366", () => {
-        testFrontTile("1366", "landscape");
+        testFrontTile("landscape", 1366);
       });
     });
 
     describe("portrait", () => {
       it("768", () => {
-        testFrontTile("768", "portrait");
+        testFrontTile("portrait", 768);
       });
 
       it("810", () => {
-        testFrontTile("810", "portrait");
+        testFrontTile("portrait", 810);
       });
 
-      it("834", () => {
-        testFrontTile("834", "portrait");
+      describe("834", () => {
+        it("0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1112);
+        });
+        it("less than 0.75 ratio", () => {
+          testFrontTile("portrait", 834, 1194);
+        });
       });
 
       it("1024", () => {
-        testFrontTile("1024", "portrait");
+        testFrontTile("portrait", 1024);
       });
     });
   });

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -9,13 +9,13 @@ import { getDimensions } from "@times-components-native/utils";
 const getAspectRatio = (crop) => (crop === "crop32" ? 3 / 2 : 5 / 4);
 
 const TileAFront = ({ onPress, tile, orientation }) => {
-  const { width: windowWidth } = getDimensions();
+  const { width: windowWidth, height: windowHeight } = getDimensions();
   const isPortrait = orientation === "portrait";
   const columnCount = isPortrait ? 3 : 1;
   const crop = isPortrait ? "crop32" : "crop54";
   const showSummary = isPortrait || (1080 < windowWidth && windowWidth < 1366);
   const imageCrop = getTileImage(tile, crop);
-  const styles = getStyle(orientation, windowWidth);
+  const styles = getStyle(orientation, windowWidth, windowHeight);
 
   if (!imageCrop) return null;
 

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -33,6 +33,15 @@ const sharedStyles = {
   },
 };
 
+const portrait834 = {
+  ...sharedStyles,
+  summary: {
+    ...summary,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+};
+
 const styles = {
   landscape: {
     "1024": {
@@ -97,6 +106,26 @@ const styles = {
         lineHeight: 18,
       },
     },
+    "834": {
+      ratios: {
+        0: {
+          ...portrait834,
+          headline: {
+            ...headlinePortrait,
+            fontSize: 48,
+            lineHeight: 48,
+          },
+        },
+        0.75: {
+          ...portrait834,
+          headline: {
+            ...headlinePortrait,
+            fontSize: 45,
+            lineHeight: 45,
+          },
+        },
+      },
+    },
     "1024": {
       ...sharedStyles,
       imageContainer: {
@@ -117,5 +146,5 @@ const styles = {
   },
 };
 
-export const getStyle = (orientation, windowWidth) =>
-  getStyleByDeviceSize(styles[orientation], windowWidth);
+export const getStyle = (orientation, windowWidth, windowHeight) =>
+  getStyleByDeviceSize(styles[orientation], windowWidth, windowHeight);

--- a/packages/edition-slices/src/tiles/tile-b-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/index.js
@@ -11,8 +11,8 @@ const TileBFront = ({ onPress, tile, orientation }) => {
   const showKeyline = isPortrait;
 
   const crop = getTileImage(tile, "crop32");
-  const { width: windowWidth } = getDimensions();
-  const styles = getStyle(orientation, windowWidth);
+  const { width: windowWidth, height: windowHeight } = getDimensions();
+  const styles = getStyle(orientation, windowWidth, windowHeight);
 
   if (!crop) return null;
 

--- a/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
@@ -51,6 +51,20 @@ const sharedPortraitStyles = {
   },
 };
 
+const portrait834 = {
+  ...sharedPortraitStyles,
+  summary: {
+    ...summary,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  commentSummary: {
+    ...commentSummary,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+};
+
 const styles = {
   landscape: {
     "1024": {
@@ -112,6 +126,26 @@ const styles = {
         lineHeight: 18,
       },
     },
+    "834": {
+      ratios: {
+        0: {
+          ...portrait834,
+          headline: {
+            ...headlinePortrait,
+            fontSize: 24,
+            lineHeight: 24,
+          },
+        },
+        0.75: {
+          ...portrait834,
+          headline: {
+            ...headlinePortrait,
+            fontSize: 22,
+            lineHeight: 22,
+          },
+        },
+      },
+    },
     "1024": {
       ...sharedPortraitStyles,
       imageContainer: {
@@ -136,5 +170,5 @@ const styles = {
   },
 };
 
-export const getStyle = (orientation, windowWidth) =>
-  getStyleByDeviceSize(styles[orientation], windowWidth);
+export const getStyle = (orientation, windowWidth, windowHeight) =>
+  getStyleByDeviceSize(styles[orientation], windowWidth, windowHeight);

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -14,14 +14,14 @@ import { getStyle } from "./styles";
 import { getDimensions } from "@times-components-native/utils";
 
 const TileFFront = ({ onPress, tile, orientation }) => {
-  const { width: windowWidth } = getDimensions();
+  const { width: windowWidth, height: windowHeight } = getDimensions();
   const isLandscape = orientation === "landscape";
   const columnCount = isLandscape ? 1 : 3;
   const hideSummary = isLandscape;
 
   const isHugeLandscape = windowWidth >= editionBreakpointWidths.huge;
   const imageCrop = getTileImage(tile, "crop169");
-  const styles = getStyle(orientation, windowWidth);
+  const styles = getStyle(orientation, windowWidth, windowHeight);
 
   if (!imageCrop) return null;
 

--- a/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
@@ -47,6 +47,27 @@ const sharedPortraitStyles = {
   },
 };
 
+const portrait834 = {
+  ...sharedPortraitStyles,
+  headline: {
+    ...headline,
+    marginBottom: spacing(2),
+  },
+  imageContainer: {
+    width: "100%",
+    marginBottom: spacing(2),
+  },
+  strapline: {
+    ...strapline,
+    marginBottom: spacing(3),
+  },
+  summary: {
+    ...summary,
+    fontSize: 14,
+    lineHeight: 18,
+  },
+};
+
 const styles = {
   landscape: {
     "1024": {
@@ -161,27 +182,33 @@ const styles = {
       },
     },
     "834": {
-      ...sharedPortraitStyles,
-      headline: {
-        ...headline,
-        fontSize: 45,
-        lineHeight: 45,
-        marginBottom: spacing(2),
-      },
-      imageContainer: {
-        width: "100%",
-        marginBottom: spacing(2),
-      },
-      strapline: {
-        ...strapline,
-        fontSize: 24,
-        lineHeight: 24,
-        marginBottom: spacing(3),
-      },
-      summary: {
-        ...summary,
-        fontSize: 14,
-        lineHeight: 18,
+      ratios: {
+        0: {
+          ...portrait834,
+          headline: {
+            ...portrait834.headline,
+            fontSize: 50,
+            lineHeight: 50,
+          },
+          strapline: {
+            ...portrait834.strapline,
+            fontSize: 26,
+            lineHeight: 26,
+          },
+        },
+        0.75: {
+          ...portrait834,
+          headline: {
+            ...portrait834.headline,
+            fontSize: 45,
+            lineHeight: 45,
+          },
+          strapline: {
+            ...portrait834.strapline,
+            fontSize: 24,
+            lineHeight: 24,
+          },
+        },
       },
     },
     "1024": {
@@ -211,5 +238,5 @@ const styles = {
   },
 };
 
-export const getStyle = (orientation, windowWidth) =>
-  getStyleByDeviceSize(styles[orientation], windowWidth);
+export const getStyle = (orientation, windowWidth, windowHeight) =>
+  getStyleByDeviceSize(styles[orientation], windowWidth, windowHeight);

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -15,9 +15,9 @@ const TileGFront = ({
   showSummary,
   showByline,
 }) => {
-  const { width: windowWidth } = getDimensions();
+  const { width: windowWidth, height: windowHeight } = getDimensions();
   const crop = getTileImage(tile, "crop45");
-  const styles = getStyle(orientation, windowWidth);
+  const styles = getStyle(orientation, windowWidth, windowHeight);
 
   if (!crop) {
     return null;

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -143,5 +143,5 @@ const styles = {
   },
 };
 
-export const getStyle = (orientation, windowWidth) =>
-  getStyleByDeviceSize(styles[orientation], windowWidth);
+export const getStyle = (orientation, windowWidth, windowHeight) =>
+  getStyleByDeviceSize(styles[orientation], windowWidth, windowHeight);

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -7,8 +7,8 @@ import { getTileStrapline, TileLink } from "../shared";
 import { getStyle } from "./styles";
 
 const TileHFront = ({ onPress, tile, orientation }) => {
-  const { width: windowWidth } = getDimensions();
-  const styles = getStyle(orientation, windowWidth);
+  const { width: windowWidth, height: windowHeight } = getDimensions();
+  const styles = getStyle(orientation, windowWidth, windowHeight);
 
   const { article } = tile;
 

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -45,6 +45,23 @@ const sharedPortraitStyles = {
   },
 };
 
+const portrait834 = {
+  ...sharedPortraitStyles,
+  container: {
+    ...sharedPortraitStyles.container,
+    paddingBottom: spacing(1),
+  },
+  headline: {
+    ...sharedHeadline,
+    marginBottom: spacing(2),
+  },
+  strapline: {
+    ...sharedStrapline,
+    fontSize: 22,
+    lineHeight: 22,
+  },
+};
+
 const styles = {
   landscape: {
     "1024": {
@@ -152,21 +169,23 @@ const styles = {
       },
     },
     "834": {
-      ...sharedPortraitStyles,
-      container: {
-        ...sharedPortraitStyles.container,
-        paddingBottom: spacing(1),
-      },
-      headline: {
-        ...sharedHeadline,
-        fontSize: 30,
-        lineHeight: 30,
-        marginBottom: spacing(2),
-      },
-      strapline: {
-        ...sharedStrapline,
-        fontSize: 22,
-        lineHeight: 22,
+      ratios: {
+        0: {
+          ...portrait834,
+          headline: {
+            ...portrait834.headline,
+            fontSize: 45,
+            lineHeight: 45,
+          },
+        },
+        0.75: {
+          ...portrait834,
+          headline: {
+            ...portrait834.headline,
+            fontSize: 42,
+            lineHeight: 42,
+          },
+        },
       },
     },
     "1024": {
@@ -194,5 +213,5 @@ const styles = {
   },
 };
 
-export const getStyle = (orientation, windowWidth) =>
-  getStyleByDeviceSize(styles[orientation], windowWidth);
+export const getStyle = (orientation, windowWidth, windowHeight) =>
+  getStyleByDeviceSize(styles[orientation], windowWidth, windowHeight);

--- a/packages/styleguide/__tests__/breakpoints/index.test.js
+++ b/packages/styleguide/__tests__/breakpoints/index.test.js
@@ -8,23 +8,42 @@ describe("getStyleByDeviceSize", () => {
     "768": {
       backgroundColor: "red",
     },
+    "834": {
+      ratios: {
+        0: {
+          backgroundColor: "yellow",
+        },
+        0.5: {
+          backgroundColor: "grey",
+        },
+      },
+    },
     "1024": {
       backgroundColor: "green",
     },
   };
 
   it("gets smallest device style", () => {
-    expect(getStyleByDeviceSize(styles, 768)).toEqual(styles["768"]);
-    expect(getStyleByDeviceSize(styles, 809)).toEqual(styles["768"]);
+    expect(getStyleByDeviceSize(styles, 768, 1500)).toEqual(styles["768"]);
+    expect(getStyleByDeviceSize(styles, 809, 1500)).toEqual(styles["768"]);
   });
 
   it("gets medium device style", () => {
-    expect(getStyleByDeviceSize(styles, 810)).toEqual(styles["810"]);
-    expect(getStyleByDeviceSize(styles, 1023)).toEqual(styles["810"]);
+    expect(getStyleByDeviceSize(styles, 810, 1500)).toEqual(styles["810"]);
+    expect(getStyleByDeviceSize(styles, 833, 1500)).toEqual(styles["810"]);
   });
 
   it("gets largest device style", () => {
-    expect(getStyleByDeviceSize(styles, 1024)).toEqual(styles["1024"]);
-    expect(getStyleByDeviceSize(styles, 1366)).toEqual(styles["1024"]);
+    expect(getStyleByDeviceSize(styles, 1024, 1500)).toEqual(styles["1024"]);
+    expect(getStyleByDeviceSize(styles, 1366, 1500)).toEqual(styles["1024"]);
+  });
+
+  it("gets device style with ratio refinement", () => {
+    expect(getStyleByDeviceSize(styles, 834, 2000)).toEqual(
+      styles["834"].ratios["0"],
+    );
+    expect(getStyleByDeviceSize(styles, 834, 1000)).toEqual(
+      styles["834"].ratios["0.5"],
+    );
   });
 });

--- a/packages/styleguide/src/breakpoints/index.js
+++ b/packages/styleguide/src/breakpoints/index.js
@@ -39,10 +39,18 @@ const getNarrowArticleBreakpoint = (width) => {
   return narrowArticleWidths.wide;
 };
 
-const getStyleByDeviceSize = (styles, windowWidth) => {
+const getStyleByDeviceSize = (styles, windowWidth, windowHeight) => {
   const selectedSize = Object.entries(styles)
     .sort(([a], [b]) => b - a)
     .find(([size]) => size <= windowWidth);
+
+  if (selectedSize?.[1].ratios) {
+    const size = Object.entries(selectedSize[1].ratios)
+      .sort(([a], [b]) => b - a)
+      .find(([ratio]) => ratio <= windowWidth / windowHeight);
+    return size?.[1] ?? {};
+  }
+
   return selectedSize?.[1] ?? {};
 };
 


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/TNLT-5530
- Adds ability to add ratio refinement to style config object used to get style by device size.
- Makes sure 834px portrait iPad and iPro are as per zeplin designs.

### Lead One Front
<img width="1557" alt="Screenshot 2020-10-13 at 15 11 13" src="https://user-images.githubusercontent.com/1736782/95887611-f81f4400-0d77-11eb-9a60-aec0f27855ec.png">

### Lead Two Front

<img width="1518" alt="Screenshot 2020-10-13 at 15 34 30" src="https://user-images.githubusercontent.com/1736782/95887602-f48bbd00-0d77-11eb-8123-dc676927eb85.png">

### Lead One and One Front

<img width="1519" alt="Screenshot 2020-10-13 at 14 59 09" src="https://user-images.githubusercontent.com/1736782/95887628-fd7c8e80-0d77-11eb-9750-a624bbb455e5.png">

