### PR TITLE
fix: fixes columns on lead1 landscape

### DIFF
--- a/packages/front-page/__tests__/__snapshots__/front-article-summary-content.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-article-summary-content.test.js.snap
@@ -58,3 +58,82 @@ exports[`FrontArticleSummaryContent renders correctly with justified text 1`] = 
   </Text>
 </Text>
 `;
+
+exports[`FrontArticleSummaryContent renders correctly with multiple columns 1`] = `
+<ArticleColumns
+  articleContents={
+    Array [
+      Object {
+        "attributes": Object {
+          "tab": false,
+        },
+        "children": Array [
+          Object {
+            "attributes": Object {
+              "value": "Test",
+            },
+            "children": Array [],
+            "name": "text",
+          },
+        ],
+        "name": "paragraph",
+      },
+    ]
+  }
+  bylines={
+    Array [
+      Object {
+        "byline": Array [
+          Object {
+            "attributes": Object {
+              "slug": "richard-lloyd-parry",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Richard Lloyd Parry",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
+          },
+        ],
+        "image": null,
+      },
+      Object {
+        "byline": Array [
+          Object {
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Hanoi",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "inline",
+          },
+        ],
+        "image": null,
+      },
+    ]
+  }
+  columnCount={3}
+  containerHeight={300}
+  containerWidth={100}
+  lineHeight={20}
+  style={
+    Object {
+      "color": "#333333",
+      "flexWrap": "wrap",
+      "fontFamily": "TimesDigitalW04",
+      "fontSize": 14,
+      "lineHeight": 20,
+      "marginBottom": 0,
+    }
+  }
+/>
+`;

--- a/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
+++ b/packages/front-page/__tests__/__snapshots__/front-tile-summary.test.js.snap
@@ -183,6 +183,8 @@ exports[`FrontTileSummary renders byline with keyline 1`] = `
         },
       ]
     }
+    contentHeight={80}
+    contentWidth={200}
     numberOfLines={4}
     summary={
       Array [
@@ -289,6 +291,8 @@ exports[`FrontTileSummary renders with 2 columns 1`] = `
       ]
     }
     columnCount={2}
+    contentHeight={80}
+    contentWidth={200}
     numberOfLines={4}
     summary={
       Array [
@@ -376,6 +380,8 @@ exports[`FrontTileSummary renders with a missing byline 1`] = `
     />
   </View>
   <FrontArticleSummaryContent
+    contentHeight={120}
+    contentWidth={200}
     numberOfLines={6}
     summary={
       Array [
@@ -482,6 +488,8 @@ exports[`FrontTileSummary renders with a missing strapline 1`] = `
         },
       ]
     }
+    contentHeight={120}
+    contentWidth={200}
     numberOfLines={6}
     summary={
       Array [
@@ -650,6 +658,8 @@ exports[`FrontTileSummary shows front tile summary with headline/strapline/bylin
         },
       ]
     }
+    contentHeight={80}
+    contentWidth={200}
     numberOfLines={4}
     summary={
       Array [

--- a/packages/front-page/__tests__/front-article-summary-content.test.js
+++ b/packages/front-page/__tests__/front-article-summary-content.test.js
@@ -7,13 +7,9 @@ jest.mock("@times-components-native/article-summary", () => ({
   ArticleSummaryContent: "ArticleSummaryContent",
 }));
 
-jest.mock("@times-components-native/front-page/MeasureContainer", () => {
-  const MockMeasureContainer = ({ render }) => {
-    return render({ height: 180, width: 200 });
-  };
-  return { MeasureContainer: MockMeasureContainer };
-});
-
+jest.mock("@times-components-native/article-columns/article-columns", () => ({
+  ArticleColumns: "ArticleColumns",
+}));
 const ast = [
   {
     attributes: {},
@@ -39,10 +35,19 @@ const props = {
   numberOfLines: 9,
   style: { backgoundColor: "red" },
   summary: ast,
+  contentWidth: 100,
+  contentHeight: 300,
 };
 describe("FrontArticleSummaryContent", () => {
   it("renders correctly", () => {
     const tree = TestRenderer.create(<FrontArticleSummaryContent {...props} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders correctly with multiple columns", () => {
+    const tree = TestRenderer.create(
+      <FrontArticleSummaryContent {...props} columnCount={3} />,
+    );
     expect(tree).toMatchSnapshot();
   });
 

--- a/packages/front-page/front-article-summary-content/index.tsx
+++ b/packages/front-page/front-article-summary-content/index.tsx
@@ -6,7 +6,6 @@ import {
   BylineInput,
   Markup,
 } from "@times-components-native/fixture-generator/src/types";
-import { MeasureContainer } from "@times-components-native/front-page/MeasureContainer";
 import { ArticleColumns } from "@times-components-native/article-columns/article-columns";
 import { Text, TextStyle } from "react-native";
 import { transformContentForFront } from "@times-components-native/front-page/utils/transform-content-for-front";
@@ -17,6 +16,8 @@ interface Props {
   bylines: BylineInput[];
   numberOfLines: number;
   justified?: boolean;
+  contentWidth: number;
+  contentHeight: number;
 }
 
 interface SummaryTextProps {
@@ -37,6 +38,8 @@ const SummaryText: React.FC<SummaryTextProps> = ({
 };
 const FrontArticleSummaryContent: React.FC<Props> = (props) => {
   const {
+    contentHeight,
+    contentWidth,
     summary,
     summaryStyle,
     numberOfLines,
@@ -56,18 +59,14 @@ const FrontArticleSummaryContent: React.FC<Props> = (props) => {
   const lineHeight = style.lineHeight || 20;
   if (columnCount > 1) {
     return (
-      <MeasureContainer
-        render={({ width, height }) => (
-          <ArticleColumns
-            bylines={props.bylines}
-            style={style}
-            articleContents={transformedAst}
-            columnCount={columnCount}
-            containerHeight={height}
-            containerWidth={width}
-            lineHeight={lineHeight}
-          />
-        )}
+      <ArticleColumns
+        bylines={props.bylines}
+        style={style}
+        articleContents={transformedAst}
+        columnCount={columnCount}
+        containerHeight={contentHeight}
+        containerWidth={contentWidth}
+        lineHeight={lineHeight}
       />
     );
   }

--- a/packages/front-page/front-page.showcase.js
+++ b/packages/front-page/front-page.showcase.js
@@ -37,6 +37,9 @@ export default {
                 textAlign: "justify",
               }}
               columnCount={1}
+              contentHeight={200}
+              contentWidth={200}
+              numberOfLines={5}
             />
           </StoryContainer>
         </Responsive>
@@ -58,6 +61,9 @@ export default {
                 textAlign: "justify",
               }}
               columnCount={2}
+              contentHeight={500}
+              contentWidth={200}
+              numberOfLines={5}
             />
           </StoryContainer>
         </Responsive>

--- a/packages/front-page/front-tile-summary.tsx
+++ b/packages/front-page/front-tile-summary.tsx
@@ -33,7 +33,14 @@ interface Props {
   summaryLineHeight: number;
 }
 
-const renderContent = (props: Props, numberOfLines: number) => {
+const renderContent = (
+  props: Props,
+  {
+    numberOfLines,
+    contentWidth,
+    contentHeight,
+  }: { numberOfLines: number; contentWidth: number; contentHeight: number },
+) => {
   const { summary, summaryStyle, justified, columnCount, bylines } = props;
 
   return (
@@ -43,6 +50,8 @@ const renderContent = (props: Props, numberOfLines: number) => {
       numberOfLines={numberOfLines}
       columnCount={columnCount}
       bylines={bylines}
+      contentHeight={contentHeight}
+      contentWidth={contentWidth}
       justified={justified}
     />
   );
@@ -160,7 +169,7 @@ const FrontTileSummary: React.FC<Props> = (props) => {
       {allMeasured && (
         <MeasureContainer
           key={"measured"}
-          render={({ height }) => {
+          render={({ width, height }) => {
             const frontTileConfig = getFrontTileConfig({
               container: {
                 height,
@@ -211,7 +220,12 @@ const FrontTileSummary: React.FC<Props> = (props) => {
                   </View>
                 )}
                 {frontTileConfig.content.show &&
-                  renderContent(props, frontTileConfig.content.numberOfLines)}
+                  renderContent(props, {
+                    numberOfLines: frontTileConfig.content.numberOfLines,
+                    contentHeight:
+                      frontTileConfig.content.numberOfLines * summaryLineHeight,
+                    contentWidth: width,
+                  })}
               </TileSummaryContainer>
             );
           }}


### PR DESCRIPTION
**Problem**
![image](https://user-images.githubusercontent.com/6280629/97453391-96410b80-192d-11eb-9544-3d60c90081a9.png)


When rendering a front tile, we were previously measuring how much space is available twice. Firstly, we measured if we can fit headline+strapline+byline+content. Secondly, we measured how much room is available for columns - so we can chunk the content as required.

As we are now absolutely positioning the tile summary to allow it to grow, we're seeing issues with the second measuring phase being done in an absolutely positioned view. The measured heights are coming back all wrong - which is why we're seeing this large column being rendered.

**Solution**
We don't really need the second measuring step. We can use the info captured from the first step, and infer how much space is available for teaser text. This fixes the issue on lead1 landscape.