### PR TITLE
fix(TNLT-5722): removes extra chars on columns

### DIFF
--- a/packages/article-columns/__tests__/utils/chunkContentIntoColumns.test.tsx
+++ b/packages/article-columns/__tests__/utils/chunkContentIntoColumns.test.tsx
@@ -554,4 +554,73 @@ describe("chunkContentIntoColumns", () => {
       },
     ]);
   });
+
+  it("will not add another paragraph to first column when not enough room for one more line", () => {
+    const maxLinesInColumn = 20;
+    const linesInContent = 19;
+    const paragraph1 = createParagraphWithText(
+      createTextWithNumberOfLines(linesInContent),
+      {
+        id: "p1",
+      },
+    );
+    const paragraph2 = createParagraphWithText(
+      createTextWithNumberOfLines(linesInContent),
+      {
+        id: "p2",
+      },
+    );
+
+    const articleMeasurements: Measurements = {
+      bylineHeight: 19,
+      bylineMargin: 0,
+      contents: {
+        lines: {
+          p1: createLinesWithNumberOfLines(linesInContent),
+          p2: createLinesWithNumberOfLines(linesInContent),
+        },
+        heights: {
+          p1: linesInContent * columnLineHeight,
+          p2: linesInContent * columnLineHeight,
+        },
+      },
+    };
+
+    const columns = chunkContentIntoColumns(
+      [paragraph1, paragraph2],
+      articleMeasurements,
+      {
+        ...columnParameters,
+        columnHeight: maxLinesInColumn * columnLineHeight,
+      },
+    );
+
+    expect(columns).toHaveLength(2);
+    expect(columns[0]).toMatchObject([
+      {
+        children: [
+          {
+            attributes: {
+              value: createTextWithNumberOfLines(19),
+            },
+            children: [],
+            name: "text",
+          },
+        ],
+      },
+    ]);
+    expect(columns[1]).toMatchObject([
+      {
+        children: [
+          {
+            attributes: {
+              value: createTextWithNumberOfLines(19),
+            },
+            children: [],
+            name: "text",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/article-columns/utils/chunkContentIntoColumns.ts
+++ b/packages/article-columns/utils/chunkContentIntoColumns.ts
@@ -45,7 +45,6 @@ export const chunkContentIntoColumns = (
     columnHeight - (currentColumnHeight + heightTakenOnPage);
 
   if (heightRemainingInColumn < columnParameters.columnLineHeight) {
-    // if (heightRemainingInColumn == 0) {
     // no capacity in current column, start adding into next column
     const updatedColumns = [...columns, []];
     return chunkContentIntoColumns(

--- a/packages/article-columns/utils/chunkContentIntoColumns.ts
+++ b/packages/article-columns/utils/chunkContentIntoColumns.ts
@@ -44,7 +44,8 @@ export const chunkContentIntoColumns = (
   const heightRemainingInColumn =
     columnHeight - (currentColumnHeight + heightTakenOnPage);
 
-  if (heightRemainingInColumn === 0) {
+  if (heightRemainingInColumn < columnParameters.columnLineHeight) {
+    // if (heightRemainingInColumn == 0) {
     // no capacity in current column, start adding into next column
     const updatedColumns = [...columns, []];
     return chunkContentIntoColumns(


### PR DESCRIPTION
**Problem**
![image](https://user-images.githubusercontent.com/6280629/97440536-7c003100-191f-11eb-9b8a-06f580ff156e.png)

We have sometimes seen extra characters appear underneath the article columns. This occurs when the first paragraph takes up the entire first column. When this happens, we were actually rendering an empty paragraph at the end of column 1, and also wasn't starting column 2 with a tab. 

Before splitting a paragraph across two columns, we were first checking if there is **any** room in column 1 for any more content. If there was no room - then we just added the whole paragraph to column 2. However, sometimes there is some room in column 1 (i.e. around 8px due to presence of byline), but not enough for a full line - which was causing the empty paragraph to be rendered in column 1 instead.

**Solution**
![image](https://user-images.githubusercontent.com/6280629/97440491-6e4aab80-191f-11eb-8635-608291f78ef3.png)

Before we attempt to split a paragraph across two columns, we now check if there is room for a full line of text in column 1. If there isn't, we add the entire paragraph to column 2.

