### PR TITLE
fix: fixes 3-deck headline on lead1and1

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -16,7 +16,7 @@ exports[`tile a front landscape 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -66,6 +66,15 @@ exports[`tile a front landscape 1024 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -619,7 +628,7 @@ exports[`tile a front landscape 1080 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -669,6 +678,15 @@ exports[`tile a front landscape 1080 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {
@@ -1222,7 +1240,7 @@ exports[`tile a front landscape 1194 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1272,6 +1290,15 @@ exports[`tile a front landscape 1194 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {
@@ -1825,7 +1852,7 @@ exports[`tile a front landscape 1366 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1875,6 +1902,15 @@ exports[`tile a front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -16,7 +16,7 @@ exports[`tile a front landscape 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -66,6 +66,15 @@ exports[`tile a front landscape 1024 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -619,7 +628,7 @@ exports[`tile a front landscape 1080 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -669,6 +678,15 @@ exports[`tile a front landscape 1080 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {
@@ -1222,7 +1240,7 @@ exports[`tile a front landscape 1194 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1272,6 +1290,15 @@ exports[`tile a front landscape 1194 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {
@@ -1825,7 +1852,7 @@ exports[`tile a front landscape 1366 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 10,
+        "marginBottom": 0,
         "width": "100%",
       }
     }
@@ -1875,6 +1902,15 @@ exports[`tile a front landscape 1366 1`] = `
       ]
     }
     columnCount={1}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={15}
     headlineStyle={
       Object {

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -41,6 +41,7 @@ const TileAFront = ({ onPress, tile, orientation }) => {
         hasVideo={article.hasVideo}
       />
       <FrontTileSummary
+        containerStyle={styles.summaryContainer}
         headlineStyle={styles.headline}
         summary={article.content}
         summaryStyle={styles.summary}

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -28,10 +28,6 @@ const sharedStyles = {
     paddingRight: spacing(2),
     flex: 1,
   },
-  imageContainer: {
-    width: "100%",
-    marginBottom: spacing(2),
-  },
   summary: {
     ...summary,
     fontSize: 14,
@@ -42,10 +38,21 @@ const sharedStyles = {
 
 const sharedLandscapeStyles = {
   ...sharedStyles,
+  summaryContainer: {
+    position: "absolute",
+    bottom: 0,
+    backgroundColor: colours.functional.white,
+    width: "100%",
+    paddingTop: spacing(2),
+  },
   headlineMarginBottom: spacing(2),
   straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
   bylineMarginBottom: spacing(3),
+  imageContainer: {
+    width: "100%",
+    marginBottom: 0,
+  },
   summary: {
     ...summary,
     fontSize: 14,
@@ -59,6 +66,10 @@ const sharedPortraitStyles = {
   straplineMarginTop: spacing(2),
   straplineMarginBottom: spacing(3),
   bylineMarginBottom: 0,
+  imageContainer: {
+    width: "100%",
+    marginBottom: spacing(2),
+  },
 };
 
 const portrait834 = {


### PR DESCRIPTION
![Simulator Screen Shot - iPad mini 4 - 2020-10-26 at 14 35 28](https://user-images.githubusercontent.com/6280629/97186036-b4293780-1798-11eb-82ce-b1ab94d2a0b8.png)
![Simulator Screen Shot - iPad mini 4 - 2020-10-26 at 14 35 39](https://user-images.githubusercontent.com/6280629/97186049-b8edeb80-1798-11eb-8457-1b65e0c287f7.png)
![Simulator Screen Shot - iPad mini 4 - 2020-10-26 at 14 35 45](https://user-images.githubusercontent.com/6280629/97186053-ba1f1880-1798-11eb-8a23-82dac330fd12.png)
![image](https://user-images.githubusercontent.com/6280629/97186149-d9b64100-1798-11eb-8fb6-63b95c728523.png)
