### PR TITLE
fix: Ad Position

### DIFF
--- a/packages/article-skeleton/__tests__/body-utils.native.js
+++ b/packages/article-skeleton/__tests__/body-utils.native.js
@@ -465,5 +465,51 @@ export default () => {
         createParagraph("m"),
       ]);
     });
+
+    it("setupAd should return content with the ad in the variant requested position", () => {
+      const newSkeletonProps = {
+        ...skeletonProps,
+        data: {
+          ...skeletonProps.data,
+          content: [
+            { name: "image", children: [] },
+            ...skeletonProps.data.content,
+          ],
+        },
+      };
+
+      expect(
+        setupAd(newSkeletonProps, {
+          articleMpu: {
+            group: "C",
+            adPosition: 3,
+            width: 300,
+            height: 600,
+            slotName: "native-inline-ad-c",
+          },
+        }),
+      ).toEqual([
+        { name: "image", children: [] },
+        createParagraph("a"),
+        createParagraph("b"),
+        {
+          name: "inlineContent",
+          attributes: {
+            width: 300,
+            height: 600,
+            slotName: "native-inline-ad-c",
+            inlineContent: [
+              createParagraph("c"),
+              createParagraph("d"),
+              createParagraph("e"),
+              createParagraph("f"),
+            ],
+            originalName: "ad",
+            skeletonProps: newSkeletonProps,
+          },
+          children: [],
+        },
+      ]);
+    });
   });
 };

--- a/packages/article-skeleton/src/body-utils.js
+++ b/packages/article-skeleton/src/body-utils.js
@@ -90,7 +90,24 @@ const setupArticleMpuTestAd = (
 ) => {
   const { adPosition, group, width, height, slotName } = articleMpu;
   const isControlGroup = group === "A";
-  const adSlotIndex = isControlGroup ? currentAdSlotIndex : adPosition - 1;
+
+  // Get index of nth (adPosition) paragraph
+  let nthParagraphIndex = currentAdSlotIndex;
+
+  contentWithoutAdSlot.reduce((count, item, index) => {
+    if (item.name !== "paragraph") return count;
+    if (count === adPosition) {
+      nthParagraphIndex = index - 1;
+    }
+    return count + 1;
+  }, 0);
+
+  console.log(
+    "fdsjklfjakdfsdafjad skjskfjsdklfjksd akfjdfkldsaj;lfksd",
+    nthParagraphIndex,
+  );
+
+  const adSlotIndex = isControlGroup ? currentAdSlotIndex : nthParagraphIndex;
 
   const contentBeforeAd = contentWithoutAdSlot.slice(0, adSlotIndex);
 

--- a/packages/article-skeleton/src/body-utils.js
+++ b/packages/article-skeleton/src/body-utils.js
@@ -102,11 +102,6 @@ const setupArticleMpuTestAd = (
     return count + 1;
   }, 0);
 
-  console.log(
-    "fdsjklfjakdfsdafjad skjskfjsdklfjksd akfjdfkldsaj;lfksd",
-    nthParagraphIndex,
-  );
-
   const adSlotIndex = isControlGroup ? currentAdSlotIndex : nthParagraphIndex;
 
   const contentBeforeAd = contentWithoutAdSlot.slice(0, adSlotIndex);


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-5869

Ensures that inline adverts are positioned with the n _th_ (provided as `adPosition` in variants) paragraph inlined i.e. ignoring any non paragraph content when counting items.