### PR TITLE
fix: Aligns tile summary content to top of tile

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -16,7 +16,7 @@ exports[`tile g front landscape 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -69,7 +69,7 @@ exports[`tile g front landscape 1024 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -618,7 +618,7 @@ exports[`tile g front landscape 1080 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -671,7 +671,7 @@ exports[`tile g front landscape 1080 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -1220,7 +1220,7 @@ exports[`tile g front landscape 1194 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1273,7 +1273,7 @@ exports[`tile g front landscape 1194 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -1822,7 +1822,7 @@ exports[`tile g front landscape 1366 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1875,7 +1875,7 @@ exports[`tile g front landscape 1366 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -2423,7 +2423,7 @@ exports[`tile g front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -2476,7 +2476,7 @@ exports[`tile g front portrait 768 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -3024,7 +3024,7 @@ exports[`tile g front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -3077,7 +3077,7 @@ exports[`tile g front portrait 810 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -3625,7 +3625,7 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -3678,7 +3678,7 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -4226,7 +4226,7 @@ exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -4827,7 +4827,7 @@ exports[`tile g front portrait 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -16,7 +16,7 @@ exports[`tile g front landscape 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -69,7 +69,7 @@ exports[`tile g front landscape 1024 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -618,7 +618,7 @@ exports[`tile g front landscape 1080 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -671,7 +671,7 @@ exports[`tile g front landscape 1080 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -1220,7 +1220,7 @@ exports[`tile g front landscape 1194 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1273,7 +1273,7 @@ exports[`tile g front landscape 1194 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -1822,7 +1822,7 @@ exports[`tile g front landscape 1366 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1875,7 +1875,7 @@ exports[`tile g front landscape 1366 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -2423,7 +2423,7 @@ exports[`tile g front portrait 768 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -2476,7 +2476,7 @@ exports[`tile g front portrait 768 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -3024,7 +3024,7 @@ exports[`tile g front portrait 810 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -3077,7 +3077,7 @@ exports[`tile g front portrait 810 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -3625,7 +3625,7 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -3678,7 +3678,7 @@ exports[`tile g front portrait 834 0.75 ratio 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "bottom": 0,
-        "paddingTop": 10,
+        "paddingTop": 5,
         "position": "absolute",
         "width": "100%",
       }
@@ -4226,7 +4226,7 @@ exports[`tile g front portrait 834 less than 0.75 ratio 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -4827,7 +4827,7 @@ exports[`tile g front portrait 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -11,7 +11,6 @@ const sharedSummaryContainer = {
   bottom: 0,
   backgroundColor: colours.functional.white,
   width: "100%",
-  paddingTop: spacing(2),
 };
 
 const sharedHeadline = {
@@ -26,10 +25,10 @@ const sharedSummary = {
 };
 
 const sharedStyles = {
-  summaryContainer: { ...sharedSummaryContainer },
+  summaryContainer: { ...sharedSummaryContainer, paddingTop: spacing(1) },
   imageContainer: {
     width: "100%",
-    marginBottom: spacing(1),
+    marginBottom: 0,
   },
   summary: { ...sharedSummary },
   bylineMarginBottom: spacing(3),
@@ -129,9 +128,9 @@ const styles = {
             fontSize: 32,
             lineHeight: 32,
           },
-          imageContainer: {
-            width: "100%",
-            marginBottom: spacing(2),
+          summaryContainer: {
+            ...sharedSummaryContainer,
+            paddingTop: spacing(2),
           },
           headlineMarginBottom: spacing(3),
         },
@@ -147,9 +146,9 @@ const styles = {
     },
     "1024": {
       ...sharedPortraitStyles,
-      imageContainer: {
-        width: "100%",
-        marginBottom: spacing(2),
+      summaryContainer: {
+        ...sharedSummaryContainer,
+        paddingTop: spacing(2),
       },
       headline: {
         ...sharedHeadline,

--- a/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
@@ -11,6 +11,7 @@ exports[`FrontTileSummary performs measurements before rendering front tile summ
         "flex": 1,
       },
       Object {
+        "minHeight": undefined,
         "opacity": 0,
       },
     ]
@@ -92,6 +93,7 @@ exports[`FrontTileSummary renders byline with keyline 1`] = `
         "flex": 1,
       },
       Object {
+        "minHeight": 200,
         "opacity": 1,
       },
     ]
@@ -219,6 +221,7 @@ exports[`FrontTileSummary renders with 2 columns 1`] = `
         "flex": 1,
       },
       Object {
+        "minHeight": 200,
         "opacity": 1,
       },
     ]
@@ -324,6 +327,7 @@ exports[`FrontTileSummary renders with a missing byline 1`] = `
         "flex": 1,
       },
       Object {
+        "minHeight": 200,
         "opacity": 1,
       },
     ]
@@ -410,6 +414,7 @@ exports[`FrontTileSummary renders with a missing strapline 1`] = `
         "flex": 1,
       },
       Object {
+        "minHeight": 200,
         "opacity": 1,
       },
     ]
@@ -515,6 +520,7 @@ exports[`FrontTileSummary shows front tile summary with headline only after meas
         "flex": 1,
       },
       Object {
+        "minHeight": 200,
         "opacity": 1,
       },
     ]
@@ -555,6 +561,7 @@ exports[`FrontTileSummary shows front tile summary with headline/strapline/bylin
         "flex": 1,
       },
       Object {
+        "minHeight": 200,
         "opacity": 1,
       },
     ]

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -109,15 +109,15 @@ const FrontTileSummary: React.FC<Props> = (props) => {
     straplineHeight !== undefined &&
     bylineHeight !== undefined;
 
-  const TileSummaryContainer: React.FC<{ hidden: boolean }> = ({
-    children,
-    hidden,
-  }) => (
+  const TileSummaryContainer: React.FC<{
+    hidden: boolean;
+    minHeight?: number;
+  }> = ({ children, hidden, minHeight }) => (
     <View
       style={[
         props.containerStyle,
         styles.container,
-        { opacity: hidden ? 0 : 1 },
+        { minHeight, opacity: hidden ? 0 : 1 },
       ]}
     >
       {children}
@@ -184,7 +184,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
             });
 
             return (
-              <TileSummaryContainer hidden={false}>
+              <TileSummaryContainer hidden={false} minHeight={height}>
                 <View
                   style={{
                     marginBottom: frontTileConfig.headline.marginBottom,


### PR DESCRIPTION
For the larger iPads, we were aligning text to the bottom of the tile due to the absolute positioning that we introduced.

![image](https://user-images.githubusercontent.com/6280629/97170875-5854b380-1784-11eb-888d-62dbaac8d095.png)

To fix this, we're assigning the minHeight of this container to be the height that is available. Also, I've set the marginBottom of the lead image to 0, and instead am setting paddingTop on the summary container to ensure there's always the right padding between image and headline.

![image](https://user-images.githubusercontent.com/6280629/97171004-9a7df500-1784-11eb-9f07-3bdeb03f2325.png)
![image](https://user-images.githubusercontent.com/6280629/97171020-a23d9980-1784-11eb-8cd5-ba398a5f9574.png)

![image](https://user-images.githubusercontent.com/6280629/97171014-9eaa1280-1784-11eb-9c35-c0558844291a.png)
