### PR TITLE
fix: (TNLT-680) Android - author image appearing in small in modal in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "1.15.3",
+  "version": "2.0.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -10,6 +10,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
+        isAuthorImage={true}
         rounded={true}
         uri="https://image.io"
       />
@@ -70,6 +71,7 @@ exports[`4. an article with ads 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
+        isAuthorImage={true}
         rounded={true}
         uri="https://image.io"
       />

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -10,7 +10,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
-        isAuthorImage={true}
+        isSmallImage={true}
         rounded={true}
         uri="https://image.io"
       />
@@ -71,7 +71,7 @@ exports[`4. an article with ads 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
-        isAuthorImage={true}
+        isSmallImage={true}
         rounded={true}
         uri="https://image.io"
       />

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -10,6 +10,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
+        isAuthorImage={true}
         rounded={true}
         uri="https://image.io"
       />
@@ -70,6 +71,7 @@ exports[`4. an article with ads 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
+        isAuthorImage={true}
         rounded={true}
         uri="https://image.io"
       />

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -10,7 +10,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
-        isAuthorImage={true}
+        isSmallImage={true}
         rounded={true}
         uri="https://image.io"
       />
@@ -71,7 +71,7 @@ exports[`4. an article with ads 1`] = `
     <View>
       <ModalImage
         aspectRatio={1}
-        isAuthorImage={true}
+        isSmallImage={true}
         rounded={true}
         uri="https://image.io"
       />

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -37,7 +37,7 @@ const ArticleHeader = ({
           uri={authorImage}
           onImagePress={onImagePress ? () => onImagePress(0) : undefined}
           rounded
-          isAuthorImage
+          isSmallImage
         />
         <Label isVideo={hasVideo} label={label} />
         <Text

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -37,6 +37,7 @@ const ArticleHeader = ({
           uri={authorImage}
           onImagePress={onImagePress ? () => onImagePress(0) : undefined}
           rounded
+          isAuthorImage
         />
         <Label isVideo={hasVideo} label={label} />
         <Text

--- a/packages/image/src/modal-image/modal-image-prop-types.js
+++ b/packages/image/src/modal-image/modal-image-prop-types.js
@@ -6,6 +6,7 @@ export const modalPropTypes = {
   caption: PropTypes.node,
   onImagePress: PropTypes.func,
   show: PropTypes.bool,
+  isAuthorImage: PropTypes.bool,
 };
 
 export const modalDefaultProps = {
@@ -13,4 +14,5 @@ export const modalDefaultProps = {
   caption: null,
   onImagePress: null,
   show: false,
+  isAuthorImage: false,
 };

--- a/packages/image/src/modal-image/modal-image-prop-types.js
+++ b/packages/image/src/modal-image/modal-image-prop-types.js
@@ -6,7 +6,7 @@ export const modalPropTypes = {
   caption: PropTypes.node,
   onImagePress: PropTypes.func,
   show: PropTypes.bool,
-  isAuthorImage: PropTypes.bool,
+  isSmallImage: PropTypes.bool,
 };
 
 export const modalDefaultProps = {
@@ -14,5 +14,5 @@ export const modalDefaultProps = {
   caption: null,
   onImagePress: null,
   show: false,
-  isAuthorImage: false,
+  isSmallImage: false,
 };

--- a/packages/image/src/modal-image/modal-image.js
+++ b/packages/image/src/modal-image/modal-image.js
@@ -60,8 +60,7 @@ class ModalImage extends Component {
       onImagePress,
       images = [],
       uri,
-      isAuthorImage,
-      rounded,
+      isSmallImage,
     } = this.props;
 
     if (onImagePress) {
@@ -125,8 +124,8 @@ class ModalImage extends Component {
                             uri={onlineUrl.toString()}
                             fill
                             style={
-                              isAuthorImage
-                                ? styles.modalAuthorImage
+                              isSmallImage
+                                ? styles.modalSmallImage
                                 : this.props.styles
                             }
                           />

--- a/packages/image/src/modal-image/modal-image.js
+++ b/packages/image/src/modal-image/modal-image.js
@@ -54,7 +54,16 @@ class ModalImage extends Component {
   }
 
   render() {
-    const { highResSize, index, onImagePress, images = [], uri } = this.props;
+    const {
+      highResSize,
+      index,
+      onImagePress,
+      images = [],
+      uri,
+      isAuthorImage,
+      rounded,
+    } = this.props;
+
     if (onImagePress) {
       return (
         <Button onPress={() => onImagePress(index)}>
@@ -115,6 +124,11 @@ class ModalImage extends Component {
                             {...this.props}
                             uri={onlineUrl.toString()}
                             fill
+                            style={
+                              isAuthorImage
+                                ? styles.modalAuthorImage
+                                : this.props.styles
+                            }
                           />
                         </View>
                       );

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -95,6 +95,11 @@ const styles = {
     position: "absolute",
     overflow: "hidden",
   },
+  modalAuthorImage: {
+    backgroundColor: colours.functional.modalBackground,
+    width: "100%",
+    height: "100%",
+  },
 };
 
 export const captionStyles = {

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -95,7 +95,7 @@ const styles = {
     position: "absolute",
     overflow: "hidden",
   },
-  modalAuthorImage: {
+  modalSmallImage: {
     backgroundColor: colours.functional.modalBackground,
     width: "100%",
     height: "100%",


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/TNLT-680
- Display author image in the appropriate size on Android

Before:
![Screenshot_1607603468](https://user-images.githubusercontent.com/5861100/101778464-cadae200-3aeb-11eb-81b0-f79a3229284e.png)

After:
![Screenshot_1607607036](https://user-images.githubusercontent.com/5861100/101778540-e6de8380-3aeb-11eb-9bdb-13f07979c916.png)
