### PR TITLE
chore: release v1.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- Fix for too much teaser text showing on Tile G Front
- Only show ITE CTA in landscape