### PR TITLE
fix(TNLT-5659): corrects alignment on frontlead1and1/frontlead2

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -4724,8 +4724,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
             "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginTop": 0,
-            "marginVertical": 10,
+            "marginVertical": 0,
           }
         }
       />
@@ -4744,8 +4743,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
             "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginTop": 0,
-            "marginVertical": 10,
+            "marginVertical": 0,
           }
         }
       />
@@ -7646,8 +7644,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
               "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "marginTop": 0,
-              "marginVertical": 10,
+              "marginVertical": 0,
             }
           }
         />
@@ -7666,8 +7663,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
               "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "marginTop": 0,
-              "marginVertical": 10,
+              "marginVertical": 0,
             }
           }
         />

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -5,7 +5,7 @@ exports[`tile a front landscape 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -617,7 +617,7 @@ exports[`tile a front landscape 1080 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -1229,7 +1229,7 @@ exports[`tile a front landscape 1194 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -1841,7 +1841,7 @@ exports[`tile a front landscape 1366 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -2453,7 +2453,7 @@ exports[`tile a front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -3056,7 +3056,7 @@ exports[`tile a front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -3659,7 +3659,7 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -4262,7 +4262,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -4865,7 +4865,7 @@ exports[`tile a front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -6,7 +6,7 @@ exports[`tile b front landscape 1024 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -599,7 +599,7 @@ exports[`tile b front landscape 1080 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -1192,7 +1192,7 @@ exports[`tile b front landscape 1194 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -1785,7 +1785,7 @@ exports[`tile b front landscape 1366 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -2377,7 +2377,6 @@ exports[`tile b front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -2970,7 +2969,6 @@ exports[`tile b front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -3563,7 +3561,6 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4156,7 +4153,6 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4749,7 +4745,6 @@ exports[`tile b front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -4727,7 +4727,7 @@ exports[`tile h front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 5,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -4717,8 +4717,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
             "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginTop": 0,
-            "marginVertical": 10,
+            "marginVertical": 0,
           }
         }
       />
@@ -4737,8 +4736,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
             "borderColor": "#DBDBDB",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "marginTop": 0,
-            "marginVertical": 10,
+            "marginVertical": 0,
           }
         }
       />
@@ -7635,8 +7633,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
               "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "marginTop": 0,
-              "marginVertical": 10,
+              "marginVertical": 0,
             }
           }
         />
@@ -7655,8 +7652,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
               "borderColor": "#DBDBDB",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "marginTop": 0,
-              "marginVertical": 10,
+              "marginVertical": 0,
             }
           }
         />

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -5,7 +5,7 @@ exports[`tile a front landscape 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -617,7 +617,7 @@ exports[`tile a front landscape 1080 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -1229,7 +1229,7 @@ exports[`tile a front landscape 1194 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -1841,7 +1841,7 @@ exports[`tile a front landscape 1366 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -2453,7 +2453,7 @@ exports[`tile a front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -3056,7 +3056,7 @@ exports[`tile a front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -3659,7 +3659,7 @@ exports[`tile a front portrait 834 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -4262,7 +4262,7 @@ exports[`tile a front portrait 834 less than 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }
@@ -4865,7 +4865,7 @@ exports[`tile a front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -6,7 +6,7 @@ exports[`tile b front landscape 1024 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -599,7 +599,7 @@ exports[`tile b front landscape 1080 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -1192,7 +1192,7 @@ exports[`tile b front landscape 1194 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -1785,7 +1785,7 @@ exports[`tile b front landscape 1366 1`] = `
     Object {
       "flex": 1,
       "padding": 10,
-      "paddingTop": 0,
+      "paddingVertical": 0,
     }
   }
   url="/article/123"
@@ -2377,7 +2377,6 @@ exports[`tile b front portrait 768 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -2970,7 +2969,6 @@ exports[`tile b front portrait 810 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -3563,7 +3561,6 @@ exports[`tile b front portrait 834 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4156,7 +4153,6 @@ exports[`tile b front portrait 834 less than 0.75 ratio 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }
@@ -4749,7 +4745,6 @@ exports[`tile b front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 10,
       "paddingLeft": 10,
     }
   }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -4727,7 +4727,7 @@ exports[`tile h front portrait 1024 1`] = `
   linkStyle={
     Object {
       "flex": 1,
-      "paddingBottom": 5,
+      "paddingBottom": 0,
       "paddingRight": 10,
     }
   }

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -24,7 +24,7 @@ const strapline = {
 
 const sharedStyles = {
   container: {
-    paddingBottom: spacing(2),
+    paddingBottom: spacing(0),
     paddingRight: spacing(2),
     flex: 1,
   },

--- a/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
@@ -23,7 +23,7 @@ const sharedLandscapeStyles = {
   container: {
     flex: 1,
     padding: spacing(2),
-    paddingTop: 0,
+    paddingVertical: 0,
   },
   imageContainer: {
     width: "100%",

--- a/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/styles/index.js
@@ -37,7 +37,6 @@ const sharedPortraitStyles = {
   container: {
     flex: 1,
     paddingLeft: spacing(2),
-    paddingBottom: spacing(2),
   },
   imageContainer: {
     width: "100%",

--- a/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-h-front/styles/index.js
@@ -183,10 +183,6 @@ const styles = {
     },
     "1024": {
       ...sharedPortraitStyles,
-      container: {
-        ...sharedPortraitStyles.container,
-        paddingBottom: spacing(1),
-      },
       headline: {
         ...sharedHeadline,
         fontSize: 53,

--- a/packages/slice-layout/__tests__/android/__snapshots__/front-l1and1.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/front-l1and1.android.test.js.snap
@@ -213,7 +213,7 @@ exports[`5. front lead one - landscape - 1024 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -270,7 +270,7 @@ exports[`6. front lead one - landscape - 1080 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -327,7 +327,7 @@ exports[`7. front lead one - landscape - 1112 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -384,7 +384,7 @@ exports[`8. front lead one - landscape - 1194 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -441,7 +441,7 @@ exports[`9. front lead one - landscape - 1366 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={

--- a/packages/slice-layout/__tests__/ios/__snapshots__/front-l1and1.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/front-l1and1.ios.test.js.snap
@@ -213,7 +213,7 @@ exports[`5. front lead one - landscape - 1024 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -270,7 +270,7 @@ exports[`6. front lead one - landscape - 1080 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -327,7 +327,7 @@ exports[`7. front lead one - landscape - 1112 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -384,7 +384,7 @@ exports[`8. front lead one - landscape - 1194 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={
@@ -441,7 +441,7 @@ exports[`9. front lead one - landscape - 1366 1`] = `
     colSeparatorStyle={
       Object {
         "borderColor": "#DBDBDB",
-        "marginTop": 0,
+        "marginVertical": 0,
       }
     }
     containerStyle={

--- a/packages/slice-layout/src/templates/frontleadoneandone/styles.js
+++ b/packages/slice-layout/src/templates/frontleadoneandone/styles.js
@@ -43,7 +43,7 @@ const calculateStyles = (orientation) => {
     },
     colSeparatorStyle: {
       borderColor: colours.functional.keyline,
-      marginTop: 0,
+      marginVertical: 0,
     },
     container: {
       marginTop: spacing(3),


### PR DESCRIPTION
**Lead one and one - landscape - before:**

![image](https://user-images.githubusercontent.com/6280629/97193619-1b4aea00-17a1-11eb-9e2c-be3cb4f302d0.png)


**Lead one and one after - landscape - after:**

![image](https://user-images.githubusercontent.com/6280629/97192969-61ec1480-17a0-11eb-8824-b1dfc62cbb62.png)

___

**Lead one and one - portrait - before:**

![image](https://user-images.githubusercontent.com/6280629/97193424-e63e9780-17a0-11eb-83a2-33c8a8e76c41.png)

**Lead one and one after - portrait - after:**

![image](https://user-images.githubusercontent.com/6280629/97192949-5bf63380-17a0-11eb-9e7f-76c147b7b673.png)

Also removed paddingBottom from lead 2 lead tile (tile h front) - as it's not necessary