### PR TITLE
fix: Linking out from Dianomi ads within a WebView

### DIFF
--- a/packages/ad/__tests__/android/sponsored-ad.android.test.tsx
+++ b/packages/ad/__tests__/android/sponsored-ad.android.test.tsx
@@ -1,0 +1,33 @@
+import { SponsoredAd } from "@times-components-native/ad/src/sponsored-ad";
+import TestRenderer from "react-test-renderer";
+import React from "react";
+import WebView from "react-native-webview";
+import { Linking } from "react-native";
+
+jest.mock("react-native", () => {
+  const rn = jest.requireActual("react-native");
+  rn.NativeModules.Linking = { openURL: jest.fn() };
+  return rn;
+});
+
+describe("SponsoredAd", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("opens external browser when link is clicked", () => {
+    const ad = TestRenderer.create(<SponsoredAd />);
+    const webView = ad.root.findByType(WebView);
+
+    TestRenderer.act(() => {
+      const result = webView.props.onShouldStartLoadWithRequest({
+        navigationType: "other",
+        url: "https://some-test-url",
+      });
+
+      expect(result).toEqual(false);
+    });
+
+    expect(Linking.openURL).toHaveBeenCalledWith(`https://some-test-url`);
+  });
+});

--- a/packages/ad/__tests__/ios/sponsored-ad.ios.test.tsx
+++ b/packages/ad/__tests__/ios/sponsored-ad.ios.test.tsx
@@ -1,0 +1,49 @@
+import { SponsoredAd } from "@times-components-native/ad/src/sponsored-ad";
+import TestRenderer from "react-test-renderer";
+import React from "react";
+import WebView from "react-native-webview";
+import { Linking } from "react-native";
+
+jest.mock("react-native", () => {
+  const rn = jest.requireActual("react-native");
+  rn.NativeModules.Linking = { openURL: jest.fn() };
+  return rn;
+});
+
+describe("SponsoredAd", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("opens external browser when link is clicked", () => {
+    const ad = TestRenderer.create(<SponsoredAd />);
+    const webView = ad.root.findByType(WebView);
+
+    TestRenderer.act(() => {
+      const result = webView.props.onShouldStartLoadWithRequest({
+        navigationType: "click",
+        url: "https://some-test-url",
+      });
+
+      expect(result).toEqual(false);
+    });
+
+    expect(Linking.openURL).toHaveBeenCalledWith(`https://some-test-url`);
+  });
+
+  it("handles network requests inside webview if not initiated with a click", () => {
+    const ad = TestRenderer.create(<SponsoredAd />);
+    const webView = ad.root.findByType(WebView);
+
+    TestRenderer.act(() => {
+      const result = webView.props.onShouldStartLoadWithRequest({
+        navigationType: "other",
+        url: "https://some-test-url",
+      });
+
+      expect(result).toEqual(true);
+    });
+
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ad/__tests__/sponsored-ad.test.tsx
+++ b/packages/ad/__tests__/sponsored-ad.test.tsx
@@ -2,7 +2,6 @@ import { SponsoredAd } from "@times-components-native/ad/src/sponsored-ad";
 import TestRenderer from "react-test-renderer";
 import React from "react";
 import WebView from "react-native-webview";
-import { Linking } from "react-native";
 
 jest.mock("react-native", () => {
   const rn = jest.requireActual("react-native");

--- a/packages/ad/__tests__/sponsored-ad.test.tsx
+++ b/packages/ad/__tests__/sponsored-ad.test.tsx
@@ -42,36 +42,4 @@ describe("SponsoredAd", () => {
 
     expect(webView.props.source.html).toMatchSnapshot();
   });
-
-  it("opens external browser when link is clicked", () => {
-    const ad = TestRenderer.create(<SponsoredAd />);
-    const webView = ad.root.findByType(WebView);
-
-    TestRenderer.act(() => {
-      const result = webView.props.onShouldStartLoadWithRequest({
-        navigationType: "click",
-        url: "https://some-test-url",
-      });
-
-      expect(result).toEqual(false);
-    });
-
-    expect(Linking.openURL).toHaveBeenCalledWith(`https://some-test-url`);
-  });
-
-  it("handles network requests inside webview if not initiated with a click", () => {
-    const ad = TestRenderer.create(<SponsoredAd />);
-    const webView = ad.root.findByType(WebView);
-
-    TestRenderer.act(() => {
-      const result = webView.props.onShouldStartLoadWithRequest({
-        navigationType: "other",
-        url: "https://some-test-url",
-      });
-
-      expect(result).toEqual(true);
-    });
-
-    expect(Linking.openURL).not.toHaveBeenCalled();
-  });
 });

--- a/packages/ad/src/sponsored-ad.tsx
+++ b/packages/ad/src/sponsored-ad.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import WebView from "react-native-webview";
-import { Linking, View } from "react-native";
+import { Linking, Platform, View } from "react-native";
 import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes";
 
 import styles from "./styles";
 
+const isIOS = Platform.OS === "ios";
+
 const handleRequest = (e: WebViewNavigation) => {
-  if (e.navigationType !== "click") return true;
+  if (isIOS && e.navigationType !== "click") return true;
+  if (!isIOS && e.url.slice(0, 4) !== "http") return true;
 
   Linking.openURL(e.url);
   return false;
@@ -30,6 +33,7 @@ export const SponsoredAd: React.FC<Props> = ({ numberOfAds = 4 }) => {
       <WebView
         style={styles.sponsoredAd}
         originWhitelist={["*"]}
+        // onNavigationStateChange={handleNavChange}
         onShouldStartLoadWithRequest={handleRequest}
         scrollEnabled={false}
         source={{

--- a/packages/ad/src/sponsored-ad.tsx
+++ b/packages/ad/src/sponsored-ad.tsx
@@ -33,7 +33,6 @@ export const SponsoredAd: React.FC<Props> = ({ numberOfAds = 4 }) => {
       <WebView
         style={styles.sponsoredAd}
         originWhitelist={["*"]}
-        // onNavigationStateChange={handleNavChange}
         onShouldStartLoadWithRequest={handleRequest}
         scrollEnabled={false}
         source={{

--- a/test-setup/jest.android.config.js
+++ b/test-setup/jest.android.config.js
@@ -11,10 +11,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: [],
   rootDir: "../",
-  testMatch: [
-    "**/__tests__/android/*.test.js",
-    "**/__tests__/android/*.test.ts",
-  ],
+  testMatch: ["**/__tests__/android/?(*.)+(spec|test).[jt]s?(x)"],
   testURL: "http://localhost",
   transform: {
     "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$":

--- a/test-setup/jest.ios.config.js
+++ b/test-setup/jest.ios.config.js
@@ -11,7 +11,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: [],
   rootDir: "../",
-  testMatch: ["**/__tests__/ios/*.test.js"],
+  testMatch: ["**/__tests__/ios/?(*.)+(spec|test).[jt]s?(x)"],
   testURL: "http://localhost",
   transform: {
     "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$":


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-5579

WebView events are handled differently by Android and iOS. This PR fixes the sponsored ads (Dianomi) to handle ad clicks for both platforms.

Also changes the Jest test file pattern for both platforms to allow for `ts` and `tsx` files.