### PR TITLE
fix: (TNLT-995) Add image placeholders for offline use (iOS)

### DIFF
--- a/packages/article-comment-tablet/src/article-left-column/article-left-column.js
+++ b/packages/article-comment-tablet/src/article-left-column/article-left-column.js
@@ -9,6 +9,7 @@ import styles from "../styles";
 import Image from "@times-components-native/image";
 import ArticleTopics from "@times-components-native/article-topics";
 import articleLeftColumnPropTypes from "./article-left-column-prop-types";
+import { Placeholder } from "@times-components-native/image";
 
 const ArticleLeftColumn = ({
   authorImage,
@@ -21,7 +22,11 @@ const ArticleLeftColumn = ({
 }) => (
   <View style={styles.leftColumnContainer}>
     <View style={styles.authorContainer}>
-      <Image aspectRatio={1} uri={authorImage} rounded />
+      {authorImage !== "" ? (
+        <Image aspectRatio={1} uri={authorImage} rounded />
+      ) : (
+        <Placeholder />
+      )}
       {hasBylineData(bylines) && (
         <View style={styles.bylines}>
           <ArticleBylineWithLinks

--- a/packages/article-error/__tests__/android/__snapshots__/article-error-style.test.js.snap
+++ b/packages/article-error/__tests__/android/__snapshots__/article-error-style.test.js.snap
@@ -17,6 +17,11 @@ exports[`renders correctly with style 1`] = `
       <View>
         <Image
           accessibilityLabel="Error Cartoon"
+          defaultSource={
+            Object {
+              "testUri": "../../../packages/image/assets/t.png",
+            }
+          }
           resizeMode="contain"
           source={
             Object {

--- a/packages/article-error/__tests__/ios/__snapshots__/article-error-style.test.js.snap
+++ b/packages/article-error/__tests__/ios/__snapshots__/article-error-style.test.js.snap
@@ -17,6 +17,11 @@ exports[`renders correctly with style 1`] = `
       <View>
         <Image
           accessibilityLabel="Error Cartoon"
+          defaultSource={
+            Object {
+              "testUri": "../../../packages/image/assets/t.png",
+            }
+          }
           resizeMode="contain"
           source={
             Object {

--- a/packages/article-error/src/article-error.js
+++ b/packages/article-error/src/article-error.js
@@ -17,6 +17,7 @@ const ArticleError = ({ buttonText, refetch, title, message }) => (
           resizeMode="contain"
           source={errorImage}
           style={[styles.errorImageContainer, { height: 270, width: 240 }]}
+          defaultSource={require("../../image/assets/t.png")}
         />
 
         <Text style={styles.errorHeading}>{title}</Text>

--- a/packages/article-image/src/article-image.base.js
+++ b/packages/article-image/src/article-image.base.js
@@ -6,6 +6,7 @@ import { ModalImage } from "@times-components-native/image";
 import InsetCaption from "./inset-caption";
 import InlineImage from "./inline-image";
 import FullWidthCaption from "./fullwidth-caption";
+import { Placeholder } from "@times-components-native/image";
 import { propTypes, defaultPropTypes } from "./article-image-prop-types";
 import styles from "./styles";
 
@@ -73,6 +74,10 @@ const ArticleImage = ({
   const { caption, credits } = captionOptions;
 
   if (display === "inline") {
+    if (!uri || uri === "") {
+      return <Placeholder />;
+    }
+
     return (
       <InlineImage
         captionOptions={captionOptions}

--- a/packages/article-skeleton/__tests__/android/__snapshots__/inline-newsletter-puff.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/inline-newsletter-puff.test.js.snap
@@ -856,10 +856,6 @@ exports[`Inline Newsletter Puff renders the success view after subscribing:  med
                     "backgroundColor": "transparent",
                     "borderWidth": 0,
                   },
-                  undefined,
-                  Object {
-                    "opacity": 1,
-                  },
                   Object {
                     "flex": 0,
                     "height": 12,
@@ -871,132 +867,17 @@ exports[`Inline Newsletter Puff renders the success view after subscribing:  med
               vbWidth={60}
               width={7}
             >
-              <RNSVGGroup
-                fill={
-                  Array [
-                    0,
-                    -16777216,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                font={Object {}}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
-                propList={Array []}
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={null}
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={0}
-                strokeLinejoin={0}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth={1}
-                vectorEffect={0}
-                x={0}
-                y={0}
-              >
+              <RNSVGGroup>
                 <RNSVGGroup
-                  fill={
-                    Array [
-                      0,
-                      -16750951,
-                    ]
-                  }
-                  fillOpacity={1}
-                  fillRule={1}
-                  font={Object {}}
-                  matrix={
-                    Array [
-                      1,
-                      0,
-                      0,
-                      1,
-                      0,
-                      0,
-                    ]
-                  }
-                  opacity={1}
-                  originX={0}
-                  originY={0}
+                  fill={-16750951}
                   propList={
                     Array [
                       "fill",
                     ]
                   }
-                  rotation={0}
-                  scaleX={1}
-                  scaleY={1}
-                  skewX={0}
-                  skewY={0}
-                  stroke={null}
-                  strokeDasharray={null}
-                  strokeDashoffset={null}
-                  strokeLinecap={0}
-                  strokeLinejoin={0}
-                  strokeMiterlimit={4}
-                  strokeOpacity={1}
-                  strokeWidth={1}
-                  vectorEffect={0}
-                  x={0}
-                  y={0}
                 >
                   <RNSVGPath
                     d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
-                    fill={
-                      Array [
-                        0,
-                        -16777216,
-                      ]
-                    }
-                    fillOpacity={1}
-                    fillRule={1}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
                   />
                 </RNSVGGroup>
               </RNSVGGroup>
@@ -1118,10 +999,6 @@ exports[`Inline Newsletter Puff renders the success view after subscribing:  sma
                     "backgroundColor": "transparent",
                     "borderWidth": 0,
                   },
-                  undefined,
-                  Object {
-                    "opacity": 1,
-                  },
                   Object {
                     "flex": 0,
                     "height": 12,
@@ -1133,132 +1010,17 @@ exports[`Inline Newsletter Puff renders the success view after subscribing:  sma
               vbWidth={60}
               width={7}
             >
-              <RNSVGGroup
-                fill={
-                  Array [
-                    0,
-                    -16777216,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                font={Object {}}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
-                propList={Array []}
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={null}
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={0}
-                strokeLinejoin={0}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth={1}
-                vectorEffect={0}
-                x={0}
-                y={0}
-              >
+              <RNSVGGroup>
                 <RNSVGGroup
-                  fill={
-                    Array [
-                      0,
-                      -16750951,
-                    ]
-                  }
-                  fillOpacity={1}
-                  fillRule={1}
-                  font={Object {}}
-                  matrix={
-                    Array [
-                      1,
-                      0,
-                      0,
-                      1,
-                      0,
-                      0,
-                    ]
-                  }
-                  opacity={1}
-                  originX={0}
-                  originY={0}
+                  fill={-16750951}
                   propList={
                     Array [
                       "fill",
                     ]
                   }
-                  rotation={0}
-                  scaleX={1}
-                  scaleY={1}
-                  skewX={0}
-                  skewY={0}
-                  stroke={null}
-                  strokeDasharray={null}
-                  strokeDashoffset={null}
-                  strokeLinecap={0}
-                  strokeLinejoin={0}
-                  strokeMiterlimit={4}
-                  strokeOpacity={1}
-                  strokeWidth={1}
-                  vectorEffect={0}
-                  x={0}
-                  y={0}
                 >
                   <RNSVGPath
                     d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
-                    fill={
-                      Array [
-                        0,
-                        -16777216,
-                      ]
-                    }
-                    fillOpacity={1}
-                    fillRule={1}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
                   />
                 </RNSVGGroup>
               </RNSVGGroup>
@@ -1388,10 +1150,6 @@ exports[`Inline Newsletter Puff renders the success view after subscribing:  wid
                     "backgroundColor": "transparent",
                     "borderWidth": 0,
                   },
-                  undefined,
-                  Object {
-                    "opacity": 1,
-                  },
                   Object {
                     "flex": 0,
                     "height": 12,
@@ -1403,132 +1161,17 @@ exports[`Inline Newsletter Puff renders the success view after subscribing:  wid
               vbWidth={60}
               width={7}
             >
-              <RNSVGGroup
-                fill={
-                  Array [
-                    0,
-                    -16777216,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                font={Object {}}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
-                propList={Array []}
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={null}
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={0}
-                strokeLinejoin={0}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth={1}
-                vectorEffect={0}
-                x={0}
-                y={0}
-              >
+              <RNSVGGroup>
                 <RNSVGGroup
-                  fill={
-                    Array [
-                      0,
-                      -16750951,
-                    ]
-                  }
-                  fillOpacity={1}
-                  fillRule={1}
-                  font={Object {}}
-                  matrix={
-                    Array [
-                      1,
-                      0,
-                      0,
-                      1,
-                      0,
-                      0,
-                    ]
-                  }
-                  opacity={1}
-                  originX={0}
-                  originY={0}
+                  fill={-16750951}
                   propList={
                     Array [
                       "fill",
                     ]
                   }
-                  rotation={0}
-                  scaleX={1}
-                  scaleY={1}
-                  skewX={0}
-                  skewY={0}
-                  stroke={null}
-                  strokeDasharray={null}
-                  strokeDashoffset={null}
-                  strokeLinecap={0}
-                  strokeLinejoin={0}
-                  strokeMiterlimit={4}
-                  strokeOpacity={1}
-                  strokeWidth={1}
-                  vectorEffect={0}
-                  x={0}
-                  y={0}
                 >
                   <RNSVGPath
                     d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
-                    fill={
-                      Array [
-                        0,
-                        -16777216,
-                      ]
-                    }
-                    fillOpacity={1}
-                    fillRule={1}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
                   />
                 </RNSVGGroup>
               </RNSVGGroup>

--- a/packages/article-skeleton/__tests__/android/__snapshots__/newsletter-puff-link.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/newsletter-puff-link.test.js.snap
@@ -62,10 +62,6 @@ exports[`NewsletterPuffLink renders the link with the text \`Manage preferences 
               "backgroundColor": "transparent",
               "borderWidth": 0,
             },
-            undefined,
-            Object {
-              "opacity": 1,
-            },
             Object {
               "flex": 0,
               "height": 12,
@@ -77,132 +73,17 @@ exports[`NewsletterPuffLink renders the link with the text \`Manage preferences 
         vbWidth={60}
         width={7}
       >
-        <RNSVGGroup
-          fill={
-            Array [
-              0,
-              -16777216,
-            ]
-          }
-          fillOpacity={1}
-          fillRule={1}
-          font={Object {}}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
-          propList={Array []}
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
-        >
+        <RNSVGGroup>
           <RNSVGGroup
-            fill={
-              Array [
-                0,
-                -16750951,
-              ]
-            }
-            fillOpacity={1}
-            fillRule={1}
-            font={Object {}}
-            matrix={
-              Array [
-                1,
-                0,
-                0,
-                1,
-                0,
-                0,
-              ]
-            }
-            opacity={1}
-            originX={0}
-            originY={0}
+            fill={-16750951}
             propList={
               Array [
                 "fill",
               ]
             }
-            rotation={0}
-            scaleX={1}
-            scaleY={1}
-            skewX={0}
-            skewY={0}
-            stroke={null}
-            strokeDasharray={null}
-            strokeDashoffset={null}
-            strokeLinecap={0}
-            strokeLinejoin={0}
-            strokeMiterlimit={4}
-            strokeOpacity={1}
-            strokeWidth={1}
-            vectorEffect={0}
-            x={0}
-            y={0}
           >
             <RNSVGPath
               d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
-              fill={
-                Array [
-                  0,
-                  -16777216,
-                ]
-              }
-              fillOpacity={1}
-              fillRule={1}
-              matrix={
-                Array [
-                  1,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                ]
-              }
-              opacity={1}
-              originX={0}
-              originY={0}
-              propList={Array []}
-              rotation={0}
-              scaleX={1}
-              scaleY={1}
-              skewX={0}
-              skewY={0}
-              stroke={null}
-              strokeDasharray={null}
-              strokeDashoffset={null}
-              strokeLinecap={0}
-              strokeLinejoin={0}
-              strokeMiterlimit={4}
-              strokeOpacity={1}
-              strokeWidth={1}
-              vectorEffect={0}
-              x={0}
-              y={0}
             />
           </RNSVGGroup>
         </RNSVGGroup>

--- a/packages/author-profile/src/author-profile-head-image.js
+++ b/packages/author-profile/src/author-profile-head-image.js
@@ -1,17 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Image from "@times-components-native/image";
+import { Placeholder } from "@times-components-native/image";
 import styles from "./styles";
 
-const AuthorProfileHeadImage = ({ uri }) => (
-  <Image
-    aspectRatio={1}
-    style={styles.authorPhoto}
-    uri={uri}
-    rounded
-    accessibilityLabel="author-image"
-  />
-);
+const AuthorProfileHeadImage = ({ uri }) => {
+  return uri ? (
+    <Image
+      aspectRatio={1}
+      style={styles.authorPhoto}
+      uri={uri}
+      rounded
+      accessibilityLabel="author-image"
+    />
+  ) : (
+    <Placeholder />
+  );
+};
 
 AuthorProfileHeadImage.propTypes = {
   uri: PropTypes.string,

--- a/packages/icons/__tests__/android/__snapshots__/icons-colour.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons-colour.android.test.js.snap
@@ -2,54 +2,21 @@
 
 exports[`1. iconemail renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
       fill={null}
-      stroke={null}
     >
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            -4671304,
-          ]
-        }
-        stroke={null}
+        fill={-4671304}
       />
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            -1,
-          ]
-        }
-        stroke={null}
+        fill={-1}
       />
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            -3355444,
-          ]
-        }
-        stroke={null}
+        fill={-3355444}
       />
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            -4013374,
-          ]
-        }
-        stroke={null}
+        fill={-4013374}
       />
     </RNSVGGroup>
   </RNSVGGroup>
@@ -58,38 +25,12 @@ exports[`1. iconemail renders with different colours 1`] = `
 
 exports[`2. iconfacebook renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     >
-      <RNSVGPath
-        fill={
-          Array [
-            0,
-            -16777216,
-          ]
-        }
-        stroke={null}
-      />
+      <RNSVGPath />
     </RNSVGGroup>
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -97,33 +38,11 @@ exports[`2. iconfacebook renders with different colours 1`] = `
 
 exports[`3. iconforwardarrow renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={null}
+      fill={-341282}
     >
-      <RNSVGPath
-        fill={
-          Array [
-            0,
-            -16777216,
-          ]
-        }
-        stroke={null}
-      />
+      <RNSVGPath />
     </RNSVGGroup>
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -131,28 +50,10 @@ exports[`3. iconforwardarrow renders with different colours 1`] = `
 
 exports[`4. iconstar renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -160,28 +61,10 @@ exports[`4. iconstar renders with different colours 1`] = `
 
 exports[`5. iconcopylink renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -189,28 +72,10 @@ exports[`5. iconcopylink renders with different colours 1`] = `
 
 exports[`6. iconsavebookmark renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -218,28 +83,10 @@ exports[`6. iconsavebookmark renders with different colours 1`] = `
 
 exports[`7. icontwitter renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -247,42 +94,14 @@ exports[`7. icontwitter renders with different colours 1`] = `
 
 exports[`8. iconvideo renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGRect
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -290,28 +109,10 @@ exports[`8. iconvideo renders with different colours 1`] = `
 
 exports[`9. iconvideo360player renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -319,28 +120,10 @@ exports[`9. iconvideo360player renders with different colours 1`] = `
 
 exports[`10. thestlogo renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -348,28 +131,10 @@ exports[`10. thestlogo renders with different colours 1`] = `
 
 exports[`11. thetimeslogo renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -341282,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -4128786,
-        ]
-      }
+      fill={-341282}
+      stroke={-4128786}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -377,28 +142,10 @@ exports[`11. thetimeslogo renders with different colours 1`] = `
 
 exports[`12. closeicon renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGPath
-      fill={
-        Array [
-          0,
-          -1,
-        ]
-      }
-      stroke={
-        Array [
-          0,
-          -1,
-        ]
-      }
+      fill={-1}
+      stroke={-1}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/packages/icons/__tests__/android/__snapshots__/icons-dim.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons-dim.android.test.js.snap
@@ -9,7 +9,6 @@ exports[`1. iconemail sets a width when height is set 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="Email icon"
@@ -34,7 +33,6 @@ exports[`2. iconfacebook sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 25,
     }
   }
@@ -62,7 +60,6 @@ exports[`3. iconforwardarrow sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 29,
     }
   }
@@ -90,7 +87,6 @@ exports[`4. iconstar sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 50,
     }
   }
@@ -119,7 +115,6 @@ exports[`5. iconcopylink sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 15,
     }
   }
@@ -148,7 +143,6 @@ exports[`6. iconsavebookmark sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 12,
     }
   }
@@ -177,7 +171,6 @@ exports[`7. icontwitter sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 62,
     }
   }
@@ -206,7 +199,6 @@ exports[`8. iconvideo sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 85,
     }
   }
@@ -235,7 +227,6 @@ exports[`9. iconvideo360player sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 54,
     }
   }
@@ -264,7 +255,6 @@ exports[`10. thestlogo sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 50,
     }
   }
@@ -293,7 +283,6 @@ exports[`11. thetimeslogo sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 50,
     }
   }
@@ -322,7 +311,6 @@ exports[`12. closeicon sets a width when height is set 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 50,
-      "opacity": 1,
       "width": 28,
     }
   }

--- a/packages/icons/__tests__/android/__snapshots__/icons.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons.android.test.js.snap
@@ -8,267 +8,57 @@ exports[`1. iconemail renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconEmail"
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
       fill={null}
-      fillOpacity={1}
       fillRule={0}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
           "fillRule",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     >
       <RNSVGPath
         d="2dca68e6b455fb04a2975586f95f2052"
-        fill={
-          Array [
-            0,
-            -4671304,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={-4671304}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="d08f2857f91d1cb7ade3298227eeb176"
-        fill={
-          Array [
-            0,
-            -1,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={-1}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="59952cd14b0c0c6204892147f26f685a"
-        fill={
-          Array [
-            0,
-            -3355444,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={-3355444}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="27656d0344be367be22064a8124ce9dc"
-        fill={
-          Array [
-            0,
-            -4013374,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={-4013374}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
     </RNSVGGroup>
   </RNSVGGroup>
@@ -289,7 +79,6 @@ exports[`2. iconfacebook renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconFacebook"
@@ -297,130 +86,19 @@ exports[`2. iconfacebook renders 1`] = `
   vbWidth={10.592460632324219}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
-      fill={
-        Array [
-          0,
-          -14869221,
-        ]
-      }
-      fillOpacity={1}
+      fill={-14869221}
       fillRule={1}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
           "fillRule",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     >
       <RNSVGPath
         d="ff2ae287381fd0583b3a4df9bc45c5be"
-        fill={
-          Array [
-            0,
-            -16777216,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
     </RNSVGGroup>
   </RNSVGGroup>
@@ -440,136 +118,23 @@ exports[`3. iconforwardarrow renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   vbHeight={120}
   vbWidth={60}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
-      fill={
-        Array [
-          0,
-          -16750951,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-16750951}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     >
       <RNSVGPath
         d="cf23b8f47ac97eeec14ee4c65e472078"
-        fill={
-          Array [
-            0,
-            -16777216,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
     </RNSVGGroup>
   </RNSVGGroup>
@@ -590,7 +155,6 @@ exports[`4. iconstar renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconStar"
@@ -598,89 +162,15 @@ exports[`4. iconstar renders 1`] = `
   vbWidth={18}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="20db890d0ec5651ed550568cd37b5875"
-      fill={
-        Array [
-          0,
-          -16750951,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-16750951}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -704,7 +194,6 @@ exports[`5. iconcopylink renders 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 15,
-      "opacity": 1,
       "width": 20,
     }
   }
@@ -713,89 +202,15 @@ exports[`5. iconcopylink renders 1`] = `
   vbWidth={15}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="9caedb2f218a37cd4660f2ab42e9b771"
-      fill={
-        Array [
-          0,
-          -9868951,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-9868951}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -819,7 +234,6 @@ exports[`6. iconsavebookmark renders 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 16,
-      "opacity": 1,
       "width": 20,
     }
   }
@@ -828,89 +242,15 @@ exports[`6. iconsavebookmark renders 1`] = `
   vbWidth={12}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="25ee7ee33953337725fa0c3787ab3241"
-      fill={
-        Array [
-          0,
-          -9868951,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-9868951}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -930,7 +270,6 @@ exports[`7. icontwitter renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconTwitter"
@@ -938,89 +277,15 @@ exports[`7. icontwitter renders 1`] = `
   vbWidth={750}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="0407fd6a3edc199eb6063d0ebd2c66ad"
-      fill={
-        Array [
-          0,
-          -16750951,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-16750951}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -1040,7 +305,6 @@ exports[`8. iconvideo renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconVideo"
@@ -1048,134 +312,27 @@ exports[`8. iconvideo renders 1`] = `
   vbWidth={68}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGRect
-      fill={
-        Array [
-          0,
-          -14869221,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
+      fill={-14869221}
       height="40"
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
       width="50"
       x="0"
       y="0"
     />
     <RNSVGPath
       d="171e0421ab3c212b8bbf45e8c85e924b"
-      fill={
-        Array [
-          0,
-          -14869221,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-14869221}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -1195,7 +352,6 @@ exports[`9. iconvideo360player renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconVideo360Player"
@@ -1203,89 +359,15 @@ exports[`9. iconvideo360player renders 1`] = `
   vbWidth={108}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="92444cc628d352fe07031cfb7b426ccf"
-      fill={
-        Array [
-          0,
-          -16750951,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-16750951}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -1305,7 +387,6 @@ exports[`10. thestlogo renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="TheSTLogo"
@@ -1313,89 +394,15 @@ exports[`10. thestlogo renders 1`] = `
   vbWidth={29}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="0f4e958f2b4ff0e7612914c8ca56d8f6"
-      fill={
-        Array [
-          0,
-          -1,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-1}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -1415,7 +422,6 @@ exports[`11. thetimeslogo renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="TheTimesLogo"
@@ -1423,89 +429,15 @@ exports[`11. thetimeslogo renders 1`] = `
   vbWidth={20}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="9d34e249e9f10c48ae181fd7ef01d8e7"
-      fill={
-        Array [
-          0,
-          -1,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-1}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>
@@ -1529,7 +461,6 @@ exports[`12. closeicon renders 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 28,
-      "opacity": 1,
       "width": 20,
     }
   }
@@ -1538,95 +469,17 @@ exports[`12. closeicon renders 1`] = `
   vbWidth={28}
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGPath
       d="e47f4fab4bd751d2d3ea1eb7a66c492a"
-      fill={
-        Array [
-          0,
-          -1,
-        ]
-      }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
+      fill={-1}
       propList={
         Array [
           "fill",
           "stroke",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={
-        Array [
-          0,
-          -1,
-        ]
-      }
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
+      stroke={-1}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/packages/icons/__tests__/ios/__snapshots__/icons-colour.ios.test.js.snap
+++ b/packages/icons/__tests__/ios/__snapshots__/icons-colour.ios.test.js.snap
@@ -2,54 +2,21 @@
 
 exports[`1. iconemail renders with different colours 1`] = `
 <RNSVGSvgView>
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        4278190080,
-      ]
-    }
-    stroke={null}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
       fill={null}
-      stroke={null}
     >
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            4290295992,
-          ]
-        }
-        stroke={null}
+        fill={4290295992}
       />
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            4294967295,
-          ]
-        }
-        stroke={null}
+        fill={4294967295}
       />
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            4291611852,
-          ]
-        }
-        stroke={null}
+        fill={4291611852}
       />
       <RNSVGPath
-        fill={
-          Array [
-            0,
-            4290953922,
-          ]
-        }
-        stroke={null}
+        fill={4290953922}
       />
     </RNSVGGroup>
   </RNSVGGroup>

--- a/packages/icons/__tests__/ios/__snapshots__/icons-dim.ios.test.js.snap
+++ b/packages/icons/__tests__/ios/__snapshots__/icons-dim.ios.test.js.snap
@@ -9,7 +9,6 @@ exports[`1. iconemail sets a width when height is set 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="Email icon"

--- a/packages/icons/__tests__/ios/__snapshots__/icons.ios.test.js.snap
+++ b/packages/icons/__tests__/ios/__snapshots__/icons.ios.test.js.snap
@@ -8,267 +8,57 @@ exports[`1. iconemail renders 1`] = `
     Object {
       "backgroundColor": "transparent",
       "borderWidth": 0,
-      "opacity": 1,
     }
   }
   title="IconEmail"
   width={20}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        4278190080,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    originX={0}
-    originY={0}
-    propList={Array []}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
       fill={null}
-      fillOpacity={1}
       fillRule={0}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
           "fillRule",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     >
       <RNSVGPath
         d="2dca68e6b455fb04a2975586f95f2052"
-        fill={
-          Array [
-            0,
-            4290295992,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={4290295992}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="d08f2857f91d1cb7ade3298227eeb176"
-        fill={
-          Array [
-            0,
-            4294967295,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={4294967295}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="59952cd14b0c0c6204892147f26f685a"
-        fill={
-          Array [
-            0,
-            4291611852,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={4291611852}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="27656d0344be367be22064a8124ce9dc"
-        fill={
-          Array [
-            0,
-            4290953922,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        originX={0}
-        originY={0}
+        fill={4290953922}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
     </RNSVGGroup>
   </RNSVGGroup>

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -65,6 +65,20 @@ exports[`1. modal image 1`] = `
           }
         }
       />
+      <Image
+        defaultSource={
+          Object {
+            "testUri": "../../../packages/responsive-image/assets/t.png",
+          }
+        }
+        fadeDuration={0}
+        resizeMethod="resize"
+        source={
+          Object {
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&rel_width=1&rel_height=1&rel_vertical_offset=0&rel_horizontal_offset=0&offline=true&resize=1440",
+          }
+        }
+      />
     </View>
   </View>
 </View>
@@ -197,6 +211,20 @@ exports[`3. modal image with custom highressize 1`] = `
         source={
           Object {
             "testUri": "../../../packages/responsive-image/assets/t.png",
+          }
+        }
+      />
+      <Image
+        defaultSource={
+          Object {
+            "testUri": "../../../packages/responsive-image/assets/t.png",
+          }
+        }
+        fadeDuration={0}
+        resizeMethod="resize"
+        source={
+          Object {
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&rel_width=1&rel_height=1&rel_vertical_offset=0&rel_horizontal_offset=0&offline=true&resize=1440",
           }
         }
       />

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -131,6 +131,20 @@ exports[`1. modal image 1`] = `
           }
         }
       />
+      <Image
+        defaultSource={
+          Object {
+            "testUri": "../../../packages/responsive-image/assets/t.png",
+          }
+        }
+        fadeDuration={0}
+        resizeMethod="resize"
+        source={
+          Object {
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&rel_width=1&rel_height=1&rel_vertical_offset=0&rel_horizontal_offset=0&offline=true&resize=1440",
+          }
+        }
+      />
     </View>
   </View>
 </View>
@@ -395,6 +409,20 @@ exports[`3. modal image with custom highressize 1`] = `
         source={
           Object {
             "testUri": "../../../packages/responsive-image/assets/t.png",
+          }
+        }
+      />
+      <Image
+        defaultSource={
+          Object {
+            "testUri": "../../../packages/responsive-image/assets/t.png",
+          }
+        }
+        fadeDuration={0}
+        resizeMethod="resize"
+        source={
+          Object {
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&rel_width=1&rel_height=1&rel_vertical_offset=0&rel_horizontal_offset=0&offline=true&resize=1440",
           }
         }
       />

--- a/packages/image/src/lazy-loading-image/lazy-loading-image.js
+++ b/packages/image/src/lazy-loading-image/lazy-loading-image.js
@@ -33,9 +33,10 @@ const LazyLoadingImage = (props) => {
           {...props}
           resizeMode={fill ? "cover" : "center"}
           source={{ uri: appendParamsToQuery(source.uri, queryObject) }}
+          defaultSource={require("../../assets/t.png")}
         />
       ) : null}
-      <Image {...props} />
+      <Image {...props} defaultSource={require("../../assets/t.png")} />
     </Fragment>
   );
 };

--- a/packages/image/src/styles/shared.js
+++ b/packages/image/src/styles/shared.js
@@ -81,6 +81,8 @@ const styles = {
     width: "100%",
   },
   placeholder: {
+    zIndex: 999,
+    elevation: 5,
     alignItems: "center",
     backgroundColor: colours.functional.backgroundSecondary,
     justifyContent: "center",

--- a/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
+++ b/packages/message-bar/__tests__/android/__snapshots__/message-bar.test.js.snap
@@ -29,95 +29,17 @@ exports[`1. renders correctly 1`] = `
             vbWidth={28}
             width="28"
           >
-            <RNSVGGroup
-              fill={
-                Array [
-                  0,
-                  -16777216,
-                ]
-              }
-              fillOpacity={1}
-              fillRule={1}
-              matrix={
-                Array [
-                  1,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                ]
-              }
-              opacity={1}
-              originX={0}
-              originY={0}
-              rotation={0}
-              scaleX={1}
-              scaleY={1}
-              skewX={0}
-              skewY={0}
-              stroke={null}
-              strokeDasharray={null}
-              strokeDashoffset={null}
-              strokeLinecap={0}
-              strokeLinejoin={0}
-              strokeMiterlimit={4}
-              strokeOpacity={1}
-              strokeWidth={1}
-              vectorEffect={0}
-              x={0}
-              y={0}
-            >
+            <RNSVGGroup>
               <RNSVGPath
                 d="M15.617 14l4.683 5.838-.462.462L14 15.617 8.162 20.3l-.462-.462L12.383 14 7.7 8.162l.462-.462L14 12.383 19.838 7.7l.462.462z"
-                fill={
-                  Array [
-                    0,
-                    -1,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
+                fill={-1}
                 propList={
                   Array [
                     "fill",
                     "stroke",
                   ]
                 }
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    -1,
-                  ]
-                }
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={0}
-                strokeLinejoin={0}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth={1}
-                vectorEffect={0}
-                x={0}
-                y={0}
+                stroke={-1}
               />
             </RNSVGGroup>
           </RNSVGSvgView>

--- a/packages/responsive-image/__tests__/__snapshots__/image.test.tsx.snap
+++ b/packages/responsive-image/__tests__/__snapshots__/image.test.tsx.snap
@@ -45,7 +45,39 @@ exports[`Image gracefully handles bad high-res url 1`] = `
 </View>
 `;
 
-exports[`Image handles no uri 1`] = `null`;
+exports[`Image handles no uri 1`] = `
+<View
+  height="100%"
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#EDEDED",
+        "elevation": 5,
+        "justifyContent": "center",
+        "zIndex": 999,
+      },
+      0,
+    ]
+  }
+  width="100%"
+>
+  <Image
+    fadeDuration={0}
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../packages/image/assets/t.png",
+      }
+    }
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
+  />
+</View>
+`;
 
 exports[`Image loads high-res 1`] = `
 <View
@@ -60,26 +92,38 @@ exports[`Image loads high-res 1`] = `
   }
 >
   <Image
-    borderRadius={0}
-    fadeDuration={0}
-    onLoadEnd={[Function]}
-    source={
+    defaultSource={
       Object {
         "testUri": "../../../packages/responsive-image/assets/t.png",
       }
     }
+    fadeDuration={0}
+    onError={[Function]}
+    onLoadEnd={[Function]}
+    resizeMethod="resize"
+    source={
+      Object {
+        "uri": "http://foo.com/bar.png?rel_width=1&rel_height=1&rel_vertical_offset=0&rel_horizontal_offset=0&offline=true&resize=1024",
+      }
+    }
     style={
       Object {
-        "height": "100%",
-        "resizeMode": "center",
-        "width": 500,
+        "aspectRatio": undefined,
+        "borderRadius": 0,
+        "resizeMode": "cover",
+        "width": "100%",
       }
     }
   />
   <Image
+    defaultSource={
+      Object {
+        "testUri": "../../../packages/responsive-image/assets/t.png",
+      }
+    }
     fadeDuration={0}
     onError={[Function]}
-    onLoadEnd={[Function]}
+    onLoad={[Function]}
     resizeMethod="resize"
     source={
       Object {

--- a/packages/responsive-image/__tests__/image.test.tsx
+++ b/packages/responsive-image/__tests__/image.test.tsx
@@ -3,6 +3,8 @@ import { Image, ImageBackground } from "react-native";
 import { act, create } from "react-test-renderer";
 import ResponsiveImage from "../src";
 
+jest.mock("react-native-image-zoom-viewer", () => "ImageZoomView");
+
 const testUri = "http://foo.com/bar.png";
 
 beforeEach(() => {

--- a/packages/svgs/__tests__/android/__snapshots__/svgs.test.js.snap
+++ b/packages/svgs/__tests__/android/__snapshots__/svgs.test.js.snap
@@ -16,7 +16,6 @@ exports[`1. an svg, g, path 1`] = `
       "borderWidth": 0,
       "flex": 0,
       "height": 100,
-      "opacity": 1,
       "width": 100,
     }
   }
@@ -25,58 +24,9 @@ exports[`1. an svg, g, path 1`] = `
   version="1.1"
   width={100}
 >
-  <RNSVGGroup
-    fill={
-      Array [
-        0,
-        -16777216,
-      ]
-    }
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
-  >
+  <RNSVGGroup>
     <RNSVGGroup
-      fillOpacity={1}
       fillRule={0}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
@@ -85,61 +35,16 @@ exports[`1. an svg, g, path 1`] = `
           "strokeWidth",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
       strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     >
       <RNSVGPath
         d="4872173116d82a1a379dbcc06ad3c243"
-        fill={
-          Array [
-            0,
-            -16777216,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
+        fill={-16777216}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
     </RNSVGGroup>
   </RNSVGGroup>
@@ -149,118 +54,33 @@ exports[`1. an svg, g, path 1`] = `
 exports[`2. a path with no fill 1`] = `
 <RNSVGPath
   d="4872173116d82a1a379dbcc06ad3c243"
-  fillOpacity={1}
-  fillRule={1}
-  matrix={
-    Array [
-      1,
-      0,
-      0,
-      1,
-      0,
-      0,
-    ]
-  }
-  opacity={1}
-  originX={0}
-  originY={0}
   propList={
     Array [
       "fill",
     ]
   }
-  rotation={0}
-  scaleX={1}
-  scaleY={1}
-  skewX={0}
-  skewY={0}
-  strokeLinecap={0}
-  strokeLinejoin={0}
-  strokeMiterlimit={4}
-  strokeOpacity={1}
-  strokeWidth={1}
-  vectorEffect={0}
-  x={0}
-  y={0}
 />
 `;
 
 exports[`3. a polygon 1`] = `
 <RNSVGPath
   d="f0010c2bbdef3c3bedb66db380f29ac6"
-  fill={
-    Array [
-      0,
-      -16776961,
-    ]
-  }
-  fillOpacity={1}
-  fillRule={1}
-  matrix={
-    Array [
-      1,
-      0,
-      0,
-      1,
-      0,
-      0,
-    ]
-  }
-  opacity={1}
-  originX={0}
-  originY={0}
+  fill={-16776961}
   propList={
     Array [
       "fill",
       "stroke",
     ]
   }
-  rotation={0}
-  scaleX={1}
-  scaleY={1}
-  skewX={0}
-  skewY={0}
-  stroke={
-    Array [
-      0,
-      -65536,
-    ]
-  }
-  strokeLinecap={0}
-  strokeLinejoin={0}
-  strokeMiterlimit={4}
-  strokeOpacity={1}
-  strokeWidth={1}
-  vectorEffect={0}
-  x={0}
-  y={0}
+  stroke={-65536}
 />
 `;
 
 exports[`4. a rect 1`] = `
 <RNSVGRect
-  fill={
-    Array [
-      0,
-      -16777216,
-    ]
-  }
+  fill={-16777216}
   fillOpacity={0.4}
-  fillRule={1}
   height="100"
-  matrix={
-    Array [
-      1,
-      0,
-      0,
-      1,
-      0,
-      0,
-    ]
-  }
-  opacity={1}
-  originX={0}
-  originY={0}
   propList={
     Array [
       "fill",
@@ -269,23 +89,8 @@ exports[`4. a rect 1`] = `
       "strokeWidth",
     ]
   }
-  rotation={0}
-  scaleX={1}
-  scaleY={1}
-  skewX={0}
-  skewY={0}
-  stroke={
-    Array [
-      0,
-      -1,
-    ]
-  }
-  strokeLinecap={0}
-  strokeLinejoin={0}
-  strokeMiterlimit={4}
-  strokeOpacity={1}
+  stroke={-1}
   strokeWidth={8}
-  vectorEffect={0}
   width="100"
   x="5"
   y="10"


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/TNLT-995
- Fix rendering image placeholders for offline use on iOS

After:
![Simulator Screen Shot - iPhone 12 - 2020-12-09 at 16 45 10](https://user-images.githubusercontent.com/6978480/101661561-5434da80-3a40-11eb-9293-eb5adc710d5e.png)
