### PR TITLE
chore: removes unused Link "url" prop

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,6 @@ module.exports = {
     "jsx-a11y/anchor-is-valid": [
       "error",
       {
-        "components": ["Link"],
         "specialLink": ["url"],
         "aspects": ["noHref", "invalidHref", "preferButton"]
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -625,7 +624,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -1240,7 +1238,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -1855,7 +1852,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -2470,7 +2466,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -3076,7 +3071,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -3682,7 +3676,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4288,7 +4281,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4894,7 +4886,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tile a without breakpoint 1`] = `
-<Link
-  url="/article/123"
->
+<Link>
   <View
     style={
       Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ab.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile ab huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -118,7 +117,6 @@ exports[`tile ab medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -226,7 +224,6 @@ exports[`tile ab wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -334,7 +331,6 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ac.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ac.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile ac huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -88,7 +87,6 @@ exports[`tile ac medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -168,7 +166,6 @@ exports[`tile ac wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -248,7 +245,6 @@ exports[`tile ac without breakpoint should be like medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ad.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ad.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ad huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -97,7 +96,6 @@ exports[`tile ad medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -166,7 +164,6 @@ exports[`tile ad wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -254,7 +251,6 @@ exports[`tile ad without breakpoint should be like medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ae.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ae.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile ae huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -99,7 +98,6 @@ exports[`tile ae medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -188,7 +186,6 @@ exports[`tile ae wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -277,7 +274,6 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ah.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile ah huge 1`] = `
       "paddingRight": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}
@@ -141,7 +140,6 @@ exports[`tile ah medium 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}
@@ -271,7 +269,6 @@ exports[`tile ah wide 1`] = `
       "paddingRight": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}
@@ -401,7 +398,6 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ai.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ai.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ai huge 1`] = `
       "paddingLeft": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -33,7 +32,6 @@ exports[`tile ai medium 1`] = `
       "paddingLeft": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -57,7 +55,6 @@ exports[`tile ai wide 1`] = `
       "paddingLeft": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -81,7 +78,6 @@ exports[`tile ai without breakpoint should be like medium 1`] = `
       "paddingLeft": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-al.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile al huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -108,7 +107,6 @@ exports[`tile al wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-am.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile am without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-an.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-an.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile an without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ar.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ar huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -111,7 +110,6 @@ exports[`tile ar medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -213,7 +211,6 @@ exports[`tile ar wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -315,7 +312,6 @@ exports[`tile ar without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-as.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile as huge 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -106,7 +105,6 @@ exports[`tile as medium 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -203,7 +201,6 @@ exports[`tile as wide 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-at.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-at.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile at medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-au.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-au.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile au wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-av.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-av.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile as huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -97,7 +96,6 @@ exports[`tile as medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -185,7 +183,6 @@ exports[`tile as wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-aw.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-aw.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile aw landscape huge 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -91,7 +90,6 @@ exports[`tile aw landscape medium 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -173,7 +171,6 @@ exports[`tile aw landscape wide 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ax.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ax.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ax landscape huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -79,7 +78,6 @@ exports[`tile ax landscape medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -149,7 +147,6 @@ exports[`tile ax landscape wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -219,7 +216,6 @@ exports[`tile ax portrait huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -289,7 +285,6 @@ exports[`tile ax portrait medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -359,7 +354,6 @@ exports[`tile ax portrait wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ay.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ay.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ay huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -92,7 +91,6 @@ exports[`tile ay medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -175,7 +173,6 @@ exports[`tile ay wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -258,7 +255,6 @@ exports[`tile ay without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-az.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-az.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile az portrait medium 1`] = `
       "marginHorizontal": -30,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -93,7 +92,6 @@ exports[`tile az portrait wide 1`] = `
       "marginHorizontal": -50,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -606,7 +605,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -1202,7 +1200,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -1798,7 +1795,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -2393,7 +2389,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -2988,7 +2983,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -3583,7 +3577,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4178,7 +4171,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4773,7 +4765,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile b huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -95,7 +94,6 @@ exports[`tile b medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -183,7 +181,6 @@ exports[`tile b small 1`] = `
       "paddingBottom": 20,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -270,7 +267,6 @@ exports[`tile b wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -357,7 +353,6 @@ exports[`tile b with more teaser 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -445,7 +440,6 @@ exports[`tile b without breakpoint should be like small 1`] = `
       "paddingBottom": 20,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ba.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ba.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile ba portrait medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -83,7 +82,6 @@ exports[`tile ba portrait wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bb.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bb.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile bb landscape huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -84,7 +83,6 @@ exports[`tile bb landscape medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -160,7 +158,6 @@ exports[`tile bb landscape wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bc.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bc.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile bc huge 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -85,7 +84,6 @@ exports[`tile bc medium 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -161,7 +159,6 @@ exports[`tile bc wide 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -237,7 +234,6 @@ exports[`tile bc without breakpoint 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bd.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bd.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile bd medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -112,7 +111,6 @@ exports[`tile bd wide 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -213,7 +211,6 @@ exports[`tile bd without breakpoint 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-be.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-be.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile be without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bf.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bf.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile bf huge 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -95,7 +94,6 @@ exports[`tile bf medium 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -179,7 +177,6 @@ exports[`tile bf wide 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -263,7 +260,6 @@ exports[`tile bf without breakpoint should be like medium 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-c.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-c.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile c without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-d.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-d.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile d medium 1`] = `
       "paddingBottom": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -84,7 +83,6 @@ exports[`tile d small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -160,7 +158,6 @@ exports[`tile d without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-e.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-e.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile e huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -90,7 +89,6 @@ exports[`tile e medium 1`] = `
       "paddingBottom": 0,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -170,7 +168,6 @@ exports[`tile e small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -275,7 +272,6 @@ exports[`tile e wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -355,7 +351,6 @@ exports[`tile e without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -624,7 +623,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -1238,7 +1236,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -1852,7 +1849,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -2467,7 +2463,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3073,7 +3068,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3679,7 +3673,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -4285,7 +4278,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -4891,7 +4883,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f.test.js.snap
@@ -7,7 +7,6 @@ exports[`tile f without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -615,7 +614,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -1220,7 +1218,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -1825,7 +1822,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -2429,7 +2425,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -3033,7 +3028,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -3637,7 +3631,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -4241,7 +4234,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -4845,7 +4837,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile g huge 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -112,7 +111,6 @@ exports[`tile g medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -211,7 +209,6 @@ exports[`tile g small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -312,7 +309,6 @@ exports[`tile g wide 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -413,7 +409,6 @@ exports[`tile g without breakpoint should be like small 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -603,7 +602,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -1196,7 +1194,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -1789,7 +1786,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -2382,7 +2378,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -2975,7 +2970,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -3568,7 +3562,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -4162,7 +4155,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -4756,7 +4748,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile h without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-i.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-i.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tile i without breakpoint 1`] = `
-<Link
-  url="/article/123"
->
+<Link>
   <Image
     aspectRatio={1.7777777777777777}
     fill={true}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-j.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-j.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile j without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-k.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-k.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile k huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -83,7 +82,6 @@ exports[`tile k medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -158,7 +156,6 @@ exports[`tile k small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -233,7 +230,6 @@ exports[`tile k wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -308,7 +304,6 @@ exports[`tile k without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-l.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-l.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile l huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -72,7 +71,6 @@ exports[`tile l medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -136,7 +134,6 @@ exports[`tile l small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -200,7 +197,6 @@ exports[`tile l wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -264,7 +260,6 @@ exports[`tile l without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-m.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-m.test.js.snap
@@ -7,7 +7,6 @@ exports[`tile m huge 1`] = `
       "paddingBottom": 60,
     }
   }
-  url="/article/123"
 >
   <View>
     <Text
@@ -59,7 +58,6 @@ exports[`tile m medium 1`] = `
       "paddingBottom": 30,
     }
   }
-  url="/article/123"
 >
   <View>
     <Text
@@ -112,7 +110,6 @@ exports[`tile m small 1`] = `
       "paddingBottom": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -170,7 +167,6 @@ exports[`tile m wide 1`] = `
       "paddingBottom": 60,
     }
   }
-  url="/article/123"
 >
   <View>
     <Text
@@ -223,7 +219,6 @@ exports[`tile m without breakpoint should be like small 1`] = `
       "paddingBottom": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-n.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-n.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile n huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -95,7 +94,6 @@ exports[`tile n medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -197,7 +195,6 @@ exports[`tile n small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -298,7 +295,6 @@ exports[`tile n wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -400,7 +396,6 @@ exports[`tile n with default star 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -502,7 +497,6 @@ exports[`tile n without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-o.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-o.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile n huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -76,7 +75,6 @@ exports[`tile n medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -145,7 +143,6 @@ exports[`tile n small 1`] = `
       "paddingHorizontal": 12,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -211,7 +208,6 @@ exports[`tile n wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -280,7 +276,6 @@ exports[`tile n with default star 1`] = `
       "paddingHorizontal": 12,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-p.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-p.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile p without breakpoint 1`] = `
       "paddingTop": 20,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-q.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-q.test.js.snap
@@ -7,7 +7,6 @@ exports[`tile q without breakpoint 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile r huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -79,7 +78,6 @@ exports[`tile r medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -149,7 +147,6 @@ exports[`tile r wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -219,7 +216,6 @@ exports[`tile r without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-t.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-t.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile t without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-u.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile u with headline style 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -80,7 +79,6 @@ exports[`tile u without breakpoint 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-v.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-v.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile v without breakpoint 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-vertical-a.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-vertical-a.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile vertical a huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -97,7 +96,6 @@ exports[`tile vertical a medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -185,7 +183,6 @@ exports[`tile vertical a shows an image 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -283,7 +280,6 @@ exports[`tile vertical a wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-w.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile w huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -120,7 +119,6 @@ exports[`tile w medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -229,7 +227,6 @@ exports[`tile w wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -338,7 +335,6 @@ exports[`tile w without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-x.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-x.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile x huge 1`] = `
       "paddingTop": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -113,7 +112,6 @@ exports[`tile x medium 1`] = `
       "paddingTop": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -217,7 +215,6 @@ exports[`tile x wide 1`] = `
       "paddingTop": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-y.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-y.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile y huge 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View
@@ -86,7 +85,6 @@ exports[`tile y medium 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View
@@ -163,7 +161,6 @@ exports[`tile y wide 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View
@@ -240,7 +237,6 @@ exports[`tile y without breakpoint should be like medium 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-z.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile z huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -119,7 +118,6 @@ exports[`tile z wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -228,7 +226,6 @@ exports[`tile z without breakpoint should be like wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -625,7 +624,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -1240,7 +1238,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -1855,7 +1852,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.25}
@@ -2470,7 +2466,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -3076,7 +3071,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -3682,7 +3676,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4288,7 +4281,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4894,7 +4886,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tile a without breakpoint 1`] = `
-<Link
-  url="/article/123"
->
+<Link>
   <View
     style={
       Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ab.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile ab huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -118,7 +117,6 @@ exports[`tile ab medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -226,7 +224,6 @@ exports[`tile ab wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -334,7 +331,6 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ac.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ac.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile ac huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -88,7 +87,6 @@ exports[`tile ac medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -168,7 +166,6 @@ exports[`tile ac wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -248,7 +245,6 @@ exports[`tile ac without breakpoint should be like medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ad.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ad.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ad huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -97,7 +96,6 @@ exports[`tile ad medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -166,7 +164,6 @@ exports[`tile ad wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -254,7 +251,6 @@ exports[`tile ad without breakpoint should be like medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ae.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ae.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile ae huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -99,7 +98,6 @@ exports[`tile ae medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -188,7 +186,6 @@ exports[`tile ae wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -277,7 +274,6 @@ exports[`tile ae without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ah.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile ah huge 1`] = `
       "paddingRight": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}
@@ -141,7 +140,6 @@ exports[`tile ah medium 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}
@@ -271,7 +269,6 @@ exports[`tile ah wide 1`] = `
       "paddingRight": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}
@@ -401,7 +398,6 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ai.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ai.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ai huge 1`] = `
       "paddingLeft": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -33,7 +32,6 @@ exports[`tile ai medium 1`] = `
       "paddingLeft": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -57,7 +55,6 @@ exports[`tile ai wide 1`] = `
       "paddingLeft": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -81,7 +78,6 @@ exports[`tile ai without breakpoint should be like medium 1`] = `
       "paddingLeft": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-al.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile al huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -108,7 +107,6 @@ exports[`tile al wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-am.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile am without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-an.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-an.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile an without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ar.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ar huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -111,7 +110,6 @@ exports[`tile ar medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -213,7 +211,6 @@ exports[`tile ar wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -315,7 +312,6 @@ exports[`tile ar without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-as.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile as huge 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -106,7 +105,6 @@ exports[`tile as medium 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -203,7 +201,6 @@ exports[`tile as wide 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-at.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-at.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile at medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-au.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-au.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile au wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-av.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-av.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile as huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -97,7 +96,6 @@ exports[`tile as medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -185,7 +183,6 @@ exports[`tile as wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-aw.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-aw.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile aw landscape huge 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -91,7 +90,6 @@ exports[`tile aw landscape medium 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -173,7 +171,6 @@ exports[`tile aw landscape wide 1`] = `
       "paddingRight": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ax.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ax.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ax landscape huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -79,7 +78,6 @@ exports[`tile ax landscape medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -149,7 +147,6 @@ exports[`tile ax landscape wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -219,7 +216,6 @@ exports[`tile ax portrait huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -289,7 +285,6 @@ exports[`tile ax portrait medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -359,7 +354,6 @@ exports[`tile ax portrait wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ay.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ay.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile ay huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -92,7 +91,6 @@ exports[`tile ay medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -175,7 +173,6 @@ exports[`tile ay wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -258,7 +255,6 @@ exports[`tile ay without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-az.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-az.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile az portrait medium 1`] = `
       "marginHorizontal": -30,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -93,7 +92,6 @@ exports[`tile az portrait wide 1`] = `
       "marginHorizontal": -50,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -606,7 +605,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -1202,7 +1200,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -1798,7 +1795,6 @@ Array [
         "paddingVertical": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -2393,7 +2389,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -2988,7 +2983,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -3583,7 +3577,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4178,7 +4171,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}
@@ -4773,7 +4765,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile b huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -95,7 +94,6 @@ exports[`tile b medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -183,7 +181,6 @@ exports[`tile b small 1`] = `
       "paddingBottom": 20,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -270,7 +267,6 @@ exports[`tile b wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -357,7 +353,6 @@ exports[`tile b with more teaser 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -445,7 +440,6 @@ exports[`tile b without breakpoint should be like small 1`] = `
       "paddingBottom": 20,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ba.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ba.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile ba portrait medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -83,7 +82,6 @@ exports[`tile ba portrait wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bb.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bb.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile bb landscape huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -84,7 +83,6 @@ exports[`tile bb landscape medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -160,7 +158,6 @@ exports[`tile bb landscape wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bc.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bc.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile bc huge 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -85,7 +84,6 @@ exports[`tile bc medium 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -161,7 +159,6 @@ exports[`tile bc wide 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -237,7 +234,6 @@ exports[`tile bc without breakpoint 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bd.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bd.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile bd medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -112,7 +111,6 @@ exports[`tile bd wide 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -213,7 +211,6 @@ exports[`tile bd without breakpoint 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-be.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-be.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile be without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bf.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bf.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile bf huge 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -95,7 +94,6 @@ exports[`tile bf medium 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -179,7 +177,6 @@ exports[`tile bf wide 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -263,7 +260,6 @@ exports[`tile bf without breakpoint should be like medium 1`] = `
       "marginVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-c.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-c.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile c without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-d.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-d.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile d medium 1`] = `
       "paddingBottom": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -84,7 +83,6 @@ exports[`tile d small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -160,7 +158,6 @@ exports[`tile d without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-e.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-e.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile e huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -90,7 +89,6 @@ exports[`tile e medium 1`] = `
       "paddingBottom": 0,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -170,7 +168,6 @@ exports[`tile e small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -275,7 +272,6 @@ exports[`tile e wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -355,7 +351,6 @@ exports[`tile e without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -624,7 +623,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -1238,7 +1236,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -1852,7 +1849,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -2467,7 +2463,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3073,7 +3068,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -3679,7 +3673,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -4285,7 +4278,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -4891,7 +4883,6 @@ Array [
         "paddingBottom": 0,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f.test.js.snap
@@ -7,7 +7,6 @@ exports[`tile f without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -615,7 +614,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -1220,7 +1218,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -1825,7 +1822,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -2429,7 +2425,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -3033,7 +3028,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -3637,7 +3631,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -4241,7 +4234,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}
@@ -4845,7 +4837,6 @@ Array [
         "paddingLeft": 10,
       }
     }
-    url="/article/123"
   >
     <Image
       aspectRatio={0.8}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile g huge 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -112,7 +111,6 @@ exports[`tile g medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -211,7 +209,6 @@ exports[`tile g small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -312,7 +309,6 @@ exports[`tile g wide 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -413,7 +409,6 @@ exports[`tile g without breakpoint should be like small 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h-front.test.js.snap
@@ -10,7 +10,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -603,7 +602,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -1196,7 +1194,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -1789,7 +1786,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -2382,7 +2378,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -2975,7 +2970,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -3568,7 +3562,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -4162,7 +4155,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}
@@ -4756,7 +4748,6 @@ Array [
         "paddingRight": 10,
       }
     }
-    url="/article/123"
   >
     <FrontTileSummary
       bylineMarginBottom={15}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile h without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-i.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-i.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tile i without breakpoint 1`] = `
-<Link
-  url="/article/123"
->
+<Link>
   <Image
     aspectRatio={1.7777777777777777}
     fill={true}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-j.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-j.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile j without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-k.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-k.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile k huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -83,7 +82,6 @@ exports[`tile k medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -158,7 +156,6 @@ exports[`tile k small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -233,7 +230,6 @@ exports[`tile k wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -308,7 +304,6 @@ exports[`tile k without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-l.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-l.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile l huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -72,7 +71,6 @@ exports[`tile l medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -136,7 +134,6 @@ exports[`tile l small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -200,7 +197,6 @@ exports[`tile l wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -264,7 +260,6 @@ exports[`tile l without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-m.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-m.test.js.snap
@@ -7,7 +7,6 @@ exports[`tile m huge 1`] = `
       "paddingBottom": 60,
     }
   }
-  url="/article/123"
 >
   <View>
     <Text
@@ -59,7 +58,6 @@ exports[`tile m medium 1`] = `
       "paddingBottom": 30,
     }
   }
-  url="/article/123"
 >
   <View>
     <Text
@@ -112,7 +110,6 @@ exports[`tile m small 1`] = `
       "paddingBottom": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -170,7 +167,6 @@ exports[`tile m wide 1`] = `
       "paddingBottom": 60,
     }
   }
-  url="/article/123"
 >
   <View>
     <Text
@@ -223,7 +219,6 @@ exports[`tile m without breakpoint should be like small 1`] = `
       "paddingBottom": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-n.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-n.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile n huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -95,7 +94,6 @@ exports[`tile n medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -197,7 +195,6 @@ exports[`tile n small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -298,7 +295,6 @@ exports[`tile n wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -400,7 +396,6 @@ exports[`tile n with default star 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -502,7 +497,6 @@ exports[`tile n without breakpoint should be like small 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-o.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-o.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile n huge 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -76,7 +75,6 @@ exports[`tile n medium 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -145,7 +143,6 @@ exports[`tile n small 1`] = `
       "paddingHorizontal": 12,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -211,7 +208,6 @@ exports[`tile n wide 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -280,7 +276,6 @@ exports[`tile n with default star 1`] = `
       "paddingHorizontal": 12,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-p.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-p.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile p without breakpoint 1`] = `
       "paddingTop": 20,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-q.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-q.test.js.snap
@@ -7,7 +7,6 @@ exports[`tile q without breakpoint 1`] = `
       "paddingVertical": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile r huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -79,7 +78,6 @@ exports[`tile r medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -149,7 +147,6 @@ exports[`tile r wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -219,7 +216,6 @@ exports[`tile r without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-t.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-t.test.js.snap
@@ -8,7 +8,6 @@ exports[`tile t without breakpoint 1`] = `
       "padding": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-u.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile u with headline style 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}
@@ -80,7 +79,6 @@ exports[`tile u without breakpoint 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-v.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-v.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile v without breakpoint 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.7777777777777777}

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-vertical-a.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-vertical-a.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile vertical a huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -97,7 +96,6 @@ exports[`tile vertical a medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -185,7 +183,6 @@ exports[`tile vertical a shows an image 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <Image
     aspectRatio={1.5}
@@ -283,7 +280,6 @@ exports[`tile vertical a wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-w.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile w huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -120,7 +119,6 @@ exports[`tile w medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -229,7 +227,6 @@ exports[`tile w wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -338,7 +335,6 @@ exports[`tile w without breakpoint should be like medium 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-x.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-x.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile x huge 1`] = `
       "paddingTop": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -113,7 +112,6 @@ exports[`tile x medium 1`] = `
       "paddingTop": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -217,7 +215,6 @@ exports[`tile x wide 1`] = `
       "paddingTop": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-y.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-y.test.js.snap
@@ -9,7 +9,6 @@ exports[`tile y huge 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View
@@ -86,7 +85,6 @@ exports[`tile y medium 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View
@@ -163,7 +161,6 @@ exports[`tile y wide 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View
@@ -240,7 +237,6 @@ exports[`tile y without breakpoint should be like medium 1`] = `
       "paddingTop": 10,
     }
   }
-  url="/article/123"
 >
   <View>
     <View

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-z.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile z huge 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -119,7 +118,6 @@ exports[`tile z wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={
@@ -228,7 +226,6 @@ exports[`tile z without breakpoint should be like wide 1`] = `
       "paddingVertical": 15,
     }
   }
-  url="/article/123"
 >
   <View
     style={

--- a/packages/edition-slices/src/tiles/shared/tile-link.tsx
+++ b/packages/edition-slices/src/tiles/shared/tile-link.tsx
@@ -13,11 +13,10 @@ const TileLink: FC<Props> = ({
   onPress,
   style = {},
   tile: {
-    article: { id, url },
+    article: { id },
   },
 }) => (
-  // @ts-ignore TODO url prop no longer needed, to be deleted.
-  <Link linkStyle={style} onPress={() => onPress({ id })} url={url}>
+  <Link linkStyle={style} onPress={() => onPress({ id })}>
     {children}
   </Link>
 );


### PR DESCRIPTION
The `Link` component doesn't accept a `url` prop (see https://github.com/newsuk/times-components-native/blob/7765f923075cf5fcdaf6f9558c383177ad39406d/packages/link/src/link.android.js#L5 and https://github.com/newsuk/times-components-native/blob/7765f923075cf5fcdaf6f9558c383177ad39406d/packages/link/src/link.js#L5), however `TileLink` was providing this anyway.  