### PR TITLE
feat(TNLT-4872): Update newsletter puff tracking

### DIFF
--- a/packages/article-skeleton/__tests__/images.base.js
+++ b/packages/article-skeleton/__tests__/images.base.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { iterator } from "@times-components-native/test-utils";
 import TestRenderer from "react-test-renderer";
-import Context from "@times-components-native/context";
 import ArticleSkeleton from "../src/article-skeleton";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";

--- a/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
+++ b/packages/article-skeleton/src/article-body/inline-newsletter-puff.js
@@ -75,6 +75,7 @@ const InlineNewsletterPuff = ({
                     </Text>
                     <View style={styles.preferencesContainer}>
                       <NewsletterPuffLink
+                        enforceTracking
                         newsletterPuffName={newsletter.title}
                         analyticsStream={analyticsStream}
                         onPress={() => onManagePreferencesPress()}
@@ -88,6 +89,7 @@ const InlineNewsletterPuff = ({
                     <Text style={styles.copy}>{copy}</Text>
                     <View style={styles.signUpCTAContainer}>
                       <NewsletterPuffButton
+                        enforceTracking
                         newsletterPuffName={newsletter.title}
                         analyticsStream={analyticsStream}
                         updatingSubscription={updatingSubscription}

--- a/packages/article-skeleton/src/article-body/newsletter-puff-button.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-button.js
@@ -29,6 +29,7 @@ export default withTrackingContext(
       {
         actionName: "onPress",
         eventName: "onPress",
+        trackingName: "NewsletterPuffButton",
         getAttrs: ({ newsletterPuffName }) => ({
           article_parent_name: `${newsletterPuffName}`,
           event_navigation_name: "widget : puff : sign up now",
@@ -44,6 +45,7 @@ export default withTrackingContext(
       article_parent_name: `${newsletterPuffName}`,
       event_navigation_browsing_method: "automated",
     }),
+    trackingName: "NewsletterPuffButton",
     trackingObjectName: "NewsletterPuffButton",
   },
 );

--- a/packages/article-skeleton/src/article-body/newsletter-puff-link.js
+++ b/packages/article-skeleton/src/article-body/newsletter-puff-link.js
@@ -40,6 +40,7 @@ export default withTrackingContext(
       {
         actionName: "onPress",
         eventName: "onPress",
+        trackingName: "NewsletterPuffLink",
         getAttrs: ({ newsletterPuffName }) => ({
           article_parent_name: `${newsletterPuffName}`,
           event_navigation_name: "widget : puff : manage preferences here",
@@ -56,6 +57,7 @@ export default withTrackingContext(
       article_parent_name: `${newsletterPuffName}`,
       event_navigation_browsing_method: "automated",
     }),
+    trackingName: "NewsletterPuffLink",
     trackingObjectName: "NewsletterPuffLink",
   },
 );

--- a/packages/tracking/src/tracking-context.js
+++ b/packages/tracking/src/tracking-context.js
@@ -82,7 +82,7 @@ const withTrackingContext = (
     attemptTrackPageEvent(props) {
       if (
         isDataReady(props) &&
-        this.isRootTrackingContext() &&
+        (this.isRootTrackingContext() || props.newsletterPuffName) &&
         this.pageEventTriggered === false
       ) {
         this.pageEventTriggered = true;

--- a/packages/tracking/src/tracking-context.js
+++ b/packages/tracking/src/tracking-context.js
@@ -82,7 +82,7 @@ const withTrackingContext = (
     attemptTrackPageEvent(props) {
       if (
         isDataReady(props) &&
-        (this.isRootTrackingContext() || props.newsletterPuffName) &&
+        (this.isRootTrackingContext() || props.enforceTracking) &&
         this.pageEventTriggered === false
       ) {
         this.pageEventTriggered = true;


### PR DESCRIPTION
### Description 
In this PR we fix the `onPress` and `oneView` tracking by adding the `trackingName` to the NewsletterPuff components.

### Jira Ticket
[TNLT-4872](https://nidigitalsolutions.jira.com/browse/TNLT-4872)


### Checklist
- [x] Does it have automated tests?
- [x] Is there another PR linked to this issue (if so please list)?
 PR [#2654](https://github.com/newsuk/times-components/pull/2654) in `times-components`