### PR TITLE
fix: Three deck headline and col count

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -16,7 +16,6 @@ exports[`tile f front landscape 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -65,7 +64,16 @@ exports[`tile f front landscape 1024 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -619,7 +627,6 @@ exports[`tile f front landscape 1080 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -668,7 +675,16 @@ exports[`tile f front landscape 1080 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -1222,7 +1238,6 @@ exports[`tile f front landscape 1194 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -1271,7 +1286,16 @@ exports[`tile f front landscape 1194 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={5}
     headlineStyle={
       Object {
@@ -1874,7 +1898,16 @@ exports[`tile f front landscape 1366 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -16,7 +16,6 @@ exports[`tile f front landscape 1024 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -65,7 +64,16 @@ exports[`tile f front landscape 1024 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -619,7 +627,6 @@ exports[`tile f front landscape 1080 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -668,7 +675,16 @@ exports[`tile f front landscape 1080 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {
@@ -1222,7 +1238,6 @@ exports[`tile f front landscape 1194 1`] = `
     fill={true}
     style={
       Object {
-        "marginBottom": 5,
         "width": "100%",
       }
     }
@@ -1271,7 +1286,16 @@ exports[`tile f front landscape 1194 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={5}
     headlineStyle={
       Object {
@@ -1874,7 +1898,16 @@ exports[`tile f front landscape 1366 1`] = `
         },
       ]
     }
-    columnCount={1}
+    columnCount={3}
+    containerStyle={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "bottom": 0,
+        "paddingTop": 10,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
     headlineMarginBottom={10}
     headlineStyle={
       Object {

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -14,8 +14,6 @@ import { getDimensions } from "@times-components-native/utils";
 
 const TileFFront = ({ onPress, tile, orientation }) => {
   const { width: windowWidth, height: windowHeight } = getDimensions();
-  const isLandscape = orientation === "landscape";
-  const columnCount = isLandscape ? 1 : 3;
   const imageCrop = getTileImage(tile, "crop169");
   const styles = getStyle(orientation, windowWidth, windowHeight);
 
@@ -37,6 +35,7 @@ const TileFFront = ({ onPress, tile, orientation }) => {
         hasVideo={article.hasVideo}
       />
       <FrontTileSummary
+        containerStyle={styles.summaryContainer}
         headlineStyle={styles.headline}
         headlineMarginBottom={styles.headlineMarginBottom}
         summary={article.content}
@@ -48,7 +47,7 @@ const TileFFront = ({ onPress, tile, orientation }) => {
         justified={true}
         straplineMarginBottom={styles.straplineMarginBottom}
         tile={tile}
-        columnCount={columnCount}
+        columnCount={3}
         bylines={article.bylines}
         bylineMarginBottom={styles.bylineMarginBottom}
       />

--- a/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/styles/index.js
@@ -26,9 +26,15 @@ const sharedLandscapeStyles = {
     paddingRight: spacing(2),
     flex: 1,
   },
+  summaryContainer: {
+    position: "absolute",
+    bottom: 0,
+    backgroundColor: colours.functional.white,
+    width: "100%",
+    paddingTop: spacing(2),
+  },
   imageContainer: {
     width: "100%",
-    marginBottom: spacing(1),
   },
   summary: {
     ...summary,


### PR DESCRIPTION
- set col count to 3 on both orientations
- absolutely position headline


### Before
<img width="1028" alt="Screenshot 2020-10-26 at 17 15 39" src="https://user-images.githubusercontent.com/1736782/97205938-03c72d80-17b0-11eb-8f1b-0ccf9502f9c3.png">

### After
<img width="1038" alt="Screenshot 2020-10-26 at 17 21 06" src="https://user-images.githubusercontent.com/1736782/97205944-06c21e00-17b0-11eb-9d0e-add24fc56985.png">

### Showing body content with short headline and no standfirst (edge case)
<img width="1263" alt="Screenshot 2020-10-26 at 17 06 08" src="https://user-images.githubusercontent.com/1736782/97296237-4c322a00-1848-11eb-8c65-747e96672f54.png">


