### PR TITLE
fix: Adds correct margins to headlines and optional straplines

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -76,6 +76,7 @@ exports[`tile a front landscape 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -669,7 +670,7 @@ exports[`tile a front landscape 1080 1`] = `
       ]
     }
     columnCount={1}
-    headlineMarginBottom={10}
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -679,6 +680,7 @@ exports[`tile a front landscape 1080 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1272,7 +1274,7 @@ exports[`tile a front landscape 1194 1`] = `
       ]
     }
     columnCount={1}
-    headlineMarginBottom={10}
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1282,6 +1284,7 @@ exports[`tile a front landscape 1194 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1875,7 +1878,7 @@ exports[`tile a front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
-    headlineMarginBottom={10}
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1885,6 +1888,7 @@ exports[`tile a front landscape 1366 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2488,6 +2492,7 @@ exports[`tile a front portrait 768 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3091,6 +3096,7 @@ exports[`tile a front portrait 810 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3694,6 +3700,7 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4297,6 +4304,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4900,6 +4908,7 @@ exports[`tile a front portrait 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -76,6 +76,7 @@ exports[`tile f front landscape 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -632,6 +633,7 @@ exports[`tile f front landscape 1080 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1188,6 +1190,7 @@ exports[`tile f front landscape 1194 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1744,6 +1747,7 @@ exports[`tile f front landscape 1366 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2290,7 +2294,7 @@ exports[`tile f front portrait 768 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={5}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -2300,6 +2304,7 @@ exports[`tile f front portrait 768 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={10}
+    straplineMarginTop={5}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2893,7 +2898,7 @@ exports[`tile f front portrait 810 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={5}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -2903,6 +2908,7 @@ exports[`tile f front portrait 810 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={5}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3496,7 +3502,7 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -3506,6 +3512,7 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4099,7 +4106,7 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4108,7 +4115,8 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
       }
     }
     strapline="Three Conservative MPs resign"
-    straplineMarginBottom={20}
+    straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4702,7 +4710,7 @@ exports[`tile f front portrait 1024 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={5}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4712,6 +4720,7 @@ exports[`tile f front portrait 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={25}
+    straplineMarginTop={5}
     straplineStyle={
       Object {
         "color": "#333333",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -2422,8 +2422,8 @@ exports[`tile h front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 28,
+        "lineHeight": 28,
       }
     }
     strapline="Three Conservative MPs resign"

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -54,7 +54,7 @@ exports[`tile h front landscape 1024 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -64,6 +64,7 @@ exports[`tile h front landscape 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -644,7 +645,7 @@ exports[`tile h front landscape 1080 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -654,6 +655,7 @@ exports[`tile h front landscape 1080 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1234,7 +1236,7 @@ exports[`tile h front landscape 1194 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1244,6 +1246,7 @@ exports[`tile h front landscape 1194 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1834,6 +1837,7 @@ exports[`tile h front landscape 1366 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2414,16 +2418,17 @@ exports[`tile h front portrait 768 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 28,
-        "lineHeight": 28,
+        "fontSize": 40,
+        "lineHeight": 40,
       }
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3004,7 +3009,7 @@ exports[`tile h front portrait 810 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -3014,6 +3019,7 @@ exports[`tile h front portrait 810 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3594,7 +3600,7 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -3605,6 +3611,7 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4185,7 +4192,7 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4196,6 +4203,7 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4776,7 +4784,7 @@ exports[`tile h front portrait 1024 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4786,6 +4794,7 @@ exports[`tile h front portrait 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -76,6 +76,7 @@ exports[`tile a front landscape 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -669,7 +670,7 @@ exports[`tile a front landscape 1080 1`] = `
       ]
     }
     columnCount={1}
-    headlineMarginBottom={10}
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -679,6 +680,7 @@ exports[`tile a front landscape 1080 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1272,7 +1274,7 @@ exports[`tile a front landscape 1194 1`] = `
       ]
     }
     columnCount={1}
-    headlineMarginBottom={10}
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1282,6 +1284,7 @@ exports[`tile a front landscape 1194 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1875,7 +1878,7 @@ exports[`tile a front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
-    headlineMarginBottom={10}
+    headlineMarginBottom={15}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1885,6 +1888,7 @@ exports[`tile a front landscape 1366 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2488,6 +2492,7 @@ exports[`tile a front portrait 768 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3091,6 +3096,7 @@ exports[`tile a front portrait 810 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3694,6 +3700,7 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4297,6 +4304,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4900,6 +4908,7 @@ exports[`tile a front portrait 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -76,6 +76,7 @@ exports[`tile f front landscape 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -632,6 +633,7 @@ exports[`tile f front landscape 1080 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1188,6 +1190,7 @@ exports[`tile f front landscape 1194 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1744,6 +1747,7 @@ exports[`tile f front landscape 1366 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2290,7 +2294,7 @@ exports[`tile f front portrait 768 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={5}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -2300,6 +2304,7 @@ exports[`tile f front portrait 768 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={10}
+    straplineMarginTop={5}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2893,7 +2898,7 @@ exports[`tile f front portrait 810 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={5}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -2903,6 +2908,7 @@ exports[`tile f front portrait 810 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={5}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3496,7 +3502,7 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -3506,6 +3512,7 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4099,7 +4106,7 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4108,7 +4115,8 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
       }
     }
     strapline="Three Conservative MPs resign"
-    straplineMarginBottom={20}
+    straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4702,7 +4710,7 @@ exports[`tile f front portrait 1024 1`] = `
       ]
     }
     columnCount={3}
-    headlineMarginBottom={5}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4712,6 +4720,7 @@ exports[`tile f front portrait 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={25}
+    straplineMarginTop={5}
     straplineStyle={
       Object {
         "color": "#333333",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -2422,8 +2422,8 @@ exports[`tile h front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 40,
-        "lineHeight": 40,
+        "fontSize": 28,
+        "lineHeight": 28,
       }
     }
     strapline="Three Conservative MPs resign"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -54,7 +54,7 @@ exports[`tile h front landscape 1024 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -64,6 +64,7 @@ exports[`tile h front landscape 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -644,7 +645,7 @@ exports[`tile h front landscape 1080 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -654,6 +655,7 @@ exports[`tile h front landscape 1080 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1234,7 +1236,7 @@ exports[`tile h front landscape 1194 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1244,6 +1246,7 @@ exports[`tile h front landscape 1194 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -1834,6 +1837,7 @@ exports[`tile h front landscape 1366 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -2414,16 +2418,17 @@ exports[`tile h front portrait 768 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 28,
-        "lineHeight": 28,
+        "fontSize": 40,
+        "lineHeight": 40,
       }
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3004,7 +3009,7 @@ exports[`tile h front portrait 810 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -3014,6 +3019,7 @@ exports[`tile h front portrait 810 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -3594,7 +3600,7 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -3605,6 +3611,7 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4185,7 +4192,7 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4196,6 +4203,7 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",
@@ -4776,7 +4784,7 @@ exports[`tile h front portrait 1024 1`] = `
         },
       ]
     }
-    headlineMarginBottom={10}
+    headlineMarginBottom={20}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -4786,6 +4794,7 @@ exports[`tile h front portrait 1024 1`] = `
     }
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
+    straplineMarginTop={10}
     straplineStyle={
       Object {
         "color": "#333333",

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -51,6 +51,7 @@ const TileAFront = ({ onPress, tile, orientation }) => {
         columnCount={columnCount}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}
+        straplineMarginTop={styles.straplineMarginTop}
         straplineMarginBottom={styles.straplineMarginBottom}
         headlineMarginBottom={styles.headlineMarginBottom}
         summaryLineHeight={styles.summary.lineHeight}

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -44,6 +44,7 @@ const sharedStyles = {
 const sharedLandscapeStyles = {
   ...sharedStyles,
   headlineMarginBottom: spacing(2),
+  straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
   bylineMarginBottom: spacing(3),
 };
@@ -51,6 +52,7 @@ const sharedLandscapeStyles = {
 const sharedPortraitStyles = {
   ...sharedStyles,
   headlineMarginBottom: spacing(4),
+  straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
   bylineMarginBottom: 0,
 };
@@ -68,6 +70,9 @@ const styles = {
   landscape: {
     "1024": {
       ...sharedLandscapeStyles,
+      headlineMarginBottom: spacing(2),
+      straplineMarginTop: spacing(2),
+      straplineMarginBottom: spacing(3),
       headline: {
         ...headline,
         fontSize: 42,
@@ -76,6 +81,9 @@ const styles = {
     },
     "1080": {
       ...sharedLandscapeStyles,
+      headlineMarginBottom: spacing(3),
+      straplineMarginTop: spacing(2),
+      straplineMarginBottom: spacing(3),
       headline: {
         ...headline,
         fontSize: 45,
@@ -84,6 +92,9 @@ const styles = {
     },
     "1112": {
       ...sharedLandscapeStyles,
+      headlineMarginBottom: spacing(3),
+      straplineMarginTop: spacing(2),
+      straplineMarginBottom: spacing(3),
       headline: {
         ...headline,
         fontSize: 45,
@@ -92,6 +103,9 @@ const styles = {
     },
     "1366": {
       ...sharedLandscapeStyles,
+      headlineMarginBottom: spacing(3),
+      straplineMarginTop: spacing(2),
+      straplineMarginBottom: spacing(3),
       headline: {
         ...headline,
         fontSize: 55,

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -46,6 +46,7 @@ const TileFFront = ({ onPress, tile, orientation }) => {
         summaryLineHeight={styles.summary.lineHeight}
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
+        straplineMarginTop={styles.straplineMarginTop}
         straplineMarginBottom={styles.straplineMarginBottom}
         tile={tile}
         template={article.template}

--- a/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
@@ -36,6 +36,7 @@ const sharedLandscapeStyles = {
     fontSize: 14,
     lineHeight: 18,
   },
+  straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
   headlineMarginBottom: spacing(2),
   bylineMarginBottom: spacing(3),
@@ -47,8 +48,6 @@ const sharedPortraitStyles = {
     flex: 1,
     flexDirection: "column",
   },
-  headlineMarginBottom: spacing(1),
-  straplineMarginBottom: spacing(3),
   bylineMarginBottom: 0,
   summary: {
     ...summary,
@@ -59,7 +58,6 @@ const sharedPortraitStyles = {
 
 const portrait834 = {
   ...sharedPortraitStyles,
-  headlineMarginBottom: spacing(2),
   headline: {
     ...headline,
   },
@@ -149,6 +147,8 @@ const styles = {
         fontSize: 24,
         lineHeight: 24,
       },
+      headlineMarginBottom: spacing(4),
+      straplineMarginTop: spacing(1),
       straplineMarginBottom: spacing(2),
     },
     "810": {
@@ -167,13 +167,17 @@ const styles = {
         fontSize: 24,
         lineHeight: 24,
       },
+      headlineMarginBottom: spacing(4),
+      straplineMarginTop: spacing(1),
       straplineMarginBottom: spacing(3),
     },
     "834": {
       ratios: {
         0: {
           ...portrait834,
-          straplineMarginBottom: spacing(4),
+          headlineMarginBottom: spacing(4),
+          straplineMarginTop: spacing(2),
+          straplineMarginBottom: spacing(3),
           headline: {
             ...portrait834.headline,
             fontSize: 50,
@@ -187,6 +191,9 @@ const styles = {
         },
         0.75: {
           ...portrait834,
+          headlineMarginBottom: spacing(4),
+          straplineMarginTop: spacing(2),
+          straplineMarginBottom: spacing(3),
           headline: {
             ...portrait834.headline,
             fontSize: 45,
@@ -216,6 +223,8 @@ const styles = {
         fontSize: 30,
         lineHeight: 30,
       },
+      headlineMarginBottom: spacing(4),
+      straplineMarginTop: spacing(1),
       straplineMarginBottom: spacing(5),
       summary: {
         ...summary,

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -16,7 +16,7 @@ const TileHFront = ({ onPress, tile, orientation }) => {
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <FrontTileSummary
-        headlineStyle={[styles.headline]}
+        headlineStyle={styles.headline}
         headlineMarginBottom={styles.headlineMarginBottom}
         strapline={strapline}
         straplineStyle={styles.strapline}

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -16,10 +16,11 @@ const TileHFront = ({ onPress, tile, orientation }) => {
   return (
     <TileLink onPress={onPress} style={styles.container} tile={tile}>
       <FrontTileSummary
-        headlineStyle={styles.headline}
+        headlineStyle={[styles.headline]}
         headlineMarginBottom={styles.headlineMarginBottom}
         strapline={strapline}
         straplineStyle={styles.strapline}
+        straplineMarginTop={styles.straplineMarginTop}
         straplineMarginBottom={styles.straplineMarginBottom}
         summary={article.content}
         summaryStyle={styles.summary}

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -139,8 +139,8 @@ const styles = {
       ...sharedPortraitStyles,
       headline: {
         ...sharedHeadline,
-        fontSize: 40,
-        lineHeight: 40,
+        fontSize: 28,
+        lineHeight: 28,
       },
       strapline: {
         ...sharedStrapline,

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -25,7 +25,8 @@ const sharedSummary = {
 const sharedStyles = {
   summary: { ...sharedSummary },
   bylineMarginBottom: spacing(3),
-  headlineMarginBottom: spacing(2),
+  headlineMarginBottom: spacing(4),
+  straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
 };
 
@@ -138,8 +139,8 @@ const styles = {
       ...sharedPortraitStyles,
       headline: {
         ...sharedHeadline,
-        fontSize: 28,
-        lineHeight: 28,
+        fontSize: 40,
+        lineHeight: 40,
       },
       strapline: {
         ...sharedStrapline,

--- a/packages/front-page/__tests__/front-tile-summary.test.js
+++ b/packages/front-page/__tests__/front-tile-summary.test.js
@@ -64,6 +64,7 @@ const props = {
   template: "mainstandard",
   summaryStyle: { backgroundColor: "orange" },
   headlineMarginBottom: 10,
+  straplineMarginTop: 10,
   straplineMarginBottom: 20,
   bylineMarginBottom: 15,
   summaryLineHeight: 20,

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -112,7 +112,7 @@ describe("getFrontTileConfig", () => {
     const config = getFrontTileConfig(summaryConfig);
     expect(config).toEqual({
       headline: {
-        marginBottom: 25,
+        marginBottom: 10,
         show: true,
       },
       byline: {
@@ -155,7 +155,7 @@ describe("getFrontTileConfig", () => {
     const config = getFrontTileConfig(summaryConfig);
     expect(config).toEqual({
       headline: {
-        marginBottom: 20,
+        marginBottom: 10,
         show: true,
       },
       byline: {
@@ -163,7 +163,7 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 20,
+        marginBottom: 15,
         show: true,
       },
       content: {
@@ -184,7 +184,7 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 80,
-        marginTop: 10,
+        marginTop: 20,
         marginBottom: 15,
       },
       bylines: {
@@ -206,7 +206,6 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginTop: 10,
         marginBottom: 15,
         show: true,
       },
@@ -229,7 +228,7 @@ describe("getFrontTileConfig", () => {
       strapline: {
         height: 0,
         marginTop: 10,
-        marginBottom: 15,
+        marginBottom: 25,
       },
       bylines: {
         height: 100,
@@ -250,7 +249,7 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 20,
+        marginBottom: 25,
         show: false,
       },
       content: {

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -270,6 +270,7 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 0,
+        marginTop: 20,
         marginBottom: 20,
       },
       bylines: {

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -12,7 +12,8 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 100,
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
       },
       bylines: {
         height: 100,
@@ -54,7 +55,8 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 80,
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
       },
       bylines: {
         height: 100,
@@ -67,7 +69,7 @@ describe("getFrontTileConfig", () => {
     const config = getFrontTileConfig(summaryConfig);
     expect(config).toEqual({
       headline: {
-        marginBottom: 20,
+        marginBottom: 10,
         show: true,
       },
       byline: {
@@ -96,7 +98,8 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 80,
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
       },
       bylines: {
         height: 100,
@@ -109,7 +112,7 @@ describe("getFrontTileConfig", () => {
     const config = getFrontTileConfig(summaryConfig);
     expect(config).toEqual({
       headline: {
-        marginBottom: 20,
+        marginBottom: 25,
         show: true,
       },
       byline: {
@@ -117,7 +120,7 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 20,
+        marginBottom: 15,
         show: true,
       },
       content: {
@@ -138,7 +141,8 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 80,
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
       },
       bylines: {
         height: 80,
@@ -180,7 +184,8 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 80,
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
       },
       bylines: {
         height: 80,
@@ -201,7 +206,8 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
         show: true,
       },
       content: {
@@ -222,7 +228,8 @@ describe("getFrontTileConfig", () => {
       },
       strapline: {
         height: 0,
-        marginBottom: 20,
+        marginTop: 10,
+        marginBottom: 15,
       },
       bylines: {
         height: 100,

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -29,6 +29,7 @@ interface Props {
   showKeyline?: boolean;
   bylineContainerStyle?: any;
   headlineMarginBottom: number;
+  straplineMarginTop: number;
   straplineMarginBottom: number;
   bylineMarginBottom: number;
   summaryLineHeight: number;
@@ -94,6 +95,7 @@ const renderByline = (props: Props) => {
 const FrontTileSummary: React.FC<Props> = (props) => {
   const {
     bylineMarginBottom,
+    straplineMarginTop,
     straplineMarginBottom,
     headlineMarginBottom,
     summaryLineHeight,
@@ -161,6 +163,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
               },
               strapline: {
                 height: straplineHeight,
+                marginTop: straplineMarginTop,
                 marginBottom: straplineMarginBottom,
               },
               bylines: {

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -10,6 +10,7 @@ interface SummaryConfig {
   };
   strapline: {
     height: number;
+    marginTop: number;
     marginBottom: number;
   };
   bylines: {
@@ -24,7 +25,10 @@ interface SummaryConfig {
 export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
   const { container, headline, strapline, bylines, content } = summaryConfig;
 
-  const headlineWithMargin = headline.height + headline.marginBottom;
+  const headlineMargin =
+    strapline.height === 0 ? headline.marginBottom : strapline.marginTop;
+
+  const headlineWithMargin = headlineMargin + headline.marginBottom;
 
   const straplineWithMargin =
     strapline.height > 0 ? strapline.height + strapline.marginBottom : 0;
@@ -49,7 +53,7 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
       show: true,
       marginBottom:
         canAccommodateStrapline || canAccommodateByline || canAccommodateContent
-          ? headline.marginBottom
+          ? headlineMargin
           : 0,
     },
     strapline: {

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -28,7 +28,7 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
   const headlineMargin =
     strapline.height === 0 ? headline.marginBottom : strapline.marginTop;
 
-  const headlineWithMargin = headlineMargin + headline.marginBottom;
+  const headlineWithMargin = headlineMargin + headline.height;
 
   const straplineWithMargin =
     strapline.height > 0 ? strapline.height + strapline.marginBottom : 0;


### PR DESCRIPTION
![Simulator Screen Shot - iPad mini 4 - 2020-10-22 at 15 08 22](https://user-images.githubusercontent.com/6280629/96883571-7b2b5300-1478-11eb-9cf0-ea7a237742a3.png)
![Simulator Screen Shot - iPad mini 4 - 2020-10-22 at 15 08 16](https://user-images.githubusercontent.com/6280629/96883589-7ff00700-1478-11eb-813b-91a86d7d6c36.png)
