### PR TITLE
feat: (TNLT-5500) Integrate fronts

### DIFF
--- a/packages/edition-slices/src/edition-slices.js
+++ b/packages/edition-slices/src/edition-slices.js
@@ -69,7 +69,7 @@ const sliceMap = (isInSupplement) => {
     TwoPicAndSixNoPicSlice: ListTwoAndSixNoPicSlice,
     LeadTwoFrontSlice,
     LeadOneAndOneFrontSlice,
-    LeadOneFullWidthFrontSlice,
+    LeadOneFullWidthFrontSlice: LeadOneFullWidthFrontSlice,
     TopSecondaryTwoAndTwoSlice: TopSecondarySlice,
     TopSecondaryTwoNoPicAndTwoSlice: TopSecondarySlice,
     TopSecondaryFourSlice: TopSecondarySlice,

--- a/packages/edition-slices/src/edition-slices.js
+++ b/packages/edition-slices/src/edition-slices.js
@@ -69,7 +69,7 @@ const sliceMap = (isInSupplement) => {
     TwoPicAndSixNoPicSlice: ListTwoAndSixNoPicSlice,
     LeadTwoFrontSlice,
     LeadOneAndOneFrontSlice,
-    LeadOneFullWidthFrontSlice: LeadOneFullWidthFrontSlice,
+    LeadOneFullWidthFrontSlice,
     TopSecondaryTwoAndTwoSlice: TopSecondarySlice,
     TopSecondaryTwoNoPicAndTwoSlice: TopSecondarySlice,
     TopSecondaryFourSlice: TopSecondarySlice,

--- a/packages/edition-slices/src/slices/frontleadone/index.js
+++ b/packages/edition-slices/src/slices/frontleadone/index.js
@@ -9,8 +9,12 @@ function renderMedium(props, breakpoint, orientation) {
     onPress,
     onLinkPress,
     slice: { lead },
-    inTodaysEditionSlice: { items: inTodaysEditionItems },
+    inTodaysEditionSlice,
   } = props;
+
+  if (!inTodaysEditionSlice?.items.length) return null;
+
+  const { items: inTodaysEditionItems } = inTodaysEditionSlice;
 
   return (
     <FrontLeadOneSlice

--- a/packages/edition-slices/src/slices/frontleadone/index.js
+++ b/packages/edition-slices/src/slices/frontleadone/index.js
@@ -9,12 +9,8 @@ function renderMedium(props, breakpoint, orientation) {
     onPress,
     onLinkPress,
     slice: { lead },
-    inTodaysEditionSlice,
+    inTodaysEditionSlice: { items: inTodaysEditionItems = [] },
   } = props;
-
-  if (!inTodaysEditionSlice?.items.length) return null;
-
-  const { items: inTodaysEditionItems } = inTodaysEditionSlice;
 
   return (
     <FrontLeadOneSlice

--- a/packages/edition-slices/src/slices/frontleadoneandone/index.js
+++ b/packages/edition-slices/src/slices/frontleadoneandone/index.js
@@ -12,8 +12,12 @@ function renderMedium(props, orientation) {
     onPress,
     onLinkPress,
     slice: { lead, support },
-    inTodaysEditionSlice: { items: inTodaysEditionItems },
+    inTodaysEditionSlice,
   } = props;
+
+  if (!inTodaysEditionSlice?.items.length) return null;
+
+  const { items: inTodaysEditionItems } = inTodaysEditionSlice;
 
   return (
     <FrontLeadOneAndOneSlice

--- a/packages/edition-slices/src/slices/frontleadoneandone/index.js
+++ b/packages/edition-slices/src/slices/frontleadoneandone/index.js
@@ -12,12 +12,8 @@ function renderMedium(props, orientation) {
     onPress,
     onLinkPress,
     slice: { lead, support },
-    inTodaysEditionSlice,
+    inTodaysEditionSlice: { items: inTodaysEditionItems = [] },
   } = props;
-
-  if (!inTodaysEditionSlice?.items.length) return null;
-
-  const { items: inTodaysEditionItems } = inTodaysEditionSlice;
 
   return (
     <FrontLeadOneAndOneSlice

--- a/packages/edition-slices/src/slices/frontleadtwo/index.js
+++ b/packages/edition-slices/src/slices/frontleadtwo/index.js
@@ -15,8 +15,12 @@ function renderMedium(props, breakpoint, orientation) {
     onPress,
     onLinkPress,
     slice: { lead1, lead2 },
-    inTodaysEditionSlice: { items: inTodaysEditionItems },
+    inTodaysEditionSlice,
   } = props;
+
+  if (!inTodaysEditionSlice?.items.length) return null;
+
+  const { items: inTodaysEditionItems } = inTodaysEditionSlice;
 
   const showSummary =
     breakpoint === editionBreakpoints.huge && orientation === "landscape";

--- a/packages/edition-slices/src/slices/frontleadtwo/index.js
+++ b/packages/edition-slices/src/slices/frontleadtwo/index.js
@@ -12,12 +12,8 @@ function renderMedium(props, orientation) {
     onPress,
     onLinkPress,
     slice: { lead1, lead2 },
-    inTodaysEditionSlice,
+    inTodaysEditionSlice: { items: inTodaysEditionItems = [] },
   } = props;
-
-  if (!inTodaysEditionSlice?.items.length) return null;
-
-  const { items: inTodaysEditionItems } = inTodaysEditionSlice;
 
   return (
     <FrontLeadTwoSlice

--- a/packages/edition-slices/src/tiles/shared/tile-link.js
+++ b/packages/edition-slices/src/tiles/shared/tile-link.js
@@ -10,7 +10,7 @@ const TileLink = ({
     article: { id, url },
   },
 }) => (
-  <Link linkStyle={style} onPress={() => onPress({ id, url })} url={url}>
+  <Link linkStyle={style} onPress={() => onPress({ id })} url={url}>
     {children}
   </Link>
 );

--- a/packages/fixture-generator/src/types.ts
+++ b/packages/fixture-generator/src/types.ts
@@ -2762,6 +2762,7 @@ export type Media = Image | Video;
 export type DraftTileArticle = Article | DraftArticle;
 
 export type FrontPageSectionSlice =
+  | InTheNewsSlice
   | LeadTwoFrontSlice
   | LeadOneAndOneFrontSlice
   | LeadOneFullWidthFrontSlice;

--- a/packages/in-todays-edition/in-todays-edition.tsx
+++ b/packages/in-todays-edition/in-todays-edition.tsx
@@ -37,6 +37,8 @@ const InTodaysEdition: React.FC<Props> = ({
   onLinkPress,
   orientation,
 }) => {
+  if (!items.length) return null;
+
   const { width: windowWidth } = getDimensions();
   const styles = getStyles(orientation, windowWidth);
 

--- a/packages/in-todays-edition/item.tsx
+++ b/packages/in-todays-edition/item.tsx
@@ -37,8 +37,16 @@ const Item: React.FC<Props> = ({
 
   const ctaText = isArticleLink(link) ? "Read the full story" : "Take me there";
   const onPress = isArticleLink(link)
-    ? () => onArticlePress((item.mainLink as ArticleLinkType).articleId)
-    : () => onLinkPress((item.mainLink as LinkType).url);
+    ? () =>
+        onArticlePress({
+          id: (item.mainLink as ArticleLinkType).articleId,
+          url: (item.mainLink as ArticleLinkType).articleId,
+        })
+    : () =>
+        onLinkPress({
+          id: (item.mainLink as LinkType).url,
+          url: (item.mainLink as LinkType).url,
+        });
 
   return (
     <>

--- a/packages/in-todays-edition/item.tsx
+++ b/packages/in-todays-edition/item.tsx
@@ -40,11 +40,9 @@ const Item: React.FC<Props> = ({
     ? () =>
         onArticlePress({
           id: (item.mainLink as ArticleLinkType).articleId,
-          url: (item.mainLink as ArticleLinkType).articleId,
         })
     : () =>
         onLinkPress({
-          id: (item.mainLink as LinkType).url,
           url: (item.mainLink as LinkType).url,
         });
 

--- a/packages/in-todays-edition/item.tsx
+++ b/packages/in-todays-edition/item.tsx
@@ -37,14 +37,8 @@ const Item: React.FC<Props> = ({
 
   const ctaText = isArticleLink(link) ? "Read the full story" : "Take me there";
   const onPress = isArticleLink(link)
-    ? () =>
-        onArticlePress({
-          id: (item.mainLink as ArticleLinkType).articleId,
-        })
-    : () =>
-        onLinkPress({
-          url: (item.mainLink as LinkType).url,
-        });
+    ? () => onArticlePress({ id: (item.mainLink as ArticleLinkType).articleId })
+    : () => onLinkPress({ url: (item.mainLink as LinkType).url });
 
   return (
     <>

--- a/packages/pages/src/section/section.js
+++ b/packages/pages/src/section/section.js
@@ -21,8 +21,8 @@ const {
   onPuzzlePress: () => null,
 };
 
-const onArticlePress = ({ id, url }) => onArticlePressBridge(url, id);
-const onLinkPress = ({ id, url }) => onLinkPressBridge(url, id);
+const onArticlePress = ({ id }) => onArticlePressBridge(id);
+const onLinkPress = ({ url }) => onLinkPressBridge(url);
 
 const onPuzzlePress = ({ id, title, url }) =>
   onPuzzlePressBridge(url, title, id);

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -212,7 +212,7 @@ fragment leadAsset54and32 on Media {
       crop32: crop(ratio: "3:2") {
         ...sectionCropProps
       }
-      crop45: crop(ratio: "5:4") {
+      crop54: crop(ratio: "5:4") {
         ...sectionCropProps
       }
     }
@@ -221,7 +221,7 @@ fragment leadAsset54and32 on Media {
     crop32: crop(ratio: "3:2") {
       ...sectionCropProps
     }
-    crop45: crop(ratio: "5:4") {
+    crop54: crop(ratio: "5:4") {
       ...sectionCropProps
     }
   }

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -986,17 +986,17 @@ fragment frontSlicesSection on FrontPageSectionSlice {
       headline
       strapline
       leadAsset {
-        ...leadAsset169and32
+        ...leadAsset169
       }
       article {
         ...baseArticleProps
         strapline
         content
         leadAsset {
-          ...leadAsset169and32
+          ...leadAsset169
         }
         listingAsset {
-          ...leadAsset169and32
+          ...leadAsset169
         }
       }
     }

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -1001,6 +1001,24 @@ fragment frontSlicesSection on FrontPageSectionSlice {
       }
     }
   }
+  ... on InTheNewsSlice {
+    items {
+      strapline
+      title
+      mainLink {
+        __typename
+        ... on PuffMainLinkRef {
+          __typename
+          ... on ArticleLink {
+            articleId
+          }
+           ... on Link {
+            url
+          }
+        }
+      }
+    }
+  }
 }
 
 fragment topSecondarySlice on ArticleSlice {

--- a/packages/section/__tests__/android/__snapshots__/section-tracking.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section-tracking.test.js.snap
@@ -73,7 +73,6 @@ Array [
   Array [
     Object {
       "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-      "url": "/article/123",
     },
   ],
 ]

--- a/packages/section/__tests__/ios/__snapshots__/section-tracking.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section-tracking.test.js.snap
@@ -28,7 +28,6 @@ Array [
   Array [
     Object {
       "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-      "url": "/article/123",
     },
   ],
 ]

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -56,7 +56,7 @@ class Section extends Component {
     return null;
   }
 
-  renderItem({ index, item: slice }) {
+  renderItem({ index, item: slice, inTodaysEditionSlice }) {
     const {
       onArticlePress,
       onLinkPress,
@@ -73,6 +73,7 @@ class Section extends Component {
         onLinkPress={onLinkPress}
         slice={slice}
         isInSupplement={isSupplementSection(title)}
+        inTodaysEditionSlice={inTodaysEditionSlice}
       />
     );
   }
@@ -110,7 +111,19 @@ class Section extends Component {
         <ResponsiveContext.Consumer>
           {({ isTablet, editionBreakpoint }) => {
             if (name === "FrontPageSection") {
-              return this.renderItem({ index: 0, item: slices[0] });
+              const inTheNewsSlice = slices.find(
+                (slice) => slice.name === "InTheNewsSlice",
+              );
+
+              const frontSlice = slices.find(
+                (slice) => slice.name !== "InTheNewsSlice",
+              );
+
+              return this.renderItem({
+                index: 0,
+                item: frontSlice,
+                inTodaysEditionSlice: inTheNewsSlice,
+              });
             }
 
             const data = isPuzzle

--- a/packages/section/src/section.js
+++ b/packages/section/src/section.js
@@ -121,8 +121,8 @@ class Section extends Component {
 
               return this.renderItem({
                 index: 0,
-                item: frontSlice,
-                inTodaysEditionSlice: inTheNewsSlice,
+                item: frontSlice || {},
+                inTodaysEditionSlice: inTheNewsSlice || {},
               });
             }
 

--- a/packages/section/src/slice.js
+++ b/packages/section/src/slice.js
@@ -3,10 +3,21 @@ import PropTypes from "prop-types";
 import { getSlice } from "@times-components-native/edition-slices";
 import withSliceTrackingContext from "./slice-tracking-context";
 
-const Slice = ({ slice, onPress, onLinkPress, isInSupplement }) => {
+const Slice = ({
+  slice,
+  onPress,
+  onLinkPress,
+  isInSupplement,
+  inTodaysEditionSlice,
+}) => {
   const Component = getSlice(isInSupplement, slice.name);
   return Component ? (
-    <Component onPress={onPress} onLinkPress={onLinkPress} slice={slice} />
+    <Component
+      onPress={onPress}
+      onLinkPress={onLinkPress}
+      slice={slice}
+      inTodaysEditionSlice={inTodaysEditionSlice}
+    />
   ) : null;
 };
 


### PR DESCRIPTION
- Add `InTheNewsSlice` to front page query
- Fix some incorrect image crops in query
- on section page refactor `onArticlePress` to only send `id` as agreed with Native devs
- on section page refactor `onLinkPress` to only send `url` as agreed with Native devs

### Lead Two 
<img width="1365" alt="Screenshot 2020-10-15 at 10 44 02" src="https://user-images.githubusercontent.com/1736782/96114585-b7413f80-0edd-11eb-94ab-905d8d42d2a0.png">
<img width="977" alt="Screenshot 2020-10-15 at 10 43 56" src="https://user-images.githubusercontent.com/1736782/96114626-c7f1b580-0edd-11eb-9b58-6e28a70c2431.png">

### Lead One and One
<img width="991" alt="Screenshot 2020-10-15 at 15 38 57" src="https://user-images.githubusercontent.com/1736782/96145744-70634200-0efd-11eb-8eb3-f1fb363aee2d.png">
<img width="1336" alt="Screenshot 2020-10-15 at 15 39 36" src="https://user-images.githubusercontent.com/1736782/96145768-7527f600-0efd-11eb-802e-88dacb0ea9f1.png">

### Lead One
<img width="742" alt="Screenshot 2020-10-15 at 17 01 51" src="https://user-images.githubusercontent.com/1736782/96155970-727ece00-0f08-11eb-8b85-a79f86ca084b.png">
<img width="1020" alt="Screenshot 2020-10-15 at 17 03 22" src="https://user-images.githubusercontent.com/1736782/96155885-5b3fe080-0f08-11eb-9e30-67df31f6c5af.png">

### Android
<img width="701" alt="Screenshot 2020-10-16 at 15 18 36" src="https://user-images.githubusercontent.com/1736782/96271055-55a7d080-0fc4-11eb-9115-ca306943729b.png">

