### PR TITLE
fix(TNLT-5659): headline text changes on fronts

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -83,6 +83,7 @@ exports[`tile g front landscape 1024 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -684,6 +685,7 @@ exports[`tile g front landscape 1080 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1276,7 +1278,7 @@ exports[`tile g front landscape 1194 1`] = `
         "width": "100%",
       }
     }
-    headlineMarginBottom={5}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1285,6 +1287,7 @@ exports[`tile g front landscape 1194 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1886,6 +1889,7 @@ exports[`tile g front landscape 1366 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -2486,6 +2490,7 @@ exports[`tile g front portrait 768 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3086,6 +3091,7 @@ exports[`tile g front portrait 810 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3686,6 +3692,7 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4281,11 +4288,12 @@ exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 30,
-        "lineHeight": 30,
+        "fontSize": 32,
+        "lineHeight": 32,
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4886,6 +4894,7 @@ exports[`tile g front portrait 1024 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -2418,8 +2418,8 @@ exports[`tile h front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 28,
-        "lineHeight": 28,
+        "fontSize": 40,
+        "lineHeight": 40,
       }
     }
     strapline="Three Conservative MPs resign"
@@ -3008,8 +3008,8 @@ exports[`tile h front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 28,
-        "lineHeight": 28,
+        "fontSize": 42,
+        "lineHeight": 42,
       }
     }
     strapline="Three Conservative MPs resign"

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -83,6 +83,7 @@ exports[`tile g front landscape 1024 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -684,6 +685,7 @@ exports[`tile g front landscape 1080 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1276,7 +1278,7 @@ exports[`tile g front landscape 1194 1`] = `
         "width": "100%",
       }
     }
-    headlineMarginBottom={5}
+    headlineMarginBottom={10}
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
@@ -1285,6 +1287,7 @@ exports[`tile g front landscape 1194 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -1886,6 +1889,7 @@ exports[`tile g front landscape 1366 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -2486,6 +2490,7 @@ exports[`tile g front portrait 768 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3086,6 +3091,7 @@ exports[`tile g front portrait 810 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -3686,6 +3692,7 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4281,11 +4288,12 @@ exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 30,
-        "lineHeight": 30,
+        "fontSize": 32,
+        "lineHeight": 32,
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {
@@ -4886,6 +4894,7 @@ exports[`tile g front portrait 1024 1`] = `
       }
     }
     straplineMarginBottom={0}
+    straplineMarginTop={0}
     summary={
       Array [
         Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -2418,8 +2418,8 @@ exports[`tile h front portrait 768 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 28,
-        "lineHeight": 28,
+        "fontSize": 40,
+        "lineHeight": 40,
       }
     }
     strapline="Three Conservative MPs resign"
@@ -3008,8 +3008,8 @@ exports[`tile h front portrait 810 1`] = `
     headlineStyle={
       Object {
         "fontFamily": "TimesModern-Bold",
-        "fontSize": 28,
-        "lineHeight": 28,
+        "fontSize": 42,
+        "lineHeight": 42,
       }
     }
     strapline="Three Conservative MPs resign"

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -41,6 +41,7 @@ const TileGFront = ({ onPress, tile, orientation }) => {
         template={article.template}
         bylineMarginBottom={styles.bylineMarginBottom}
         headlineMarginBottom={styles.headlineMarginBottom}
+        straplineMarginTop={0}
         straplineMarginBottom={0}
         summaryLineHeight={styles.summary.lineHeight}
         containerStyle={styles.summaryContainer}

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -82,6 +82,7 @@ const styles = {
     },
     "1194": {
       ...sharedLandscapeStyles,
+      headlineMarginBottom: spacing(2),
       headline: {
         ...sharedHeadline,
         fontSize: 24,
@@ -125,8 +126,8 @@ const styles = {
           ...sharedPortraitStyles,
           headline: {
             ...sharedHeadline,
-            fontSize: 30,
-            lineHeight: 30,
+            fontSize: 32,
+            lineHeight: 32,
           },
           imageContainer: {
             width: "100%",

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -139,8 +139,8 @@ const styles = {
       ...sharedPortraitStyles,
       headline: {
         ...sharedHeadline,
-        fontSize: 28,
-        lineHeight: 28,
+        fontSize: 40,
+        lineHeight: 40,
       },
       strapline: {
         ...sharedStrapline,
@@ -152,8 +152,8 @@ const styles = {
       ...sharedPortraitStyles,
       headline: {
         ...sharedHeadline,
-        fontSize: 28,
-        lineHeight: 28,
+        fontSize: 42,
+        lineHeight: 42,
       },
       strapline: {
         ...sharedStrapline,


### PR DESCRIPTION
**iPad 11: Lead Two** 

Changed headline in tile 2 from 30px to 32px on portrait

![image](https://user-images.githubusercontent.com/6280629/97006877-6615f900-1538-11eb-949d-d6d22aed6015.png)

Changed padding in tile 2 from 5px to 10px on landscape

![image](https://user-images.githubusercontent.com/6280629/97006838-5991a080-1538-11eb-8b3d-83e8827b0306.png)

**iPad mini (and iPad air): Lead Two**

Changed headline in tile 1

![image](https://user-images.githubusercontent.com/6280629/97006977-9362a700-1538-11eb-81ac-4223c3a37a58.png)

