### PR TITLE
fix: (TNLT-6029) Adjusts the content inset behaviour on ScrollView

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`1. article with header 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`1. a primary image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>
@@ -60,7 +62,9 @@ exports[`1. a primary image 1`] = `
 
 exports[`2. a fullwidth image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>
@@ -118,7 +122,9 @@ exports[`2. a fullwidth image 1`] = `
 
 exports[`3. a secondary image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>
@@ -176,7 +182,9 @@ exports[`3. a secondary image 1`] = `
 
 exports[`4. an inline image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -8,7 +8,9 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -1437,7 +1439,9 @@ exports[`2. an article with interactives 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -1571,7 +1575,9 @@ exports[`3. an article with no content 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -1640,7 +1646,9 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2249,7 +2257,9 @@ exports[`6. an article with heading tags 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2428,7 +2438,9 @@ exports[`7. an article with link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2574,7 +2586,9 @@ exports[`8. an article with italic link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2734,7 +2748,9 @@ exports[`9. an article with bold text followed by bold link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2882,7 +2898,9 @@ exports[`10. an article with italic and normal text link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3062,7 +3080,9 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3190,7 +3210,9 @@ exports[`12. an article with text wrapped in inline element 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3316,7 +3338,9 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3455,7 +3479,9 @@ exports[`14. an article with inline inside a bold tag 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3582,7 +3608,9 @@ exports[`15. an article starting with single quote 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -4196,7 +4224,9 @@ exports[`16. an article starting with double quote 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -4810,7 +4840,9 @@ exports[`17. an article with variant testing 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -6099,7 +6131,9 @@ exports[`20. renders content 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -8742,7 +8776,9 @@ exports[`21. an article with inline paragraph 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`1. article with header 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`1. a primary image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>
@@ -60,7 +62,9 @@ exports[`1. a primary image 1`] = `
 
 exports[`2. a fullwidth image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>
@@ -118,7 +122,9 @@ exports[`2. a fullwidth image 1`] = `
 
 exports[`3. a secondary image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>
@@ -176,7 +182,9 @@ exports[`3. a secondary image 1`] = `
 
 exports[`4. an inline image 1`] = `
 <View>
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View />
       <View>

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -8,7 +8,9 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -1437,7 +1439,9 @@ exports[`2. an article with interactives 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -1571,7 +1575,9 @@ exports[`3. an article with no content 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -1640,7 +1646,9 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2249,7 +2257,9 @@ exports[`6. an article with heading tags 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2428,7 +2438,9 @@ exports[`7. an article with link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2574,7 +2586,9 @@ exports[`8. an article with italic link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2734,7 +2748,9 @@ exports[`9. an article with bold text followed by bold link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -2882,7 +2898,9 @@ exports[`10. an article with italic and normal text link 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3062,7 +3080,9 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3190,7 +3210,9 @@ exports[`12. an article with text wrapped in inline element 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3316,7 +3338,9 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3455,7 +3479,9 @@ exports[`14. an article with inline inside a bold tag 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -3582,7 +3608,9 @@ exports[`15. an article starting with single quote 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -4196,7 +4224,9 @@ exports[`16. an article starting with double quote 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -4810,7 +4840,9 @@ exports[`17. an article with variant testing 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -6099,7 +6131,9 @@ exports[`20. renders content 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={
@@ -8742,7 +8776,9 @@ exports[`21. an article with inline paragraph 1`] = `
     }
   }
 >
-  <RCTScrollView>
+  <RCTScrollView
+    contentInsetAdjustmentBehavior="automatic"
+  >
     <View>
       <View
         style={

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -118,7 +118,7 @@ const ArticleWithContent = (props) => {
   return (
     <View style={styles.articleContainer}>
       <Viewport.Tracker>
-        <ScrollView>
+        <ScrollView contentInsetAdjustmentBehavior="automatic">
           {header}
           {processedContent}
         </ScrollView>


### PR DESCRIPTION
- Fix for https://nidigitalsolutions.jira.com/browse/TNLT-6029
- Issue is only present on iOS devices not Android
- Adjusts the content inset behaviour on ScrollView. See docs: https://reactnative.dev/docs/scrollview#contentinsetadjustmentbehavior

## iOS Phone

### Before
<img width="509" alt="Screenshot 2020-11-23 at 13 14 38" src="https://user-images.githubusercontent.com/1736782/99980956-b6cf7a80-2da0-11eb-8c87-8b402b65018b.png">

### After
<img width="521" alt="Screenshot 2020-11-23 at 15 20 48" src="https://user-images.githubusercontent.com/1736782/99980862-9f908d00-2da0-11eb-8fd4-bd588e2d061e.png">


## Android Phone

### Before
<img width="424" alt="Screenshot 2020-11-23 at 15 19 45" src="https://user-images.githubusercontent.com/1736782/99980903-a9b28b80-2da0-11eb-9089-de784a6ca475.png">

### After

<img width="430" alt="Screenshot 2020-11-23 at 15 17 17" src="https://user-images.githubusercontent.com/1736782/99981002-c2bb3c80-2da0-11eb-9b61-014950daf629.png">
