### PR TITLE
fix (TNLT-6233): fixes webview issue on android

### DIFF
--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -103,7 +103,9 @@ class DOMContext extends PureComponent {
 
   outViewport = () => {
     this.isVisible = false;
-    this.webView.injectJavaScript(`
+
+    if (this.webView) {
+      this.webView.injectJavaScript(`
         if (typeof unrulyViewportStatus === "function") {
           unrulyViewportStatus(${JSON.stringify({
             ...this.deviceInfo,
@@ -111,6 +113,7 @@ class DOMContext extends PureComponent {
           })});
         };
       `);
+    }
   };
 
   loadAd = () => {
@@ -121,7 +124,9 @@ class DOMContext extends PureComponent {
 
   inViewport = () => {
     this.isVisible = true;
-    this.webView.injectJavaScript(`
+
+    if (this.webView) {
+      this.webView.injectJavaScript(`
           if (typeof unrulyViewportStatus === "function") {
             unrulyViewportStatus(${JSON.stringify({
               ...this.deviceInfo,
@@ -129,6 +134,7 @@ class DOMContext extends PureComponent {
             })})
           };
         `);
+    }
   };
 
   render() {


### PR DESCRIPTION
Fixes an issue on the android mobile apps, whereby we try to inject javascript into a webview that hasn't loaded yet.

```
TypeError: Cannot read property 'injectJavaScript' of undefined, js engine: v8, stack: Object.S.n.inViewport [as onViewportEnter]@587.js:1:2573 O.o._checkViewportEnterOrLeave@596.js:1:1929 O._onViewportChange@596.js:1:1765 <unknown>@595.js:1:3004 Array.forEach@-1 w.M.<computed> [as notifyViewportListeners]@595.js:1:2977 w.f._onViewportChange@594.js:1:1642 Object.f._onScroll [as onScroll]@594.js:1:1466 y.scrollResponderHandleScroll@279.js:1:2281 n._handleScroll@273.js:1:3371
```