### PR TITLE
fix: Remove overflow hidden on article containers + topic tooltip issue

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. a primary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. a primary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -37,7 +37,7 @@ exports[`1. a primary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -47,7 +47,7 @@ exports[`1. a primary image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -75,7 +75,7 @@ exports[`2. a fullwidth image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -85,7 +85,7 @@ exports[`2. a fullwidth image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -97,7 +97,7 @@ exports[`2. a fullwidth image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -107,7 +107,7 @@ exports[`2. a fullwidth image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -135,7 +135,7 @@ exports[`3. a secondary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -145,7 +145,7 @@ exports[`3. a secondary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -157,7 +157,7 @@ exports[`3. a secondary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -167,7 +167,7 @@ exports[`3. a secondary image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -195,7 +195,7 @@ exports[`4. an inline image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -205,7 +205,7 @@ exports[`4. an inline image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -217,7 +217,7 @@ exports[`4. an inline image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -227,7 +227,7 @@ exports[`4. an inline image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. with inline video 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. with inline video 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -71,7 +71,7 @@ exports[`1. with inline video 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -81,7 +81,7 @@ exports[`1. with inline video 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -109,7 +109,7 @@ exports[`2. with ad on mainstandard 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -119,7 +119,7 @@ exports[`2. with ad on mainstandard 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -131,7 +131,7 @@ exports[`2. with ad on mainstandard 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -141,7 +141,7 @@ exports[`2. with ad on mainstandard 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -169,7 +169,7 @@ exports[`3. with ad on maincomment 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -179,7 +179,7 @@ exports[`3. with ad on maincomment 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -191,7 +191,7 @@ exports[`3. with ad on maincomment 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -201,7 +201,7 @@ exports[`3. with ad on maincomment 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -191,7 +191,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -212,7 +212,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -224,7 +224,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -236,7 +236,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -248,7 +248,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -294,7 +294,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -337,7 +337,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -349,7 +349,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -363,7 +363,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -408,7 +408,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -629,7 +629,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -665,7 +665,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -701,7 +701,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -737,7 +737,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -773,7 +773,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -809,7 +809,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -819,7 +819,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -847,7 +847,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -857,7 +857,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -878,7 +878,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -900,7 +900,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -910,7 +910,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -938,7 +938,7 @@ exports[`3. an article with no content 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -948,7 +948,7 @@ exports[`3. an article with no content 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -958,7 +958,7 @@ exports[`3. an article with no content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -988,7 +988,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -998,7 +998,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1348,7 +1348,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1392,7 +1392,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1402,7 +1402,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1430,7 +1430,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1440,7 +1440,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1476,7 +1476,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1512,7 +1512,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1522,7 +1522,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1550,7 +1550,7 @@ exports[`7. an article with link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1560,7 +1560,7 @@ exports[`7. an article with link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1618,7 +1618,7 @@ exports[`7. an article with link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1628,7 +1628,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1656,7 +1656,7 @@ exports[`8. an article with italic link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1666,7 +1666,7 @@ exports[`8. an article with italic link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1737,7 +1737,7 @@ exports[`8. an article with italic link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1747,7 +1747,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1775,7 +1775,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1785,7 +1785,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1845,7 +1845,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1855,7 +1855,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1883,7 +1883,7 @@ exports[`10. an article with italic and normal text link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1893,7 +1893,7 @@ exports[`10. an article with italic and normal text link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1979,7 +1979,7 @@ exports[`10. an article with italic and normal text link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1989,7 +1989,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2017,7 +2017,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2027,7 +2027,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2072,7 +2072,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2082,7 +2082,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2110,7 +2110,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2120,7 +2120,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2163,7 +2163,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2173,7 +2173,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2201,7 +2201,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2211,7 +2211,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2266,7 +2266,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2276,7 +2276,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2304,7 +2304,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2314,7 +2314,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2358,7 +2358,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2368,7 +2368,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2396,7 +2396,7 @@ exports[`15. an article starting with single quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2406,7 +2406,7 @@ exports[`15. an article starting with single quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2797,7 +2797,7 @@ exports[`15. an article starting with single quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2807,7 +2807,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2835,7 +2835,7 @@ exports[`16. an article starting with double quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2845,7 +2845,7 @@ exports[`16. an article starting with double quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3236,7 +3236,7 @@ exports[`16. an article starting with double quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3246,7 +3246,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -3274,7 +3274,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3284,7 +3284,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3327,7 +3327,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3348,7 +3348,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3360,7 +3360,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3372,7 +3372,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3384,7 +3384,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3430,7 +3430,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3473,7 +3473,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3485,7 +3485,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3499,7 +3499,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3544,7 +3544,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3765,7 +3765,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3801,7 +3801,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3837,7 +3837,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3873,7 +3873,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3909,7 +3909,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3945,7 +3945,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3955,7 +3955,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -3983,7 +3983,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3993,7 +3993,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4038,7 +4038,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4059,7 +4059,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4071,7 +4071,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4083,7 +4083,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4095,7 +4095,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4143,7 +4143,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4188,7 +4188,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4200,7 +4200,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4214,7 +4214,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4259,7 +4259,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4485,7 +4485,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4523,7 +4523,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4561,7 +4561,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4599,7 +4599,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4637,7 +4637,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4675,7 +4675,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4685,7 +4685,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -19,6 +19,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -33,6 +34,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -264,6 +266,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -295,6 +298,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -371,6 +375,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -447,6 +452,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -523,6 +529,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -588,6 +595,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -646,6 +654,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -722,6 +731,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -744,6 +754,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -816,6 +827,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1104,6 +1116,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1159,6 +1172,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1214,6 +1228,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1269,6 +1284,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1324,6 +1340,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1379,6 +1396,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1393,6 +1411,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -1429,6 +1448,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1443,6 +1463,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1474,6 +1495,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1508,6 +1530,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1522,6 +1545,7 @@ exports[`2. an article with interactives 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -1558,6 +1582,7 @@ exports[`3. an article with no content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1572,6 +1597,7 @@ exports[`3. an article with no content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1586,6 +1612,7 @@ exports[`3. an article with no content 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -1624,6 +1651,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1638,6 +1666,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2119,6 +2148,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2178,6 +2208,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2192,6 +2223,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2228,6 +2260,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2242,6 +2275,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2297,6 +2331,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2352,6 +2387,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2366,6 +2402,7 @@ exports[`6. an article with heading tags 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2402,6 +2439,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2416,6 +2454,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2494,6 +2533,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2508,6 +2548,7 @@ exports[`7. an article with link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2544,6 +2585,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2558,6 +2600,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2650,6 +2693,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2664,6 +2708,7 @@ exports[`8. an article with italic link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2700,6 +2745,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2714,6 +2760,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2794,6 +2841,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2808,6 +2856,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2844,6 +2893,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2858,6 +2908,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2970,6 +3021,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2984,6 +3036,7 @@ exports[`10. an article with italic and normal text link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3020,6 +3073,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3034,6 +3088,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3094,6 +3149,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3108,6 +3164,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3144,6 +3201,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3158,6 +3216,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3216,6 +3275,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3230,6 +3290,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3266,6 +3327,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3280,6 +3342,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3351,6 +3414,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3365,6 +3429,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3401,6 +3466,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3415,6 +3481,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3474,6 +3541,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3488,6 +3556,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3524,6 +3593,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3538,6 +3608,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4084,6 +4155,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4098,6 +4170,7 @@ exports[`15. an article starting with single quote 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -4134,6 +4207,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4148,6 +4222,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4694,6 +4769,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4708,6 +4784,7 @@ exports[`16. an article starting with double quote 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -4744,6 +4821,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4758,6 +4836,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4816,6 +4895,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4847,6 +4927,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4923,6 +5004,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4999,6 +5081,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5075,6 +5158,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5140,6 +5224,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5198,6 +5283,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5274,6 +5360,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5296,6 +5383,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5368,6 +5456,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5656,6 +5745,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5711,6 +5801,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5766,6 +5857,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5821,6 +5913,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5876,6 +5969,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5931,6 +6025,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5945,6 +6040,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -6014,6 +6110,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6028,6 +6125,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6127,6 +6225,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6186,6 +6285,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6270,6 +6370,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6328,6 +6429,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6386,6 +6488,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6470,6 +6573,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6528,6 +6632,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6604,6 +6709,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6662,6 +6768,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6746,6 +6853,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6804,6 +6912,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6888,6 +6997,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6946,6 +7056,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6977,6 +7088,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7035,6 +7147,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7093,6 +7206,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7151,6 +7265,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7209,6 +7324,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7267,6 +7383,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7325,6 +7442,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7383,6 +7501,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7441,6 +7560,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7499,6 +7619,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7557,6 +7678,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7615,6 +7737,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7673,6 +7796,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7731,6 +7855,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7789,6 +7914,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7847,6 +7973,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7905,6 +8032,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7963,6 +8091,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8021,6 +8150,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8079,6 +8209,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8137,6 +8268,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8195,6 +8327,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8253,6 +8386,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8311,6 +8445,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8369,6 +8504,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8427,6 +8563,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8505,6 +8642,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8563,6 +8701,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8577,6 +8716,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -8613,6 +8753,7 @@ exports[`21. an article with inline paragraph 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8627,6 +8768,7 @@ exports[`21. an article with inline paragraph 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -10094,6 +10236,7 @@ exports[`21. an article with inline paragraph 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -10108,6 +10251,7 @@ exports[`21. an article with inline paragraph 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images-with-style.ios.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. a primary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. a primary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -37,7 +37,7 @@ exports[`1. a primary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -47,7 +47,7 @@ exports[`1. a primary image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -75,7 +75,7 @@ exports[`2. a fullwidth image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -85,7 +85,7 @@ exports[`2. a fullwidth image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -97,7 +97,7 @@ exports[`2. a fullwidth image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -107,7 +107,7 @@ exports[`2. a fullwidth image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -135,7 +135,7 @@ exports[`3. a secondary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -145,7 +145,7 @@ exports[`3. a secondary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -157,7 +157,7 @@ exports[`3. a secondary image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -167,7 +167,7 @@ exports[`3. a secondary image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -195,7 +195,7 @@ exports[`4. an inline image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -205,7 +205,7 @@ exports[`4. an inline image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -217,7 +217,7 @@ exports[`4. an inline image 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -227,7 +227,7 @@ exports[`4. an inline image 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-scaling.ios.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. scaled medium full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. scaled medium full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -68,7 +68,7 @@ exports[`1. scaled medium full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -78,7 +78,7 @@ exports[`1. scaled medium full article 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -106,7 +106,7 @@ exports[`2. scaled large full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -116,7 +116,7 @@ exports[`2. scaled large full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -159,7 +159,7 @@ exports[`2. scaled large full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -169,7 +169,7 @@ exports[`2. scaled large full article 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -197,7 +197,7 @@ exports[`3. scaled xlarge full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -207,7 +207,7 @@ exports[`3. scaled xlarge full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -250,7 +250,7 @@ exports[`3. scaled xlarge full article 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -260,7 +260,7 @@ exports[`3. scaled xlarge full article 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. with inline video 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. with inline video 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -71,7 +71,7 @@ exports[`1. with inline video 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -81,7 +81,7 @@ exports[`1. with inline video 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -109,7 +109,7 @@ exports[`2. with ad on mainstandard 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -119,7 +119,7 @@ exports[`2. with ad on mainstandard 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -131,7 +131,7 @@ exports[`2. with ad on mainstandard 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -141,7 +141,7 @@ exports[`2. with ad on mainstandard 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -169,7 +169,7 @@ exports[`3. with ad on maincomment 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -179,7 +179,7 @@ exports[`3. with ad on maincomment 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -191,7 +191,7 @@ exports[`3. with ad on maincomment 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -201,7 +201,7 @@ exports[`3. with ad on maincomment 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -25,7 +25,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -191,7 +191,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -212,7 +212,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -224,7 +224,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -236,7 +236,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -248,7 +248,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -294,7 +294,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -337,7 +337,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -349,7 +349,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -363,7 +363,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -408,7 +408,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -629,7 +629,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -665,7 +665,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -701,7 +701,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -737,7 +737,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -773,7 +773,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -809,7 +809,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -819,7 +819,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -847,7 +847,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -857,7 +857,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -878,7 +878,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -900,7 +900,7 @@ exports[`2. an article with interactives 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -910,7 +910,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -938,7 +938,7 @@ exports[`3. an article with no content 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -948,7 +948,7 @@ exports[`3. an article with no content 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -958,7 +958,7 @@ exports[`3. an article with no content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -988,7 +988,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -998,7 +998,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1348,7 +1348,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1392,7 +1392,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1402,7 +1402,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1430,7 +1430,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1440,7 +1440,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1476,7 +1476,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1512,7 +1512,7 @@ exports[`6. an article with heading tags 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1522,7 +1522,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1550,7 +1550,7 @@ exports[`7. an article with link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1560,7 +1560,7 @@ exports[`7. an article with link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1618,7 +1618,7 @@ exports[`7. an article with link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1628,7 +1628,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1656,7 +1656,7 @@ exports[`8. an article with italic link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1666,7 +1666,7 @@ exports[`8. an article with italic link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1737,7 +1737,7 @@ exports[`8. an article with italic link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1747,7 +1747,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1775,7 +1775,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1785,7 +1785,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1845,7 +1845,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1855,7 +1855,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -1883,7 +1883,7 @@ exports[`10. an article with italic and normal text link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1893,7 +1893,7 @@ exports[`10. an article with italic and normal text link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1979,7 +1979,7 @@ exports[`10. an article with italic and normal text link 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -1989,7 +1989,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2017,7 +2017,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2027,7 +2027,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2072,7 +2072,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2082,7 +2082,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2110,7 +2110,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2120,7 +2120,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2163,7 +2163,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2173,7 +2173,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2201,7 +2201,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2211,7 +2211,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2266,7 +2266,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2276,7 +2276,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2304,7 +2304,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2314,7 +2314,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2358,7 +2358,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2368,7 +2368,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2396,7 +2396,7 @@ exports[`15. an article starting with single quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2406,7 +2406,7 @@ exports[`15. an article starting with single quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2797,7 +2797,7 @@ exports[`15. an article starting with single quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2807,7 +2807,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -2835,7 +2835,7 @@ exports[`16. an article starting with double quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -2845,7 +2845,7 @@ exports[`16. an article starting with double quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3236,7 +3236,7 @@ exports[`16. an article starting with double quote 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3246,7 +3246,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -3274,7 +3274,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3284,7 +3284,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3327,7 +3327,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3348,7 +3348,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3360,7 +3360,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3372,7 +3372,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3384,7 +3384,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3430,7 +3430,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3473,7 +3473,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3485,7 +3485,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3499,7 +3499,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3544,7 +3544,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3765,7 +3765,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3801,7 +3801,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3837,7 +3837,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3873,7 +3873,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3909,7 +3909,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3945,7 +3945,7 @@ exports[`17. an article with variant testing 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3955,7 +3955,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }
@@ -3983,7 +3983,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -3993,7 +3993,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4038,7 +4038,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4059,7 +4059,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4071,7 +4071,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4083,7 +4083,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4095,7 +4095,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4143,7 +4143,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4188,7 +4188,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4200,7 +4200,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4214,7 +4214,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4259,7 +4259,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4485,7 +4485,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4523,7 +4523,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4561,7 +4561,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4599,7 +4599,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4637,7 +4637,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4675,7 +4675,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
           Object {
             "backgroundColor": "#ffffff",
             "maxWidth": "100%",
-            "overflow": "hidden",
+            "overflow": "visible",
             "width": undefined,
           }
         }
@@ -4685,7 +4685,7 @@ exports[`18. an article skeleton with responsive items 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
-              "overflow": "hidden",
+              "overflow": "visible",
               "width": undefined,
             }
           }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -19,6 +19,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -33,6 +34,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -264,6 +266,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -295,6 +298,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -371,6 +375,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -447,6 +452,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -523,6 +529,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -588,6 +595,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -646,6 +654,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -722,6 +731,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -744,6 +754,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -816,6 +827,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1104,6 +1116,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1159,6 +1172,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1214,6 +1228,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1269,6 +1284,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1324,6 +1340,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1379,6 +1396,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1393,6 +1411,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -1429,6 +1448,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1443,6 +1463,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1474,6 +1495,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1508,6 +1530,7 @@ exports[`2. an article with interactives 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1522,6 +1545,7 @@ exports[`2. an article with interactives 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -1558,6 +1582,7 @@ exports[`3. an article with no content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1572,6 +1597,7 @@ exports[`3. an article with no content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1586,6 +1612,7 @@ exports[`3. an article with no content 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -1624,6 +1651,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -1638,6 +1666,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2119,6 +2148,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2178,6 +2208,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2192,6 +2223,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2228,6 +2260,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2242,6 +2275,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2297,6 +2331,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2352,6 +2387,7 @@ exports[`6. an article with heading tags 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2366,6 +2402,7 @@ exports[`6. an article with heading tags 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2402,6 +2439,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2416,6 +2454,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2494,6 +2533,7 @@ exports[`7. an article with link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2508,6 +2548,7 @@ exports[`7. an article with link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2544,6 +2585,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2558,6 +2600,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2650,6 +2693,7 @@ exports[`8. an article with italic link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2664,6 +2708,7 @@ exports[`8. an article with italic link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2700,6 +2745,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2714,6 +2760,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2794,6 +2841,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2808,6 +2856,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -2844,6 +2893,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2858,6 +2908,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2970,6 +3021,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -2984,6 +3036,7 @@ exports[`10. an article with italic and normal text link 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3020,6 +3073,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3034,6 +3088,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3094,6 +3149,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3108,6 +3164,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3144,6 +3201,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3158,6 +3216,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3216,6 +3275,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3230,6 +3290,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3266,6 +3327,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3280,6 +3342,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3351,6 +3414,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3365,6 +3429,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3401,6 +3466,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3415,6 +3481,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3474,6 +3541,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3488,6 +3556,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -3524,6 +3593,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -3538,6 +3608,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4084,6 +4155,7 @@ exports[`15. an article starting with single quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4098,6 +4170,7 @@ exports[`15. an article starting with single quote 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -4134,6 +4207,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4148,6 +4222,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4694,6 +4769,7 @@ exports[`16. an article starting with double quote 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4708,6 +4784,7 @@ exports[`16. an article starting with double quote 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -4744,6 +4821,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4758,6 +4836,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4816,6 +4895,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4847,6 +4927,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4923,6 +5004,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -4999,6 +5081,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5075,6 +5158,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5140,6 +5224,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5198,6 +5283,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5274,6 +5360,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5296,6 +5383,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5368,6 +5456,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5656,6 +5745,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5711,6 +5801,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5766,6 +5857,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5821,6 +5913,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5876,6 +5969,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5931,6 +6025,7 @@ exports[`17. an article with variant testing 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -5945,6 +6040,7 @@ exports[`17. an article with variant testing 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -6014,6 +6110,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6028,6 +6125,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6127,6 +6225,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6186,6 +6285,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6270,6 +6370,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6328,6 +6429,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6386,6 +6488,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6470,6 +6573,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6528,6 +6632,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6604,6 +6709,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6662,6 +6768,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6746,6 +6853,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6804,6 +6912,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6888,6 +6997,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6946,6 +7056,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -6977,6 +7088,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7035,6 +7147,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7093,6 +7206,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7151,6 +7265,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7209,6 +7324,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7267,6 +7383,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7325,6 +7442,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7383,6 +7501,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7441,6 +7560,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7499,6 +7619,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7557,6 +7678,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7615,6 +7737,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7673,6 +7796,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7731,6 +7855,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7789,6 +7914,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7847,6 +7973,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7905,6 +8032,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -7963,6 +8091,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8021,6 +8150,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8079,6 +8209,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8137,6 +8268,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8195,6 +8327,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8253,6 +8386,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8311,6 +8445,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8369,6 +8504,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8427,6 +8563,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8505,6 +8642,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8563,6 +8701,7 @@ exports[`20. renders content 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8577,6 +8716,7 @@ exports[`20. renders content 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]
@@ -8613,6 +8753,7 @@ exports[`21. an article with inline paragraph 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -8627,6 +8768,7 @@ exports[`21. an article with inline paragraph 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -10094,6 +10236,7 @@ exports[`21. an article with inline paragraph 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "maxWidth": "100%",
+              "overflow": "visible",
               "width": undefined,
             },
           ]
@@ -10108,6 +10251,7 @@ exports[`21. an article with inline paragraph 1`] = `
               Object {
                 "backgroundColor": "#ffffff",
                 "maxWidth": "100%",
+                "overflow": "visible",
                 "width": undefined,
               },
             ]

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -93,7 +93,7 @@ const ArticleWithContent = (props) => {
   // eslint-disable-next-line react/prop-types
   const Child = useCallback(
     ({ item, index }) => (
-      <Gutter style={{ overflow: "hidden" }}>
+      <Gutter>
         <ErrorBoundary>
           {item.name === "footer"
             ? footer

--- a/packages/article-skeleton/src/styles/shared.js
+++ b/packages/article-skeleton/src/styles/shared.js
@@ -20,6 +20,7 @@ const globalStyle = {
     backgroundColor: "#ffffff",
     maxWidth: "100%",
     width: maxWidth,
+    overflow: "visible",
   },
 };
 

--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
@@ -23,10 +23,10 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#3C81BE",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -73,10 +73,10 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#3C81BE",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -123,10 +123,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#3C81BE",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
@@ -29,10 +29,10 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#3C81BE",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -85,10 +85,10 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#3C81BE",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -141,10 +141,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#3C81BE",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >

--- a/packages/article-topics/src/article-topic.js
+++ b/packages/article-topics/src/article-topic.js
@@ -20,7 +20,8 @@ const ArticleTopic = ({
   const fontSizeStyle = fontSize ? { fontSize } : null;
   const lineHeightStyle = lineHeight ? { lineHeight } : null;
 
-  const showTooltip = index === 0;
+  const tooltipType = "topics";
+  const showTooltip = index === 0 && tooltips.includes(tooltipType);
   const [isHighlighted, setIsHighlighted] = useState(showTooltip);
 
   const unhighlightTopic = () => {
@@ -61,7 +62,7 @@ const ArticleTopic = ({
       content={<Text>Tap a topic to see more of our coverage</Text>}
       onClose={unhighlightTopic}
       onTooltipPresented={onTooltipPresented}
-      type="topics"
+      type={tooltipType}
       tooltips={[tooltips]}
       alignment="left"
       width={236}


### PR DESCRIPTION
- Fixes issue with content being clipped 
- `overflow-hidden` was introduced in this PR: https://github.com/newsuk/times-components/pull/2437/commits/f14e38786aa84485d49731674b28bbe6641a0f44 but I can't find a problem with removing it
- Also fixes issue with article topic being highlighted even when no tooltip is displayed.



### before
<img width="750" alt="Screenshot 2020-11-18 at 14 30 04" src="https://user-images.githubusercontent.com/1736782/99548620-c0c43880-29b0-11eb-9eac-953fad59c9a6.png">


### after
<img width="734" alt="Screenshot 2020-11-18 at 14 27 15" src="https://user-images.githubusercontent.com/1736782/99548607-bd30b180-29b0-11eb-8ce2-403fff6a74a0.png">