### PR TITLE
chore: Fix max tablet width

### DIFF
--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -140,7 +140,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
     Object {
       "marginBottom": 10,
       "marginHorizontal": "auto",
-      "maxWidth": 1194,
+      "maxWidth": 1366,
     }
   }
 >
@@ -217,7 +217,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
     Object {
       "marginBottom": 10,
       "marginHorizontal": "auto",
-      "maxWidth": 1194,
+      "maxWidth": 1366,
     }
   }
 >

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -138,7 +138,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
     Object {
       "marginBottom": 10,
       "marginHorizontal": "auto",
-      "maxWidth": 1194,
+      "maxWidth": 1366,
     }
   }
 >
@@ -214,7 +214,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
     Object {
       "marginBottom": 10,
       "marginHorizontal": "auto",
-      "maxWidth": 1194,
+      "maxWidth": 1366,
     }
   }
 >

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -8,7 +8,7 @@ exports[`1. article in depth - tablet 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -69,7 +69,7 @@ exports[`1. article in depth - tablet 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -481,7 +481,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -542,7 +542,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }
@@ -634,7 +634,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -696,7 +696,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }
@@ -788,7 +788,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -849,7 +849,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }

--- a/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -72,7 +72,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             text="Some Caption"
           />
         }
-        highResSize={1194}
+        highResSize={1366}
         index={0}
         onImagePress={null}
         uri="https://crop169.io"
@@ -159,7 +159,7 @@ exports[`4. an article with ads 1`] = `
             text="Some Caption"
           />
         }
-        highResSize={1194}
+        highResSize={1366}
         index={0}
         onImagePress={null}
         uri="https://crop169.io"

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-tablet.ios.test.js.snap
@@ -8,7 +8,7 @@ exports[`1. article in depth - tablet 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -69,7 +69,7 @@ exports[`1. article in depth - tablet 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -481,7 +481,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -542,7 +542,7 @@ exports[`tablet full article with style in the culture magazine 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }
@@ -634,7 +634,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -696,7 +696,7 @@ exports[`tablet full article with style in the style magazine 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }
@@ -788,7 +788,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
         "alignItems": "center",
         "alignSelf": "center",
         "backgroundColor": "rgba(60, 129, 190, 1)",
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "paddingBottom": 40,
         "paddingHorizontal": 20,
         "paddingTop": 45,
@@ -849,7 +849,7 @@ exports[`tablet full article with style in the sunday times magazine 1`] = `
       Object {
         "alignSelf": "center",
         "marginBottom": 0,
-        "maxWidth": 1194,
+        "maxWidth": 1366,
         "width": "100%",
       }
     }

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -72,7 +72,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             text="Some Caption"
           />
         }
-        highResSize={1194}
+        highResSize={1366}
         index={0}
         onImagePress={null}
         uri="https://crop169.io"
@@ -159,7 +159,7 @@ exports[`4. an article with ads 1`] = `
             text="Some Caption"
           />
         }
-        highResSize={1194}
+        highResSize={1366}
         index={0}
         onImagePress={null}
         uri="https://crop169.io"

--- a/packages/styleguide/src/breakpoints/index.shared.js
+++ b/packages/styleguide/src/breakpoints/index.shared.js
@@ -32,7 +32,7 @@ export default {
   huge: 1320,
   medium: 768,
   nativeTablet: 660,
-  nativeTabletWide: 1194,
+  nativeTabletWide: 1366,
   small: 520,
   wide: 1024,
 };


### PR DESCRIPTION
Seems we have the max tablet width currently set to `1194`. As far as I can tell this is because this is the landscape width for iPad Pro 11. However the iPad Pro 12.9 is `1366`  thus the PR

Before:
![Screenshot 2020-12-07 at 11 43 37](https://user-images.githubusercontent.com/5103512/101355484-86063f80-388e-11eb-8195-a44c0fdea257.png)

After:
![Screenshot 2020-12-07 at 11 29 09](https://user-images.githubusercontent.com/5103512/101355509-8e5e7a80-388e-11eb-918a-605845baa08a.png)
