### PR TITLE
chore: release v1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- Fix for `onTooltipPresented` not being passed 