### PR TITLE
chore: revert back to blue tooltips

### DIFF
--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
@@ -22,7 +22,7 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": 0,
@@ -108,7 +108,7 @@ exports[`1. group of topics 1`] = `
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -148,7 +148,7 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#ff007f",
+            "borderColor": "#3C81BE",
             "borderRadius": 2,
             "borderWidth": 2,
             "padding": 9,
@@ -197,7 +197,7 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": 0,
@@ -283,7 +283,7 @@ exports[`2. group of topics at large scale 1`] = `
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -323,7 +323,7 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#ff007f",
+            "borderColor": "#3C81BE",
             "borderRadius": 2,
             "borderWidth": 2,
             "padding": 9,
@@ -372,7 +372,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": 0,
@@ -458,7 +458,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -498,7 +498,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#ff007f",
+            "borderColor": "#3C81BE",
             "borderRadius": 2,
             "borderWidth": 2,
             "padding": 9,

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
@@ -22,7 +22,7 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": 0,
@@ -108,7 +108,7 @@ exports[`1. group of topics 1`] = `
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -154,7 +154,7 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#ff007f",
+            "borderColor": "#3C81BE",
             "borderRadius": 2,
             "borderWidth": 2,
             "padding": 9,
@@ -203,7 +203,7 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": 0,
@@ -289,7 +289,7 @@ exports[`2. group of topics at large scale 1`] = `
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -335,7 +335,7 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#ff007f",
+            "borderColor": "#3C81BE",
             "borderRadius": 2,
             "borderWidth": 2,
             "padding": 9,
@@ -384,7 +384,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": 0,
@@ -470,7 +470,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -516,7 +516,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#ff007f",
+            "borderColor": "#3C81BE",
             "borderRadius": 2,
             "borderWidth": 2,
             "padding": 9,

--- a/packages/styleguide/src/colours/functional.js
+++ b/packages/styleguide/src/colours/functional.js
@@ -29,7 +29,7 @@ const functionalColours = {
   tertiary: "#4D4D4D",
   transparentBlack: "rgba(0, 0, 0, 0.6)",
   transparentWhite: "rgba(255, 255, 255, 0.3)",
-  tooltip: "#ff007f",
+  tooltip: "#3C81BE",
   white: "#FFFFFF",
   whiteGrey: "#F5F5F5",
   darkGrey: "#999999",

--- a/packages/tooltip/__tests__/android/__snapshots__/shared.test.js.snap
+++ b/packages/tooltip/__tests__/android/__snapshots__/shared.test.js.snap
@@ -13,7 +13,7 @@ Array [
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": -128,
@@ -98,7 +98,7 @@ Array [
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -143,7 +143,7 @@ Array [
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": -128,
@@ -228,7 +228,7 @@ Array [
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,

--- a/packages/tooltip/__tests__/ios/__snapshots__/shared.test.js.snap
+++ b/packages/tooltip/__tests__/ios/__snapshots__/shared.test.js.snap
@@ -13,7 +13,7 @@ Array [
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": -128,
@@ -98,7 +98,7 @@ Array [
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,
@@ -143,7 +143,7 @@ Array [
       <View
         style={
           Object {
-            "backgroundColor": "#ff007f",
+            "backgroundColor": "#3C81BE",
             "borderRadius": 3,
             "bottom": 5,
             "left": -128,
@@ -228,7 +228,7 @@ Array [
             Object {
               "backgroundColor": "transparent",
               "borderBottomWidth": 8,
-              "borderColor": "#ff007f",
+              "borderColor": "#3C81BE",
               "borderLeftColor": "transparent",
               "borderLeftWidth": 12,
               "borderRadius": 3,


### PR DESCRIPTION
- Although the pink was nice, I thought we should revert back to the blue

### before
<img width="803" alt="Screenshot 2020-11-17 at 17 27 40" src="https://user-images.githubusercontent.com/1736782/99425195-6ff20880-28fa-11eb-8589-4430ba6a9b67.png">

### after
<img width="816" alt="Screenshot 2020-11-17 at 17 28 21" src="https://user-images.githubusercontent.com/1736782/99425204-72546280-28fa-11eb-95fb-45a05a60fafb.png">

