### PR TITLE
feat: Send extra param for native to identify puff links

### DIFF
--- a/packages/in-todays-edition/item.tsx
+++ b/packages/in-todays-edition/item.tsx
@@ -37,7 +37,11 @@ const Item: React.FC<Props> = ({
 
   const ctaText = isArticleLink(link) ? "Read the full story" : "Take me there";
   const onPress = isArticleLink(link)
-    ? () => onArticlePress({ id: (item.mainLink as ArticleLinkType).articleId })
+    ? () =>
+        onArticlePress({
+          id: (item.mainLink as ArticleLinkType).articleId,
+          isPuff: true,
+        })
     : () => onLinkPress({ url: (item.mainLink as LinkType).url });
 
   return (

--- a/packages/pages/src/section/section.js
+++ b/packages/pages/src/section/section.js
@@ -21,7 +21,8 @@ const {
   onPuzzlePress: () => null,
 };
 
-const onArticlePress = ({ id }) => onArticlePressBridge(id);
+const onArticlePress = ({ id, isPuff = false }) =>
+  onArticlePressBridge(id, isPuff);
 const onLinkPress = ({ url }) => onLinkPressBridge(url);
 
 const onPuzzlePress = ({ id, title, url }) =>


### PR DESCRIPTION
- Send a 2nd parameter to `onArticlePressBridge` on secton page to identify that the pressed article link is a puff link for back button functionality.