### PR TITLE
fix: Only hyphenates justified content

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -74,6 +74,7 @@ exports[`tile a front landscape 1024 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -133,15 +134,13 @@ exports[`tile a front landscape 1024 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -678,6 +677,7 @@ exports[`tile a front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -737,15 +737,13 @@ exports[`tile a front landscape 1080 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1282,6 +1280,7 @@ exports[`tile a front landscape 1194 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1341,15 +1340,13 @@ exports[`tile a front landscape 1194 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1886,6 +1883,7 @@ exports[`tile a front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1945,15 +1943,13 @@ exports[`tile a front landscape 1366 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
-        "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "fontSize": 15,
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2490,6 +2486,7 @@ exports[`tile a front portrait 768 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -2554,10 +2551,8 @@ exports[`tile a front portrait 768 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3094,6 +3089,7 @@ exports[`tile a front portrait 810 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3158,10 +3154,8 @@ exports[`tile a front portrait 810 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3698,6 +3692,7 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3762,10 +3757,8 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4302,6 +4295,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 48,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4366,10 +4360,8 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4906,6 +4898,7 @@ exports[`tile a front portrait 1024 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4970,10 +4963,8 @@ exports[`tile a front portrait 1024 1`] = `
       Object {
         "fontSize": 15,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -73,8 +73,10 @@ exports[`tile b front landscape 1024 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -128,10 +130,8 @@ exports[`tile b front landscape 1024 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -667,8 +667,10 @@ exports[`tile b front landscape 1080 1`] = `
         "lineHeight": 25,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -722,10 +724,8 @@ exports[`tile b front landscape 1080 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1261,8 +1261,10 @@ exports[`tile b front landscape 1194 1`] = `
         "lineHeight": 25,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1316,10 +1318,8 @@ exports[`tile b front landscape 1194 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1855,8 +1855,10 @@ exports[`tile b front landscape 1366 1`] = `
         "lineHeight": 25,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1910,10 +1912,8 @@ exports[`tile b front landscape 1366 1`] = `
       Object {
         "fontSize": 15,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2449,8 +2449,10 @@ exports[`tile b front portrait 768 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -2504,10 +2506,8 @@ exports[`tile b front portrait 768 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3043,8 +3043,10 @@ exports[`tile b front portrait 810 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3098,10 +3100,8 @@ exports[`tile b front portrait 810 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3637,8 +3637,10 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3692,10 +3694,8 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4231,8 +4231,10 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 24,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4286,10 +4288,8 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4825,8 +4825,10 @@ exports[`tile b front portrait 1024 1`] = `
         "lineHeight": 26,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4882,7 +4884,6 @@ exports[`tile b front portrait 1024 1`] = `
         "lineHeight": 18,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -73,7 +73,6 @@ exports[`tile b front landscape 1024 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -667,7 +666,6 @@ exports[`tile b front landscape 1080 1`] = `
         "lineHeight": 25,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -1261,7 +1259,6 @@ exports[`tile b front landscape 1194 1`] = `
         "lineHeight": 25,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -1855,7 +1852,6 @@ exports[`tile b front landscape 1366 1`] = `
         "lineHeight": 25,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -2449,7 +2445,6 @@ exports[`tile b front portrait 768 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -3043,7 +3038,6 @@ exports[`tile b front portrait 810 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -3637,7 +3631,6 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -4231,7 +4224,6 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 24,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -4825,7 +4817,6 @@ exports[`tile b front portrait 1024 1`] = `
         "lineHeight": 26,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -74,6 +74,7 @@ exports[`tile f front landscape 1024 1`] = `
         "lineHeight": 40,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -91,10 +92,8 @@ exports[`tile f front landscape 1024 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -631,6 +630,7 @@ exports[`tile f front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -648,10 +648,8 @@ exports[`tile f front landscape 1080 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1188,6 +1186,7 @@ exports[`tile f front landscape 1194 1`] = `
         "lineHeight": 50,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1205,10 +1204,8 @@ exports[`tile f front landscape 1194 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1745,6 +1742,7 @@ exports[`tile f front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1762,10 +1760,8 @@ exports[`tile f front landscape 1366 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2302,6 +2298,7 @@ exports[`tile f front portrait 768 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={10}
     straplineMarginTop={5}
@@ -2366,10 +2363,8 @@ exports[`tile f front portrait 768 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2906,6 +2901,7 @@ exports[`tile f front portrait 810 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={5}
@@ -2970,10 +2966,8 @@ exports[`tile f front portrait 810 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3510,6 +3504,7 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3574,10 +3569,8 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4114,6 +4107,7 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 50,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4178,10 +4172,8 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4718,6 +4710,7 @@ exports[`tile f front portrait 1024 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={25}
     straplineMarginTop={5}
@@ -4782,10 +4775,8 @@ exports[`tile f front portrait 1024 1`] = `
       Object {
         "fontSize": 15,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -62,7 +62,6 @@ exports[`tile h front landscape 1024 1`] = `
         "lineHeight": 42,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -653,7 +652,6 @@ exports[`tile h front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1244,7 +1242,6 @@ exports[`tile h front landscape 1194 1`] = `
         "lineHeight": 48,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1835,7 +1832,6 @@ exports[`tile h front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -2426,7 +2422,6 @@ exports[`tile h front portrait 768 1`] = `
         "lineHeight": 28,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3017,7 +3012,6 @@ exports[`tile h front portrait 810 1`] = `
         "lineHeight": 28,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3609,7 +3603,6 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4201,7 +4194,6 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4792,7 +4784,6 @@ exports[`tile h front portrait 1024 1`] = `
         "lineHeight": 53,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -62,6 +62,7 @@ exports[`tile h front landscape 1024 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -128,7 +129,6 @@ exports[`tile h front landscape 1024 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -653,6 +653,7 @@ exports[`tile h front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -719,7 +720,6 @@ exports[`tile h front landscape 1080 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1244,6 +1244,7 @@ exports[`tile h front landscape 1194 1`] = `
         "lineHeight": 48,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1310,7 +1311,6 @@ exports[`tile h front landscape 1194 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1835,6 +1835,7 @@ exports[`tile h front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1901,7 +1902,6 @@ exports[`tile h front landscape 1366 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2426,6 +2426,7 @@ exports[`tile h front portrait 768 1`] = `
         "lineHeight": 28,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -2492,7 +2493,6 @@ exports[`tile h front portrait 768 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3017,6 +3017,7 @@ exports[`tile h front portrait 810 1`] = `
         "lineHeight": 28,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3083,7 +3084,6 @@ exports[`tile h front portrait 810 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3609,6 +3609,7 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3675,7 +3676,6 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4201,6 +4201,7 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4267,7 +4268,6 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4792,6 +4792,7 @@ exports[`tile h front portrait 1024 1`] = `
         "lineHeight": 53,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4858,7 +4859,6 @@ exports[`tile h front portrait 1024 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -74,6 +74,7 @@ exports[`tile a front landscape 1024 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -133,15 +134,13 @@ exports[`tile a front landscape 1024 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -678,6 +677,7 @@ exports[`tile a front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -737,15 +737,13 @@ exports[`tile a front landscape 1080 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1282,6 +1280,7 @@ exports[`tile a front landscape 1194 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1341,15 +1340,13 @@ exports[`tile a front landscape 1194 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
         "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1886,6 +1883,7 @@ exports[`tile a front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1945,15 +1943,13 @@ exports[`tile a front landscape 1366 1`] = `
         },
       ]
     }
-    summaryLineHeight={18}
+    summaryLineHeight={20}
     summaryStyle={
       Object {
-        "fontSize": 14,
-        "lineHeight": 18,
-        "textAlign": "justify",
+        "fontSize": 15,
+        "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2490,6 +2486,7 @@ exports[`tile a front portrait 768 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -2554,10 +2551,8 @@ exports[`tile a front portrait 768 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3094,6 +3089,7 @@ exports[`tile a front portrait 810 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3158,10 +3154,8 @@ exports[`tile a front portrait 810 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3698,6 +3692,7 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3762,10 +3757,8 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4302,6 +4295,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 48,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4366,10 +4360,8 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4906,6 +4898,7 @@ exports[`tile a front portrait 1024 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4970,10 +4963,8 @@ exports[`tile a front portrait 1024 1`] = `
       Object {
         "fontSize": 15,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -73,8 +73,10 @@ exports[`tile b front landscape 1024 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -128,10 +130,8 @@ exports[`tile b front landscape 1024 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -667,8 +667,10 @@ exports[`tile b front landscape 1080 1`] = `
         "lineHeight": 25,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -722,10 +724,8 @@ exports[`tile b front landscape 1080 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1261,8 +1261,10 @@ exports[`tile b front landscape 1194 1`] = `
         "lineHeight": 25,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1316,10 +1318,8 @@ exports[`tile b front landscape 1194 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1855,8 +1855,10 @@ exports[`tile b front landscape 1366 1`] = `
         "lineHeight": 25,
       }
     }
+    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1910,10 +1912,8 @@ exports[`tile b front landscape 1366 1`] = `
       Object {
         "fontSize": 15,
         "lineHeight": 20,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2449,8 +2449,10 @@ exports[`tile b front portrait 768 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -2504,10 +2506,8 @@ exports[`tile b front portrait 768 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3043,8 +3043,10 @@ exports[`tile b front portrait 810 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3098,10 +3100,8 @@ exports[`tile b front portrait 810 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3637,8 +3637,10 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 22,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3692,10 +3694,8 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4231,8 +4231,10 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 24,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4286,10 +4288,8 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4825,8 +4825,10 @@ exports[`tile b front portrait 1024 1`] = `
         "lineHeight": 26,
       }
     }
+    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4882,7 +4884,6 @@ exports[`tile b front portrait 1024 1`] = `
         "lineHeight": 18,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -73,7 +73,6 @@ exports[`tile b front landscape 1024 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -667,7 +666,6 @@ exports[`tile b front landscape 1080 1`] = `
         "lineHeight": 25,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -1261,7 +1259,6 @@ exports[`tile b front landscape 1194 1`] = `
         "lineHeight": 25,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -1855,7 +1852,6 @@ exports[`tile b front landscape 1366 1`] = `
         "lineHeight": 25,
       }
     }
-    justified={false}
     showKeyline={false}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -2449,7 +2445,6 @@ exports[`tile b front portrait 768 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -3043,7 +3038,6 @@ exports[`tile b front portrait 810 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -3637,7 +3631,6 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 22,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -4231,7 +4224,6 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 24,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}
@@ -4825,7 +4817,6 @@ exports[`tile b front portrait 1024 1`] = `
         "lineHeight": 26,
       }
     }
-    justified={false}
     showKeyline={true}
     straplineMarginBottom={0}
     straplineMarginTop={0}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -74,6 +74,7 @@ exports[`tile f front landscape 1024 1`] = `
         "lineHeight": 40,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -91,10 +92,8 @@ exports[`tile f front landscape 1024 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -631,6 +630,7 @@ exports[`tile f front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -648,10 +648,8 @@ exports[`tile f front landscape 1080 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1188,6 +1186,7 @@ exports[`tile f front landscape 1194 1`] = `
         "lineHeight": 50,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1205,10 +1204,8 @@ exports[`tile f front landscape 1194 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1745,6 +1742,7 @@ exports[`tile f front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1762,10 +1760,8 @@ exports[`tile f front landscape 1366 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2302,6 +2298,7 @@ exports[`tile f front portrait 768 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={10}
     straplineMarginTop={5}
@@ -2366,10 +2363,8 @@ exports[`tile f front portrait 768 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2906,6 +2901,7 @@ exports[`tile f front portrait 810 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={5}
@@ -2970,10 +2966,8 @@ exports[`tile f front portrait 810 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3510,6 +3504,7 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3574,10 +3569,8 @@ exports[`tile f front portrait 834 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4114,6 +4107,7 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 50,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4178,10 +4172,8 @@ exports[`tile f front portrait 834 less than 0.75 ratio 1`] = `
       Object {
         "fontSize": 14,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4718,6 +4710,7 @@ exports[`tile f front portrait 1024 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={true}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={25}
     straplineMarginTop={5}
@@ -4782,10 +4775,8 @@ exports[`tile f front portrait 1024 1`] = `
       Object {
         "fontSize": 15,
         "lineHeight": 18,
-        "textAlign": "justify",
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -62,7 +62,6 @@ exports[`tile h front landscape 1024 1`] = `
         "lineHeight": 42,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -653,7 +652,6 @@ exports[`tile h front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1244,7 +1242,6 @@ exports[`tile h front landscape 1194 1`] = `
         "lineHeight": 48,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1835,7 +1832,6 @@ exports[`tile h front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -2426,7 +2422,6 @@ exports[`tile h front portrait 768 1`] = `
         "lineHeight": 28,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3017,7 +3012,6 @@ exports[`tile h front portrait 810 1`] = `
         "lineHeight": 28,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3609,7 +3603,6 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4201,7 +4194,6 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4792,7 +4784,6 @@ exports[`tile h front portrait 1024 1`] = `
         "lineHeight": 53,
       }
     }
-    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -62,6 +62,7 @@ exports[`tile h front landscape 1024 1`] = `
         "lineHeight": 42,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -128,7 +129,6 @@ exports[`tile h front landscape 1024 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -653,6 +653,7 @@ exports[`tile h front landscape 1080 1`] = `
         "lineHeight": 45,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -719,7 +720,6 @@ exports[`tile h front landscape 1080 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1244,6 +1244,7 @@ exports[`tile h front landscape 1194 1`] = `
         "lineHeight": 48,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1310,7 +1311,6 @@ exports[`tile h front landscape 1194 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -1835,6 +1835,7 @@ exports[`tile h front landscape 1366 1`] = `
         "lineHeight": 55,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -1901,7 +1902,6 @@ exports[`tile h front landscape 1366 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -2426,6 +2426,7 @@ exports[`tile h front portrait 768 1`] = `
         "lineHeight": 28,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -2492,7 +2493,6 @@ exports[`tile h front portrait 768 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3017,6 +3017,7 @@ exports[`tile h front portrait 810 1`] = `
         "lineHeight": 28,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3083,7 +3084,6 @@ exports[`tile h front portrait 810 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -3609,6 +3609,7 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -3675,7 +3676,6 @@ exports[`tile h front portrait 834 0.75 ratio 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4201,6 +4201,7 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         "marginBottom": 10,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4267,7 +4268,6 @@ exports[`tile h front portrait 834 less than 0.75 ratio 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {
@@ -4792,6 +4792,7 @@ exports[`tile h front portrait 1024 1`] = `
         "lineHeight": 53,
       }
     }
+    justified={false}
     strapline="Three Conservative MPs resign"
     straplineMarginBottom={15}
     straplineMarginTop={10}
@@ -4858,7 +4859,6 @@ exports[`tile h front portrait 1024 1`] = `
         "lineHeight": 20,
       }
     }
-    template="mainstandard"
     tile={
       Object {
         "article": Object {

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -47,7 +47,7 @@ const TileAFront = ({ onPress, tile, orientation }) => {
         strapline={strapline}
         straplineStyle={styles.strapline}
         tile={tile}
-        template={article.template}
+        justified={columnCount > 1}
         columnCount={columnCount}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -8,7 +8,6 @@ import { getStyleByDeviceSize } from "@times-components-native/styleguide/src/st
 
 const summary = {
   ...globalSpacingStyles.tabletTeaser,
-  textAlign: "justify",
 };
 
 const headline = {
@@ -47,6 +46,11 @@ const sharedLandscapeStyles = {
   straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
   bylineMarginBottom: spacing(3),
+  summary: {
+    ...summary,
+    fontSize: 14,
+    lineHeight: 20,
+  },
 };
 
 const sharedPortraitStyles = {
@@ -110,6 +114,11 @@ const styles = {
         ...headline,
         fontSize: 55,
         lineHeight: 55,
+      },
+      summary: {
+        ...summary,
+        fontSize: 15,
+        lineHeight: 20,
       },
     },
   },

--- a/packages/edition-slices/src/tiles/tile-b-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/index.js
@@ -39,7 +39,6 @@ const TileBFront = ({ onPress, tile, orientation }) => {
         straplineMarginBottom={0}
         summaryLineHeight={styles.summary.lineHeight}
         summary={article.content}
-        justified={false}
         summaryStyle={styles.summary}
         showKeyline={showKeyline}
         tile={tile}

--- a/packages/edition-slices/src/tiles/tile-b-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/index.js
@@ -35,18 +35,15 @@ const TileBFront = ({ onPress, tile, orientation }) => {
         headlineStyle={styles.headline}
         headlineMarginBottom={styles.headlineMarginBottom}
         bylineMarginBottom={styles.bylineMarginBottom}
+        straplineMarginTop={0}
         straplineMarginBottom={0}
         summaryLineHeight={styles.summary.lineHeight}
         summary={article.content}
-        summaryStyle={
-          article.template === "maincomment"
-            ? styles.commentSummary
-            : styles.summary
-        }
+        justified={false}
+        summaryStyle={styles.summary}
         showKeyline={showKeyline}
         tile={tile}
         bylines={article.bylines}
-        template={article.template}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
@@ -7,12 +7,6 @@ import { getStyleByDeviceSize } from "@times-components-native/styleguide/src/st
 
 const summary = {
   ...globalSpacingStyles.tabletTeaser,
-  textAlign: "justify",
-};
-
-const commentSummary = {
-  ...summary,
-  textAlign: "left",
 };
 
 const headlineLandscape = {
@@ -57,11 +51,6 @@ const portrait834 = {
   ...sharedPortraitStyles,
   summary: {
     ...summary,
-    fontSize: 14,
-    lineHeight: 18,
-  },
-  commentSummary: {
-    ...commentSummary,
     fontSize: 14,
     lineHeight: 18,
   },
@@ -122,11 +111,6 @@ const styles = {
         fontSize: 14,
         lineHeight: 18,
       },
-      commentSummary: {
-        ...commentSummary,
-        fontSize: 14,
-        lineHeight: 18,
-      },
     },
     "834": {
       ratios: {
@@ -160,11 +144,6 @@ const styles = {
         lineHeight: 26,
       },
       summary: {
-        fontSize: 15,
-        lineHeight: 18,
-      },
-      commentSummary: {
-        ...commentSummary,
         fontSize: 15,
         lineHeight: 18,
       },

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -47,9 +47,9 @@ const TileFFront = ({ onPress, tile, orientation }) => {
         strapline={getTileStrapline(tile)}
         straplineStyle={styles.strapline}
         straplineMarginTop={styles.straplineMarginTop}
+        justified={true}
         straplineMarginBottom={styles.straplineMarginBottom}
         tile={tile}
-        template={article.template}
         columnCount={columnCount}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}

--- a/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
@@ -13,7 +13,6 @@ const headline = {
 
 const summary = {
   ...globalSpacingStyles.tabletTeaser,
-  textAlign: "justify",
 };
 
 const strapline = {

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -27,8 +27,8 @@ const TileHFront = ({ onPress, tile, orientation }) => {
         summaryLineHeight={styles.summary.lineHeight}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}
+        justified={false}
         tile={tile}
-        template={article.template}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-h-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/index.js
@@ -27,7 +27,6 @@ const TileHFront = ({ onPress, tile, orientation }) => {
         summaryLineHeight={styles.summary.lineHeight}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}
-        justified={false}
         tile={tile}
       />
     </TileLink>

--- a/packages/front-page/__tests__/__snapshots__/front-article-summary-content.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-article-summary-content.test.js.snap
@@ -28,3 +28,33 @@ exports[`FrontArticleSummaryContent renders correctly 1`] = `
   </Text>
 </Text>
 `;
+
+exports[`FrontArticleSummaryContent renders correctly with justified text 1`] = `
+<Text
+  numberOfLines={9}
+  style={
+    Object {
+      "color": "#333333",
+      "flexWrap": "wrap",
+      "fontFamily": "TimesDigitalW04",
+      "fontSize": 14,
+      "lineHeight": 20,
+      "marginBottom": 0,
+      "textAlign": "justify",
+    }
+  }
+>
+  <Text
+    style={
+      Array [
+        false,
+      ]
+    }
+    textBreakStrategy="simple"
+  >
+    Test
+    
+
+  </Text>
+</Text>
+`;

--- a/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
@@ -203,7 +203,6 @@ exports[`FrontTileSummary renders byline with keyline 1`] = `
         "backgroundColor": "orange",
       }
     }
-    template="mainstandard"
   />
 </View>
 `;
@@ -308,7 +307,6 @@ exports[`FrontTileSummary renders with 2 columns 1`] = `
         "backgroundColor": "orange",
       }
     }
-    template="mainstandard"
   />
 </View>
 `;
@@ -394,7 +392,6 @@ exports[`FrontTileSummary renders with a missing byline 1`] = `
         "backgroundColor": "orange",
       }
     }
-    template="mainstandard"
   />
 </View>
 `;
@@ -499,7 +496,6 @@ exports[`FrontTileSummary renders with a missing strapline 1`] = `
         "backgroundColor": "orange",
       }
     }
-    template="mainstandard"
   />
 </View>
 `;
@@ -665,7 +661,6 @@ exports[`FrontTileSummary shows front tile summary with headline/strapline/bylin
         "backgroundColor": "orange",
       }
     }
-    template="mainstandard"
   />
 </View>
 `;

--- a/packages/front-page/__tests__/front-article-summary-content.test.js
+++ b/packages/front-page/__tests__/front-article-summary-content.test.js
@@ -36,7 +36,6 @@ const props = {
   bylines: bylines,
   whiteSpaceHeight: 20,
   justified: false,
-  linesOfTeaserToRender: 1,
   style: { backgoundColor: "red" },
   summary: ast,
 };

--- a/packages/front-page/__tests__/front-article-summary-content.test.js
+++ b/packages/front-page/__tests__/front-article-summary-content.test.js
@@ -31,20 +31,25 @@ const ast = [
 ];
 
 const bylines = new MockMarkup().addBylines().get();
-const component = (
-  <FrontArticleSummaryContent
-    bylines={bylines}
-    whiteSpaceHeight={20}
-    justified={false}
-    linesOfTeaserToRender={1}
-    style={{ backgoundColor: "red" }}
-    summary={ast}
-  />
-);
 
+const props = {
+  bylines: bylines,
+  whiteSpaceHeight: 20,
+  justified: false,
+  linesOfTeaserToRender: 1,
+  style: { backgoundColor: "red" },
+  summary: ast,
+};
 describe("FrontArticleSummaryContent", () => {
   it("renders correctly", () => {
-    const tree = TestRenderer.create(component);
+    const tree = TestRenderer.create(<FrontArticleSummaryContent {...props} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders correctly with justified text", () => {
+    const tree = TestRenderer.create(
+      <FrontArticleSummaryContent {...props} justified={true} />,
+    );
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/front-page/__tests__/front-article-summary-content.test.js
+++ b/packages/front-page/__tests__/front-article-summary-content.test.js
@@ -35,7 +35,7 @@ const component = (
   <FrontArticleSummaryContent
     bylines={bylines}
     whiteSpaceHeight={20}
-    template={"mainstandard"}
+    justified={false}
     linesOfTeaserToRender={1}
     style={{ backgoundColor: "red" }}
     summary={ast}

--- a/packages/front-page/__tests__/front-tile-summary.test.js
+++ b/packages/front-page/__tests__/front-tile-summary.test.js
@@ -61,7 +61,6 @@ const props = {
   headlineStyle: { backgroundColor: "blue" },
   straplineStyle: { backgroundColor: "green" },
   strapline: "Strapline Text",
-  template: "mainstandard",
   summaryStyle: { backgroundColor: "orange" },
   headlineMarginBottom: 10,
   straplineMarginTop: 10,

--- a/packages/front-page/__tests__/front-tile-summary.test.js
+++ b/packages/front-page/__tests__/front-tile-summary.test.js
@@ -56,7 +56,6 @@ const props = {
   tile: new MockTile().get(),
   whiteSpaceHeight: 40,
   bylines: bylines,
-  linesOfTeaserToRender: 2,
   containerStyle: { backgroundColor: "red" },
   headlineStyle: { backgroundColor: "blue" },
   straplineStyle: { backgroundColor: "green" },

--- a/packages/front-page/__tests__/transform-content-for-front.test.ts
+++ b/packages/front-page/__tests__/transform-content-for-front.test.ts
@@ -1,14 +1,12 @@
 import { transformContentForFront } from "@times-components-native/front-page/utils/transform-content-for-front";
 import MockMarkup from "@times-components-native/fixture-generator/src/mock-markup";
 import { ArticleContent } from "@times-components-native/article-columns/domain-types";
-import { TemplateType } from "@times-components-native/fixture-generator/src/types";
 
-const template: TemplateType = TemplateType.Magazinestandard;
 describe("indentation", () => {
   it("does not add indent to first paragraph", () => {
     const content = new MockMarkup().addParagraphs(10).get();
 
-    const indentedContent = transformContentForFront(content, template);
+    const indentedContent = transformContentForFront(content, false);
 
     expect(indentedContent[0].attributes.tab).toBeFalsy();
   });
@@ -16,7 +14,7 @@ describe("indentation", () => {
   it("does add indents to subsequent paragraphs", () => {
     const content = new MockMarkup().addParagraphs(10).get();
 
-    const indentedContent = transformContentForFront(content, template);
+    const indentedContent = transformContentForFront(content, false);
 
     expect(indentedContent[1].attributes.tab).toBeTruthy();
   });
@@ -24,14 +22,14 @@ describe("indentation", () => {
   it("does not add indent to non-paragraphs", () => {
     const content = new MockMarkup().addAds(2).get();
 
-    const indentedContent = transformContentForFront(content, template);
+    const indentedContent = transformContentForFront(content, false);
     expect(indentedContent[0].attributes.tab).toBeFalsy();
     expect(indentedContent[1].attributes.tab).toBeFalsy();
   });
 });
 
 describe("hyphenation", () => {
-  it("hyphenates the content", () => {
+  it("hyphenates justified content", () => {
     const content = [
       {
         name: "paragraph",
@@ -47,7 +45,7 @@ describe("hyphenation", () => {
       },
     ] as ArticleContent[];
 
-    const transformedContent = transformContentForFront(content, template);
+    const transformedContent = transformContentForFront(content, true);
 
     expect(transformedContent).toEqual([
       {
@@ -66,7 +64,7 @@ describe("hyphenation", () => {
     ]);
   });
 
-  it("does not hyphenate content when maincomment template used", () => {
+  it("does not hyphenate unjustified content", () => {
     const content = [
       {
         name: "paragraph",
@@ -82,10 +80,7 @@ describe("hyphenation", () => {
       },
     ] as ArticleContent[];
 
-    const transformedContent = transformContentForFront(
-      content,
-      TemplateType.Maincomment,
-    );
+    const transformedContent = transformContentForFront(content, false);
 
     expect(transformedContent).toEqual([
       {

--- a/packages/front-page/front-article-summary-content/index.tsx
+++ b/packages/front-page/front-article-summary-content/index.tsx
@@ -15,7 +15,7 @@ interface Props {
   summaryStyle?: any;
   columnCount?: number;
   bylines: BylineInput[];
-  justified: boolean;
+  justified?: boolean;
 }
 
 interface SummaryTextProps {
@@ -35,7 +35,7 @@ const SummaryText: React.FC<SummaryTextProps> = ({
   ) : null;
 };
 const FrontArticleSummaryContent: React.FC<Props> = (props) => {
-  const { summary, summaryStyle, justified, columnCount = 1 } = props;
+  const { summary, summaryStyle, justified = false, columnCount = 1 } = props;
 
   if (!summary) return null;
 

--- a/packages/front-page/front-article-summary-content/index.tsx
+++ b/packages/front-page/front-article-summary-content/index.tsx
@@ -5,7 +5,6 @@ import React from "react";
 import {
   BylineInput,
   Markup,
-  TemplateType,
 } from "@times-components-native/fixture-generator/src/types";
 import { MeasureContainer } from "@times-components-native/front-page/MeasureContainer";
 import { ArticleColumns } from "@times-components-native/article-columns/article-columns";
@@ -16,8 +15,9 @@ interface Props {
   summaryStyle?: any;
   columnCount?: number;
   bylines: BylineInput[];
-  template: TemplateType;
+  justified: boolean;
 }
+
 interface SummaryTextProps {
   ast: Markup;
   style: TextStyle;
@@ -35,13 +35,17 @@ const SummaryText: React.FC<SummaryTextProps> = ({
   ) : null;
 };
 const FrontArticleSummaryContent: React.FC<Props> = (props) => {
-  const { summary, summaryStyle, template, columnCount = 1 } = props;
+  const { summary, summaryStyle, justified, columnCount = 1 } = props;
 
   if (!summary) return null;
 
-  const transformedAst = transformContentForFront(summary, template);
+  const transformedAst = transformContentForFront(summary, justified);
 
-  const style = { ...styles.summary, ...summaryStyle } as TextStyle;
+  const style = {
+    ...styles.summary,
+    ...summaryStyle,
+    ...(justified && { textAlign: "justify" }),
+  } as TextStyle;
   const lineHeight = style.lineHeight || 20;
   const numberOfLinesToRender = (height: number) => height / lineHeight;
   if (columnCount > 1) {

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -28,7 +28,7 @@ interface Props {
   straplineMarginTop: number;
   straplineMarginBottom: number;
   bylineMarginBottom: number;
-  justified: boolean;
+  justified?: boolean;
   summaryLineHeight: number;
 }
 

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -7,10 +7,7 @@ import {
 import { View } from "react-native";
 import styleFactory from "./styles";
 import FrontArticleSummaryContent from "./front-article-summary-content";
-import {
-  Markup,
-  TemplateType,
-} from "@times-components-native/fixture-generator/src/types";
+import { Markup } from "@times-components-native/fixture-generator/src/types";
 import { FrontPageByline } from "./front-page-byline";
 import { MeasureContainer } from "./MeasureContainer";
 import { getFrontTileConfig } from "./utils/get-front-tile-config";
@@ -23,7 +20,6 @@ interface Props {
   containerStyle?: any;
   summary: Markup;
   summaryStyle?: any;
-  template: TemplateType;
   tile: any;
   bylines?: Markup;
   showKeyline?: boolean;
@@ -32,19 +28,20 @@ interface Props {
   straplineMarginTop: number;
   straplineMarginBottom: number;
   bylineMarginBottom: number;
+  justified: boolean;
   summaryLineHeight: number;
 }
 
 const renderContent = (props: Props) => {
-  const { summary, summaryStyle, template } = props;
+  const { summary, summaryStyle, justified, columnCount, bylines } = props;
 
   return (
     <FrontArticleSummaryContent
       summary={summary}
       summaryStyle={summaryStyle}
-      columnCount={props.columnCount}
-      template={template}
-      bylines={props.bylines}
+      columnCount={columnCount}
+      bylines={bylines}
+      justified={justified}
     />
   );
 };

--- a/packages/front-page/utils/transform-content-for-front.ts
+++ b/packages/front-page/utils/transform-content-for-front.ts
@@ -1,9 +1,6 @@
 import { ArticleContent } from "@times-components-native/article-columns/domain-types";
 import { hyphenateArticleContent } from "@times-components-native/utils/src/hyphenate-article-content";
-import {
-  Markup,
-  TemplateType,
-} from "@times-components-native/fixture-generator/src/types";
+import { Markup } from "@times-components-native/fixture-generator/src/types";
 
 const addTab = (content: ArticleContent, index: number): Markup => {
   if (content.name !== "paragraph") return content;
@@ -15,9 +12,10 @@ export const indent = (contents: Markup[]) => contents.map(addTab);
 
 export const transformContentForFront = (
   contents: ArticleContent[],
-  template: TemplateType,
+  justified: boolean,
 ) => {
-  const hyphenatedContent =
-    template === "maincomment" ? contents : hyphenateArticleContent(contents);
+  const hyphenatedContent = justified
+    ? hyphenateArticleContent(contents)
+    : contents;
   return indent(hyphenatedContent);
 };


### PR DESCRIPTION
This PR changes the front logic to only hyphenate justified content. 

Furthermore, previously we were only left aligning text in the support tile when it was a maincomment article. As justified content looks bad in a narrow column, we're now always left-aligning text in the support tile.

Also - I fixed the summary text size on the first lead one and one tile in landscape, as it didn't match the support tile.

![image](https://user-images.githubusercontent.com/6280629/96991456-5ee2f100-1520-11eb-88c6-df21813e9b46.png)
