### PR TITLE
fix: (TNLT-2130) remove caption under main standard lead image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # times-components-native [![circleci][circleci-image]][circleci-url]
 
-Home of The Times' `react native` components used in the mobile and tablet apps.
+Home of The Times' React Native components used in the mobile and tablet apps.
 
 ## Table of Contents
 

--- a/packages/article-magazine-standard/src/article-magazine-standard.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.js
@@ -1,6 +1,5 @@
 /* eslint-disable consistent-return */
-
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import { View } from "react-native";
 import ArticleError from "@times-components-native/article-error";
 import ArticleSkeleton from "@times-components-native/article-skeleton";

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -140,7 +140,6 @@ exports[`1. article main standard - tablet 1`] = `
         }
       >
         <ModalImage />
-        <Caption />
       </View>
     </View>
   </View>

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -12,15 +12,6 @@ exports[`full article with style on mobile 1`] = `
         }
       >
         <ModalImage />
-        <Caption
-          style={
-            Object {
-              "container": Object {
-                "paddingHorizontal": 10,
-              },
-            }
-          }
-        />
       </View>
     </View>
     <View
@@ -281,7 +272,6 @@ exports[`full article with style on tablet 1`] = `
         }
       >
         <ModalImage />
-        <Caption />
       </View>
     </View>
   </View>

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -18,10 +18,6 @@ exports[`1. an article 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
-        <Caption
-          credits="Some Credits"
-          text="Some Caption"
-        />
       </View>
     </View>
     <View>
@@ -191,10 +187,6 @@ exports[`6. an article with no byline 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
-        <Caption
-          credits="Some Credits"
-          text="Some Caption"
-        />
       </View>
     </View>
     <View>
@@ -266,10 +258,6 @@ exports[`7. an article with no label 1`] = `
           index={0}
           onImagePress={null}
           uri="https://crop169.io"
-        />
-        <Caption
-          credits="Some Credits"
-          text="Some Caption"
         />
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -140,7 +140,6 @@ exports[`1. article main standard - tablet 1`] = `
         }
       >
         <ModalImage />
-        <Caption />
       </View>
     </View>
   </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -12,15 +12,6 @@ exports[`full article with style on mobile 1`] = `
         }
       >
         <ModalImage />
-        <Caption
-          style={
-            Object {
-              "container": Object {
-                "paddingHorizontal": 10,
-              },
-            }
-          }
-        />
       </View>
     </View>
     <View
@@ -281,7 +272,6 @@ exports[`full article with style on tablet 1`] = `
         }
       >
         <ModalImage />
-        <Caption />
       </View>
     </View>
   </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -18,10 +18,6 @@ exports[`1. an article 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
-        <Caption
-          credits="Some Credits"
-          text="Some Caption"
-        />
       </View>
     </View>
     <View>
@@ -191,10 +187,6 @@ exports[`6. an article with no byline 1`] = `
           onImagePress={null}
           uri="https://crop169.io"
         />
-        <Caption
-          credits="Some Credits"
-          text="Some Caption"
-        />
       </View>
     </View>
     <View>
@@ -266,10 +258,6 @@ exports[`7. an article with no label 1`] = `
           index={0}
           onImagePress={null}
           uri="https://crop169.io"
-        />
-        <Caption
-          credits="Some Credits"
-          text="Some Caption"
         />
       </View>
     </View>

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -12,7 +12,6 @@ import {
   getStandardTemplateCrop,
 } from "@times-components-native/utils";
 import { tabletWidth } from "@times-components-native/styleguide";
-import Caption from "@times-components-native/caption";
 import Context from "@times-components-native/context";
 import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
@@ -61,12 +60,6 @@ class ArticlePage extends Component {
                 getImageCrop={getStandardTemplateCrop}
                 onImagePress={onImagePress}
                 onVideoPress={onVideoPress}
-                renderCaption={({ caption }) => (
-                  <Caption
-                    {...caption}
-                    style={!isTablet && { container: styles.captionContainer }}
-                  />
-                )}
                 style={[styles.leadAsset, isTablet && styles.leadAssetTablet]}
                 width={Math.min(parentProps.width, tabletWidth)}
               />


### PR DESCRIPTION
- DO NOT MERGE: This is a test for circleCI !

- https://nidigitalsolutions.jira.com/browse/TNLT-2130
- Remove caption under the lead image in the main standard template

Before:
![Screenshot_1606932009](https://user-images.githubusercontent.com/5861100/100912444-622aae80-34c8-11eb-98e1-d65966176310.png)
![Simulator Screen Shot - iPhone 12 - 2020-12-02 at 18 00 39](https://user-images.githubusercontent.com/5861100/100912548-81294080-34c8-11eb-906c-e97b7b7dc5bd.png)


After:
![Screenshot_1606931305](https://user-images.githubusercontent.com/5861100/100912494-7373bb00-34c8-11eb-800f-e6b22d7eb312.png)
<img width="502" alt="Screenshot 2020-12-02 at 17 31 01" src="https://user-images.githubusercontent.com/5861100/100909566-cea3ae80-34c4-11eb-91ab-80f7be802d78.png">

