### PR TITLE
fix: onTooltipPresented not firing on fixed left-hand column

### DIFF
--- a/packages/article-byline/src/article-byline-with-links.js
+++ b/packages/article-byline/src/article-byline-with-links.js
@@ -39,6 +39,7 @@ const ArticleBylineWithLinks = ({ ast, ...props }) => {
     disableTooltip,
     onTooltipPresented,
     tooltipArrowOffset,
+    tooltipDisplayedInView,
     tooltipOffsetX,
     tooltipOffsetY,
     tooltips,
@@ -64,6 +65,7 @@ const ArticleBylineWithLinks = ({ ast, ...props }) => {
         </Text>
       }
       arrowOffset={tooltipArrowOffset}
+      displayedInView={tooltipDisplayedInView}
       offsetX={tooltipOffsetX}
       offsetY={tooltipOffsetY}
       onTooltipPresented={onTooltipPresented}

--- a/packages/article-comment-tablet/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-comment-tablet/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -45,6 +45,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           }
           centered={true}
           tooltipArrowOffset={50}
+          tooltipDisplayedInView={true}
           tooltipOffsetX={10}
           tooltipOffsetY={30}
         />
@@ -52,6 +53,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     </View>
     <View>
       <ArticleTopics
+        tooltipDisplayedInView={true}
         topics={
           Array [
             Object {
@@ -129,6 +131,7 @@ exports[`4. an article with ads 1`] = `
           }
           centered={true}
           tooltipArrowOffset={50}
+          tooltipDisplayedInView={true}
           tooltipOffsetX={10}
           tooltipOffsetY={30}
         />
@@ -136,6 +139,7 @@ exports[`4. an article with ads 1`] = `
     </View>
     <View>
       <ArticleTopics
+        tooltipDisplayedInView={true}
         topics={
           Array [
             Object {

--- a/packages/article-comment-tablet/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-comment-tablet/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -45,6 +45,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           }
           centered={true}
           tooltipArrowOffset={50}
+          tooltipDisplayedInView={true}
           tooltipOffsetX={10}
           tooltipOffsetY={30}
         />
@@ -52,6 +53,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     </View>
     <View>
       <ArticleTopics
+        tooltipDisplayedInView={true}
         topics={
           Array [
             Object {
@@ -129,6 +131,7 @@ exports[`4. an article with ads 1`] = `
           }
           centered={true}
           tooltipArrowOffset={50}
+          tooltipDisplayedInView={true}
           tooltipOffsetX={10}
           tooltipOffsetY={30}
         />
@@ -136,6 +139,7 @@ exports[`4. an article with ads 1`] = `
     </View>
     <View>
       <ArticleTopics
+        tooltipDisplayedInView={true}
         topics={
           Array [
             Object {

--- a/packages/article-comment-tablet/src/article-left-column/article-left-column.js
+++ b/packages/article-comment-tablet/src/article-left-column/article-left-column.js
@@ -29,6 +29,7 @@ const ArticleLeftColumn = ({
             centered
             onAuthorPress={onAuthorPress}
             onTooltipPresented={onTooltipPresented}
+            tooltipDisplayedInView={true}
             tooltipArrowOffset={50}
             tooltipOffsetX={10}
             tooltipOffsetY={30}
@@ -42,6 +43,7 @@ const ArticleLeftColumn = ({
         <ArticleTopics
           onTooltipPresented={onTooltipPresented}
           onPress={onTopicPress}
+          tooltipDisplayedInView={true}
           tooltips={tooltips}
           topics={topics}
           style={{ justifyContent: "flex-start" }}

--- a/packages/article-topics/src/article-topic-prop-types.js
+++ b/packages/article-topics/src/article-topic-prop-types.js
@@ -7,10 +7,12 @@ export const topicPropTypes = {
   onPress: PropTypes.func.isRequired,
   onTooltipPresented: PropTypes.func,
   slug: PropTypes.string.isRequired,
+  tooltipDisplayedInView: PropTypes.bool,
   tooltips: PropTypes.array,
 };
 
 export const topicDefaultProps = {
   onTooltipPresented: () => null,
+  tooltipDisplayedInView: false,
   tooltips: [],
 };

--- a/packages/article-topics/src/article-topic.js
+++ b/packages/article-topics/src/article-topic.js
@@ -16,6 +16,7 @@ const ArticleTopic = ({
   onPress,
   onTooltipPresented,
   slug,
+  tooltipDisplayedInView,
   tooltips,
 }) => {
   const fontSizeStyle = fontSize ? { fontSize } : null;
@@ -62,6 +63,7 @@ const ArticleTopic = ({
   const articleTopicWithTooltip = (
     <Tooltip
       content={<Text>Tap a topic to see more of our coverage</Text>}
+      displayedInView={tooltipDisplayedInView}
       offsetY={5}
       onClose={unhighlightTopic}
       onTooltipPresented={onTooltipPresented}

--- a/packages/article-topics/src/article-topics-prop-types.js
+++ b/packages/article-topics/src/article-topics-prop-types.js
@@ -7,6 +7,7 @@ export const topicsPropTypes = {
   onPress: PropTypes.func.isRequired,
   onTooltipPresented: PropTypes.func,
   style: ViewPropTypesStyle,
+  tooltipDisplayedInView: PropTypes.bool,
   tooltips: PropTypes.array,
   topics: PropTypes.arrayOf(
     PropTypes.shape({
@@ -17,6 +18,7 @@ export const topicsPropTypes = {
 };
 
 export const topicsDefaultProps = {
+  tooltipDisplayedInView: false,
   onTooltipPresented: () => null,
   style: null,
   tooltips: [],

--- a/packages/article-topics/src/article-topics.js
+++ b/packages/article-topics/src/article-topics.js
@@ -10,6 +10,7 @@ import {
 } from "./article-topics-prop-types";
 
 const renderArticleTopics = (
+  tooltipDisplayedInView,
   tooltips,
   topics,
   onPress,
@@ -26,6 +27,7 @@ const renderArticleTopics = (
       onPress={onPress}
       onTooltipPresented={onTooltipPresented}
       slug={slug}
+      tooltipDisplayedInView={tooltipDisplayedInView}
       tooltips={tooltips}
     />
   ));
@@ -35,6 +37,7 @@ const ArticleTopics = ({
   onTooltipPresented,
   style,
   tooltips,
+  tooltipDisplayedInView,
   topics,
 }) => (
   <Context.Consumer>
@@ -44,6 +47,7 @@ const ArticleTopics = ({
       return (
         <View style={[styles.topicGroup, style]}>
           {renderArticleTopics(
+            tooltipDisplayedInView,
             tooltips,
             topics,
             onPress,

--- a/packages/tooltip/__tests__/shared.js
+++ b/packages/tooltip/__tests__/shared.js
@@ -165,7 +165,7 @@ export default () => {
       );
     });
 
-    it("onTooltipPresented is called correctly", async () => {
+    it("onTooltipPresented is called correctly on Viewport Enter", async () => {
       const onTooltipPresentedMock = jest.fn();
 
       const testInstance = shallow(
@@ -179,6 +179,23 @@ export default () => {
         </Tooltip>,
       );
       testInstance.children().at(0).props().onViewportEnter();
+      expect(onTooltipPresentedMock).toBeCalled();
+    });
+
+    it("onTooltipPresented is called correctly if tooltip is displayed in view", async () => {
+      const onTooltipPresentedMock = jest.fn();
+
+      shallow(
+        <Tooltip
+          content={<Text>foo</Text>}
+          displayedInView={true}
+          onTooltipPresented={onTooltipPresentedMock}
+          type="testtype"
+          tooltips={["testtype"]}
+        >
+          bar
+        </Tooltip>,
+      );
       expect(onTooltipPresentedMock).toBeCalled();
     });
 

--- a/packages/tooltip/tooltip.tsx
+++ b/packages/tooltip/tooltip.tsx
@@ -8,6 +8,7 @@ import generateStyles from "./styles";
 interface Props {
   arrowOffset?: number;
   content: string;
+  displayedInView: boolean;
   offsetX?: number;
   offsetY?: number;
   onClose?: <T = unknown, R = unknown>(args?: T) => R;
@@ -22,6 +23,7 @@ const Tooltip: React.FC<Props> = ({
   arrowOffset = 20,
   content,
   children,
+  displayedInView = false,
   offsetX = 0,
   offsetY = 0,
   onClose,
@@ -44,7 +46,6 @@ const Tooltip: React.FC<Props> = ({
   });
 
   const onClosePress = () => {
-    console.log("closing");
     onClose && onClose();
     Animated.timing(opacity, {
       duration: 200,
@@ -59,6 +60,10 @@ const Tooltip: React.FC<Props> = ({
       <View style={styles.crossDiagonal2} />
     </TouchableOpacity>
   );
+
+  if (displayedInView && onTooltipPresented) {
+    onTooltipPresented(type);
+  }
 
   return (
     <View style={styles.wrapper}>


### PR DESCRIPTION
- The `Viewport` component being used to fire the `onTooltipPresented` callback does not work when not within either a `FlatList`, `ScrollView` or `SectionList` see: https://netcetera.gitbooks.io/skele/content/packages/components/. 
- As the Comment tablet template has a left column that does not use one of these components but is always initially displayed to the user we can fire the `onTooltipPresented` callback straight away in for topics and byline tooltips on this template.
- `Tooltip` component now takes an additional `displayedInView` boolean. (I couldn't think of a nicer name).
