### PR TITLE
fix: singleMPU with a single long split paragraph

### DIFF
--- a/packages/ad/__tests__/inline-ad/measure/__snapshots__/MeasureInlineComponents.test.tsx.snap
+++ b/packages/ad/__tests__/inline-ad/measure/__snapshots__/MeasureInlineComponents.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`MeasureContent renders the content 1`] = `
         false,
         false,
         false,
+        false,
         Object {},
       ]
     }

--- a/packages/ad/src/inline-ad/index.tsx
+++ b/packages/ad/src/inline-ad/index.tsx
@@ -53,6 +53,7 @@ export const InlineAd = (props: Props) => {
 
   const Child = useCallback(({ item, index }, inline = false) => {
     item.attributes = { ...item.attributes, inline };
+
     return (
       <Gutter style={{ overflow: "hidden" }}>
         <ErrorBoundary>
@@ -100,6 +101,7 @@ export const InlineAd = (props: Props) => {
           contentMeasurements,
           contentParameters,
         );
+
         const requiredInlineContentHeight = Math.max(
           currentInlineContentHeight,
           contentHeight,

--- a/packages/ad/src/inline-ad/utils/chunkInlineContent.ts
+++ b/packages/ad/src/inline-ad/utils/chunkInlineContent.ts
@@ -61,18 +61,19 @@ export const chunkInlineContent = (
       // not enough capacity in inline chunk, splitting content into this chunk and the overflow chunk
       const provisionalLineToSplit =
         inlineContentHeightRemaining / contentLineHeight!;
+
       const actualLineToSplit = Math.ceil(provisionalLineToSplit);
 
       const totalLinesHeightAdjustment = contentLineHeight * actualLineToSplit;
 
-      const adjustmentHeightDiffernce =
+      const adjustmentHeightDifference =
         currentParagraphHeight - totalLinesHeightAdjustment;
 
       // final adjustment last paragraph lines fit without bottom padding
       const paragraphBottomSpacing = 20;
       const paddingAdjustment =
-        adjustmentHeightDiffernce <= paragraphBottomSpacing
-          ? adjustmentHeightDiffernce
+        adjustmentHeightDifference <= paragraphBottomSpacing
+          ? adjustmentHeightDifference
           : 0;
 
       const adjustedInlineContentHeight =

--- a/packages/article-paragraph/src/article-paragraph.js
+++ b/packages/article-paragraph/src/article-paragraph.js
@@ -12,6 +12,7 @@ const BodyParagraph = ({
   style,
   children,
   attributes,
+  split,
 }) => {
   const { inline } = attributes || false;
   const { isTablet, narrowArticleBreakpoint } = useResponsiveContext();
@@ -24,6 +25,10 @@ const BodyParagraph = ({
         styles.articleTextElement,
         isTablet && styles.articleMainContentRowTablet,
         isTablet && inline && styles.articleInlineContentRowTablet,
+        isTablet &&
+          inline &&
+          split &&
+          styles.articleInlineSplitContentRowTablet,
         narrowContent && getNarrowContentStyle(narrowArticleBreakpoint.content),
         style,
       ].concat(height ? [{ height: height }] : [])}

--- a/packages/article-paragraph/src/index.js
+++ b/packages/article-paragraph/src/index.js
@@ -25,6 +25,7 @@ const ArticleParagraphWrapper = ({
       style={style}
       narrowContent={narrowContent}
       attributes={attributes}
+      split={ast.split}
     >
       {children}
     </ArticleParagraph>

--- a/packages/article-paragraph/src/styles/shared.js
+++ b/packages/article-paragraph/src/styles/shared.js
@@ -30,6 +30,9 @@ const sharedStyles = (dropCapFont = "dropCap", scale = scales.medium) => {
     articleInlineContentRowTablet: {
       width: "100%",
     },
+    articleInlineSplitContentRowTablet: {
+      marginBottom: 0,
+    },
     narrow: {
       alignSelf: "flex-start",
       width: "100%",

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -75,6 +75,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
               Object {
                 "height": 156,
@@ -540,6 +541,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -601,6 +603,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -1128,6 +1131,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -1179,6 +1183,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -1236,6 +1241,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -1290,6 +1296,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -1341,6 +1348,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -1678,6 +1686,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2137,6 +2146,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -2259,6 +2269,7 @@ exports[`6. an article with heading tags 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -2310,6 +2321,7 @@ exports[`6. an article with heading tags 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2428,6 +2440,7 @@ exports[`7. an article with link 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2569,6 +2582,7 @@ exports[`8. an article with italic link 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2727,6 +2741,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -2867,6 +2882,7 @@ exports[`10. an article with italic and normal text link 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -3045,6 +3061,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -3168,6 +3185,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -3286,6 +3304,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -3420,6 +3439,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -3566,6 +3586,7 @@ exports[`15. an article starting with single quote 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -4178,6 +4199,7 @@ exports[`16. an article starting with double quote 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
               Object {
                 "height": 260,
@@ -4763,6 +4785,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -5079,6 +5102,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -5140,6 +5164,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -5667,6 +5692,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -5718,6 +5744,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -5775,6 +5802,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -5829,6 +5857,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -5880,6 +5909,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6034,6 +6064,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6129,6 +6160,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6274,6 +6306,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6328,6 +6361,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6472,6 +6506,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6602,6 +6637,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6746,6 +6782,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6887,6 +6924,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6975,6 +7013,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7029,6 +7068,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7089,6 +7129,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7143,6 +7184,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7203,6 +7245,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7257,6 +7300,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7317,6 +7361,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7371,6 +7416,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7431,6 +7477,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7485,6 +7532,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7545,6 +7593,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7599,6 +7648,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7659,6 +7709,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7713,6 +7764,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7773,6 +7825,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7827,6 +7880,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7887,6 +7941,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7941,6 +7996,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8001,6 +8057,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8055,6 +8112,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8115,6 +8173,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8169,6 +8228,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8229,6 +8289,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8283,6 +8344,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8343,6 +8405,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8397,6 +8460,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8474,6 +8538,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8619,6 +8684,7 @@ exports[`21. an article with inline paragraph 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -75,6 +75,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
               Object {
                 "height": 156,
@@ -540,6 +541,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -601,6 +603,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -1128,6 +1131,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -1179,6 +1183,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -1236,6 +1241,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -1290,6 +1296,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -1341,6 +1348,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -1678,6 +1686,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2137,6 +2146,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -2259,6 +2269,7 @@ exports[`6. an article with heading tags 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -2310,6 +2321,7 @@ exports[`6. an article with heading tags 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2428,6 +2440,7 @@ exports[`7. an article with link 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2569,6 +2582,7 @@ exports[`8. an article with italic link 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -2727,6 +2741,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -2867,6 +2882,7 @@ exports[`10. an article with italic and normal text link 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -3045,6 +3061,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -3168,6 +3185,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -3286,6 +3304,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -3420,6 +3439,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -3566,6 +3586,7 @@ exports[`15. an article starting with single quote 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -4178,6 +4199,7 @@ exports[`16. an article starting with double quote 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
               Object {
                 "height": 260,
@@ -4763,6 +4785,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -5079,6 +5102,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -5140,6 +5164,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -5667,6 +5692,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -5718,6 +5744,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -5775,6 +5802,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -5829,6 +5857,7 @@ exports[`17. an article with variant testing 1`] = `
               false,
               false,
               false,
+              false,
               Array [
                 Object {
                   "marginBottom": 0,
@@ -5880,6 +5909,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6034,6 +6064,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6129,6 +6160,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6274,6 +6306,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6328,6 +6361,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6472,6 +6506,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6602,6 +6637,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -6746,6 +6782,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6887,6 +6924,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -6975,6 +7013,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7029,6 +7068,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7089,6 +7129,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7143,6 +7184,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7203,6 +7245,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7257,6 +7300,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7317,6 +7361,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7371,6 +7416,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7431,6 +7477,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7485,6 +7532,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7545,6 +7593,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7599,6 +7648,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7659,6 +7709,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7713,6 +7764,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7773,6 +7825,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7827,6 +7880,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -7887,6 +7941,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -7941,6 +7996,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8001,6 +8057,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8055,6 +8112,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8115,6 +8173,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8169,6 +8228,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8229,6 +8289,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8283,6 +8344,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8343,6 +8405,7 @@ exports[`20. renders content 1`] = `
               false,
               false,
               false,
+              false,
               Object {},
             ]
           }
@@ -8397,6 +8460,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8474,6 +8538,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,
@@ -8619,6 +8684,7 @@ exports[`21. an article with inline paragraph 1`] = `
               Object {
                 "marginBottom": 20,
               },
+              false,
               false,
               false,
               false,


### PR DESCRIPTION
Quirky issue when inline text of an inline ad is only one long paragraph. Always adds the paragraph bottom margin even when not required (as a single paragraph is to be split up) which in turn prevents the content from fitting its calculated & desired height.

**Before:**
![Screenshot 2020-11-02 at 23 06 30](https://user-images.githubusercontent.com/5103512/97929692-9abc5880-1d61-11eb-9e91-5db6e3ac2e63.png)

**After:**
![Screenshot 2020-11-02 at 23 07 53](https://user-images.githubusercontent.com/5103512/97929705-a60f8400-1d61-11eb-9f6b-0bdf6dbf4db4.png)

**Before:**
![Screenshot 2020-11-02 at 23 06 59](https://user-images.githubusercontent.com/5103512/97929748-baec1780-1d61-11eb-8736-ee390eb45b7a.png)

**After:**
![Screenshot 2020-11-02 at 23 07 28](https://user-images.githubusercontent.com/5103512/97929773-c93a3380-1d61-11eb-8aef-b83008af9b69.png)

**NOTE: This may also fix the bug seen when screen font size increased in device accessibility settings:**

![Screenshot 2020-11-02 at 23 51 45](https://user-images.githubusercontent.com/5103512/97931907-98103200-1d66-11eb-96e4-6a782179b8b4.png)


