### PR TITLE
chore: release 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "1.11.11",
+  "version": "1.12.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Will include chapter heading fix, which will require iOS to update react-native-webview dep (https://github.com/newsuk/nuk-tnl-app-ios-universal/pull/2175)