### PR TITLE
feat: (TNLT-5669) Absolutely position tile g headline

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1875,7 +1875,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -4479,7 +4479,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -4556,7 +4556,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -4575,7 +4575,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -7371,7 +7371,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View
           style={
             Object {
-              "borderColor": "#999999",
+              "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
               "marginVertical": 0,
@@ -7458,7 +7458,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
         <View
           style={
             Object {
-              "borderColor": "#999999",
+              "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
               "marginVertical": 0,
@@ -7477,7 +7477,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
         <View
           style={
             Object {
-              "borderColor": "#999999",
+              "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
               "marginVertical": 0,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -65,6 +65,15 @@ exports[`tile g front landscape 1024 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={5}
     headlineStyle={
       Object {
@@ -656,6 +665,15 @@ exports[`tile g front landscape 1080 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={5}
     headlineStyle={
@@ -1249,6 +1267,15 @@ exports[`tile g front landscape 1194 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={5}
     headlineStyle={
       Object {
@@ -1841,6 +1868,15 @@ exports[`tile g front landscape 1366 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -2431,6 +2467,15 @@ exports[`tile g front portrait 768 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={10}
     headlineStyle={
@@ -3023,6 +3068,15 @@ exports[`tile g front portrait 810 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -3613,6 +3667,15 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={10}
     headlineStyle={
@@ -4205,6 +4268,15 @@ exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {
@@ -4795,6 +4867,15 @@ exports[`tile g front portrait 1024 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={15}
     headlineStyle={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1874,7 +1874,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -4473,7 +4473,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -4549,7 +4549,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -4568,7 +4568,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#999999",
+            "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "marginVertical": 0,
@@ -7361,7 +7361,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View
           style={
             Object {
-              "borderColor": "#999999",
+              "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
               "marginVertical": 0,
@@ -7447,7 +7447,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
         <View
           style={
             Object {
-              "borderColor": "#999999",
+              "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
               "marginVertical": 0,
@@ -7466,7 +7466,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
         <View
           style={
             Object {
-              "borderColor": "#999999",
+              "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
               "marginVertical": 0,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -65,6 +65,15 @@ exports[`tile g front landscape 1024 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={5}
     headlineStyle={
       Object {
@@ -656,6 +665,15 @@ exports[`tile g front landscape 1080 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={5}
     headlineStyle={
@@ -1249,6 +1267,15 @@ exports[`tile g front landscape 1194 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={5}
     headlineStyle={
       Object {
@@ -1841,6 +1868,15 @@ exports[`tile g front landscape 1366 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -2431,6 +2467,15 @@ exports[`tile g front portrait 768 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={10}
     headlineStyle={
@@ -3023,6 +3068,15 @@ exports[`tile g front portrait 810 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -3613,6 +3667,15 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={10}
     headlineStyle={
@@ -4205,6 +4268,15 @@ exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
         },
       ]
     }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {
@@ -4795,6 +4867,15 @@ exports[`tile g front portrait 1024 1`] = `
           "image": null,
         },
       ]
+    }
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
     }
     headlineMarginBottom={15}
     headlineStyle={

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -43,6 +43,7 @@ const TileGFront = ({ onPress, tile, orientation }) => {
         headlineMarginBottom={styles.headlineMarginBottom}
         straplineMarginBottom={0}
         summaryLineHeight={styles.summary.lineHeight}
+        containerStyle={styles.summaryContainer}
       />
     </TileLink>
   );

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -1,9 +1,18 @@
 import {
+  colours,
   fonts,
   spacing,
   globalSpacingStyles,
 } from "@times-components-native/styleguide";
 import { getStyleByDeviceSize } from "@times-components-native/styleguide/src/styleguide";
+
+const sharedSummaryContainer = {
+  position: "absolute",
+  bottom: 0,
+  backgroundColor: colours.functional.white,
+  width: "100%",
+  paddingTop: spacing(2),
+};
 
 const sharedHeadline = {
   ...globalSpacingStyles.tabletHeadline,
@@ -17,6 +26,7 @@ const sharedSummary = {
 };
 
 const sharedStyles = {
+  summaryContainer: { ...sharedSummaryContainer },
   imageContainer: {
     width: "100%",
     marginBottom: spacing(1),

--- a/packages/slice-layout/__tests__/android/__snapshots__/front-l2.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/front-l2.android.test.js.snap
@@ -8,7 +8,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -59,7 +59,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -110,7 +110,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -161,7 +161,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -212,7 +212,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -263,7 +263,7 @@ exports[`6. front lead two - landscape - 1024 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -320,7 +320,7 @@ exports[`7. front lead two - landscape - 1080 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -377,7 +377,7 @@ exports[`8. front lead two - landscape - 1112 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -434,7 +434,7 @@ exports[`9. front lead two - landscape - 1366 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }

--- a/packages/slice-layout/__tests__/ios/__snapshots__/front-l2.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/front-l2.ios.test.js.snap
@@ -8,7 +8,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -59,7 +59,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -110,7 +110,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -161,7 +161,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -212,7 +212,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -263,7 +263,7 @@ exports[`6. front lead two - landscape - 1024 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -320,7 +320,7 @@ exports[`7. front lead two - landscape - 1080 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -377,7 +377,7 @@ exports[`8. front lead two - landscape - 1112 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }
@@ -434,7 +434,7 @@ exports[`9. front lead two - landscape - 1366 1`] = `
   <HorizontalLayout
     colSeparatorStyle={
       Object {
-        "borderColor": "#999999",
+        "borderColor": "#DBDBDB",
         "marginVertical": 0,
       }
     }

--- a/packages/slice-layout/src/templates/frontleadtwo/styles.js
+++ b/packages/slice-layout/src/templates/frontleadtwo/styles.js
@@ -21,7 +21,7 @@ const calculateStyles = (orientation) => {
   const sharedStyles = {
     colSeparatorStyle: {
       marginVertical: 0,
-      borderColor: colours.functional.darkGrey,
+      borderColor: colours.functional.keyline,
     },
     horizontalContainer: {
       flex: 1,


### PR DESCRIPTION
- Fix for https://nidigitalsolutions.jira.com/browse/TNLT-5669
- Make `LeadTwoFront` Slice have same divider colour as other front slices

<img width="1792" alt="Screenshot 2020-10-23 at 11 16 14" src="https://user-images.githubusercontent.com/1736782/96995653-6c02de80-1526-11eb-965f-9ff4b601f471.png">
<img width="791" alt="Screenshot 2020-10-23 at 11 16 19" src="https://user-images.githubusercontent.com/1736782/96995657-6efdcf00-1526-11eb-9c3c-31b6cd8ac867.png">
<img width="1076" alt="Screenshot 2020-10-23 at 11 16 45" src="https://user-images.githubusercontent.com/1736782/96995674-758c4680-1526-11eb-950e-562de906cb09.png">
<img width="1023" alt="Screenshot 2020-10-23 at 11 17 06" src="https://user-images.githubusercontent.com/1736782/96995685-7a50fa80-1526-11eb-9f90-fc7b50fa2bc7.png">
<img width="749" alt="Screenshot 2020-10-23 at 11 19 08" src="https://user-images.githubusercontent.com/1736782/96995695-7de48180-1526-11eb-821e-8d9f3e65a878.png">
<img width="1030" alt="Screenshot 2020-10-23 at 11 19 14" src="https://user-images.githubusercontent.com/1736782/96995701-80df7200-1526-11eb-8afb-237770aaba00.png">
<img width="748" alt="Screenshot 2020-10-23 at 11 28 59" src="https://user-images.githubusercontent.com/1736782/96995705-83da6280-1526-11eb-8e2b-f76dd2730249.png">
<img width="1030" alt="Screenshot 2020-10-23 at 11 29 06" src="https://user-images.githubusercontent.com/1736782/96995713-863cbc80-1526-11eb-9334-dc72be125245.png">
