### PR TITLE
chore: refactor TileImage

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -627,7 +626,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1241,7 +1239,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1855,7 +1852,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -2469,7 +2465,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -3074,7 +3069,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -3679,7 +3673,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4284,7 +4277,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4889,7 +4881,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 15,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a.test.js.snap
@@ -60,7 +60,6 @@ exports[`tile a without breakpoint 1`] = `
   </View>
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ab.test.js.snap
@@ -96,7 +96,6 @@ exports[`tile ab huge 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 0.26,
@@ -203,7 +202,6 @@ exports[`tile ab medium 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 0.44,
@@ -310,7 +308,6 @@ exports[`tile ab wide 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -417,7 +414,6 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 0.44,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ac.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ac.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile ac huge 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -90,7 +89,6 @@ exports[`tile ac medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -169,7 +167,6 @@ exports[`tile ac wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -248,7 +245,6 @@ exports[`tile ac without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ah.test.js.snap
@@ -14,7 +14,6 @@ exports[`tile ah huge 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={
@@ -143,7 +142,6 @@ exports[`tile ah medium 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={
@@ -272,7 +270,6 @@ exports[`tile ah wide 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={
@@ -401,7 +398,6 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ai.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ai.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile ai huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -35,7 +34,6 @@ exports[`tile ai medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -58,7 +56,6 @@ exports[`tile ai wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -81,7 +78,6 @@ exports[`tile ai without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-aj.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-aj.test.js.snap
@@ -42,7 +42,6 @@ exports[`tile aj without breakpoint 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ak.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ak.test.js.snap
@@ -44,7 +44,6 @@ exports[`tile ak huge 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",
@@ -101,7 +100,6 @@ exports[`tile ak medium 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",
@@ -158,7 +156,6 @@ exports[`tile ak wide 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",
@@ -215,7 +212,6 @@ exports[`tile ak without breakpoint should be like medium 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-al.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile al huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -110,7 +109,6 @@ exports[`tile al wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-am.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile am without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-an.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-an.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile an without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ar.test.js.snap
@@ -20,7 +20,6 @@ exports[`tile ar huge 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -121,7 +120,6 @@ exports[`tile ar medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -222,7 +220,6 @@ exports[`tile ar wide 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -323,7 +320,6 @@ exports[`tile ar without breakpoint should be like medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-as.test.js.snap
@@ -20,7 +20,6 @@ exports[`tile as huge 1`] = `
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>
@@ -116,7 +115,6 @@ exports[`tile as medium 1`] = `
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>
@@ -212,7 +210,6 @@ exports[`tile as wide 1`] = `
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-at.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-at.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile at medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-au.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-au.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile au wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-aw.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-aw.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile aw landscape huge 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -93,7 +92,6 @@ exports[`tile aw landscape medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -174,7 +172,6 @@ exports[`tile aw landscape wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ax.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ax.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile ax landscape huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -81,7 +80,6 @@ exports[`tile ax landscape medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -150,7 +148,6 @@ exports[`tile ax landscape wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -219,7 +216,6 @@ exports[`tile ax portrait huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -288,7 +284,6 @@ exports[`tile ax portrait medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -357,7 +352,6 @@ exports[`tile ax portrait wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ay.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ay.test.js.snap
@@ -20,7 +20,6 @@ exports[`tile ay huge 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -102,7 +101,6 @@ exports[`tile ay medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -184,7 +182,6 @@ exports[`tile ay wide 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -266,7 +263,6 @@ exports[`tile ay without breakpoint should be like medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-az.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-az.test.js.snap
@@ -13,7 +13,6 @@ exports[`tile az portrait medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -95,7 +94,6 @@ exports[`tile az portrait wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-b-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -608,7 +607,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -1203,7 +1201,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -1798,7 +1795,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -2392,7 +2388,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -2986,7 +2981,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -3580,7 +3574,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -4174,7 +4167,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -4768,7 +4760,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-ba.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-ba.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile ba portrait medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -85,7 +84,6 @@ exports[`tile ba portrait wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "flex": 1,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bb.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bb.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile bb landscape huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -86,7 +85,6 @@ exports[`tile bb landscape medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -161,7 +159,6 @@ exports[`tile bb landscape wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bc.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bc.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile bc huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -87,7 +86,6 @@ exports[`tile bc medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -162,7 +160,6 @@ exports[`tile bc wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -237,7 +234,6 @@ exports[`tile bc without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bd.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bd.test.js.snap
@@ -30,7 +30,6 @@ exports[`tile bd medium 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -130,7 +129,6 @@ exports[`tile bd wide 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -230,7 +228,6 @@ exports[`tile bd without breakpoint 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-be.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-be.test.js.snap
@@ -19,7 +19,6 @@ exports[`tile be without breakpoint 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       resizeMode="cover"
       rounded={true}
       style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-bf.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-bf.test.js.snap
@@ -76,7 +76,6 @@ exports[`tile bf huge 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -159,7 +158,6 @@ exports[`tile bf medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -242,7 +240,6 @@ exports[`tile bf wide 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -325,7 +322,6 @@ exports[`tile bf without breakpoint should be like medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-c.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-c.test.js.snap
@@ -19,7 +19,6 @@ exports[`tile c without breakpoint 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-d.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-d.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile d medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -86,7 +85,6 @@ exports[`tile d small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -161,7 +159,6 @@ exports[`tile d without breakpoint should be like small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-e.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-e.test.js.snap
@@ -67,7 +67,6 @@ exports[`tile e huge 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -147,7 +146,6 @@ exports[`tile e medium 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -252,7 +250,6 @@ exports[`tile e small 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -330,7 +327,6 @@ exports[`tile e wide 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -435,7 +431,6 @@ exports[`tile e without breakpoint should be like small 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-f-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "width": "100%",
@@ -626,7 +625,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "width": "100%",
@@ -1239,7 +1237,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "width": "100%",
@@ -1852,7 +1849,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 15,
@@ -2466,7 +2462,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -3071,7 +3066,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -3676,7 +3670,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4281,7 +4274,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4886,7 +4878,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -617,7 +616,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1221,7 +1219,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1825,7 +1822,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -2428,7 +2424,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -3031,7 +3026,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -3634,7 +3628,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -4237,7 +4230,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -4840,7 +4832,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g.test.js.snap
@@ -30,7 +30,6 @@ exports[`tile g huge 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -130,7 +129,6 @@ exports[`tile g medium 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -228,7 +226,6 @@ exports[`tile g small 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -328,7 +325,6 @@ exports[`tile g wide 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -428,7 +424,6 @@ exports[`tile g without breakpoint should be like small 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-h.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-h.test.js.snap
@@ -121,7 +121,6 @@ exports[`tile h without breakpoint 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flexDirection": "column",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-i.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-i.test.js.snap
@@ -4,7 +4,6 @@ exports[`tile i without breakpoint 1`] = `
 <Link>
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-j.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-j.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile j without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "40%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-k.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-k.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile k huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -85,7 +84,6 @@ exports[`tile k medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -159,7 +157,6 @@ exports[`tile k small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -233,7 +230,6 @@ exports[`tile k wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -307,7 +303,6 @@ exports[`tile k without breakpoint should be like small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-n.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-n.test.js.snap
@@ -19,7 +19,6 @@ exports[`tile n huge 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -104,7 +103,6 @@ exports[`tile n medium 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -205,7 +203,6 @@ exports[`tile n small 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -305,7 +302,6 @@ exports[`tile n wide 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -406,7 +402,6 @@ exports[`tile n with default star 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -507,7 +502,6 @@ exports[`tile n without breakpoint should be like small 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-p.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-p.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile p without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-q.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-q.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile q without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-r.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile r huge 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 15,
@@ -81,7 +80,6 @@ exports[`tile r medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -150,7 +148,6 @@ exports[`tile r wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 15,
@@ -219,7 +216,6 @@ exports[`tile r without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-t.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-t.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile t without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-u.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile u with headline style 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -82,7 +81,6 @@ exports[`tile u without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-v.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-v.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile v without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-vertical-a.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-vertical-a.test.js.snap
@@ -186,7 +186,6 @@ exports[`tile vertical a shows an image 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-w.test.js.snap
@@ -97,7 +97,6 @@ exports[`tile w huge 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -205,7 +204,6 @@ exports[`tile w medium 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -313,7 +311,6 @@ exports[`tile w wide 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -421,7 +418,6 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-z.test.js.snap
@@ -97,7 +97,6 @@ exports[`tile z huge 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "59%",
@@ -205,7 +204,6 @@ exports[`tile z wide 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "59%",
@@ -313,7 +311,6 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "59%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -627,7 +626,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1241,7 +1239,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1855,7 +1852,6 @@ Array [
   >
     <Image
       aspectRatio={1.25}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -2469,7 +2465,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -3074,7 +3069,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -3679,7 +3673,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4284,7 +4277,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4889,7 +4881,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 15,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a.test.js.snap
@@ -60,7 +60,6 @@ exports[`tile a without breakpoint 1`] = `
   </View>
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ab.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ab.test.js.snap
@@ -96,7 +96,6 @@ exports[`tile ab huge 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 0.26,
@@ -203,7 +202,6 @@ exports[`tile ab medium 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 0.44,
@@ -310,7 +308,6 @@ exports[`tile ab wide 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -417,7 +414,6 @@ exports[`tile ab without breakpoint should be like medium 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flex": 0.44,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ac.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ac.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile ac huge 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -90,7 +89,6 @@ exports[`tile ac medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -169,7 +167,6 @@ exports[`tile ac wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -248,7 +245,6 @@ exports[`tile ac without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ah.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ah.test.js.snap
@@ -14,7 +14,6 @@ exports[`tile ah huge 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={
@@ -143,7 +142,6 @@ exports[`tile ah medium 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={
@@ -272,7 +270,6 @@ exports[`tile ah wide 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={
@@ -401,7 +398,6 @@ exports[`tile ah without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ai.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ai.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile ai huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -35,7 +34,6 @@ exports[`tile ai medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -58,7 +56,6 @@ exports[`tile ai wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -81,7 +78,6 @@ exports[`tile ai without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-aj.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-aj.test.js.snap
@@ -42,7 +42,6 @@ exports[`tile aj without breakpoint 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ak.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ak.test.js.snap
@@ -44,7 +44,6 @@ exports[`tile ak huge 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",
@@ -101,7 +100,6 @@ exports[`tile ak medium 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",
@@ -158,7 +156,6 @@ exports[`tile ak wide 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",
@@ -215,7 +212,6 @@ exports[`tile ak without breakpoint should be like medium 1`] = `
   <Image
     aspectRatio={1.5}
     disablePlaceholder={true}
-    fill={true}
     style={
       Object {
         "alignSelf": "flex-end",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-al.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-al.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile al huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -110,7 +109,6 @@ exports[`tile al wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-am.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-am.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile am without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-an.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-an.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile an without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ar.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ar.test.js.snap
@@ -20,7 +20,6 @@ exports[`tile ar huge 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -121,7 +120,6 @@ exports[`tile ar medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -222,7 +220,6 @@ exports[`tile ar wide 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -323,7 +320,6 @@ exports[`tile ar without breakpoint should be like medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-as.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-as.test.js.snap
@@ -20,7 +20,6 @@ exports[`tile as huge 1`] = `
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>
@@ -116,7 +115,6 @@ exports[`tile as medium 1`] = `
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>
@@ -212,7 +210,6 @@ exports[`tile as wide 1`] = `
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
     />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-at.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-at.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile at medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-au.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-au.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile au wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-aw.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-aw.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile aw landscape huge 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -93,7 +92,6 @@ exports[`tile aw landscape medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -174,7 +172,6 @@ exports[`tile aw landscape wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ax.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ax.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile ax landscape huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -81,7 +80,6 @@ exports[`tile ax landscape medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -150,7 +148,6 @@ exports[`tile ax landscape wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -219,7 +216,6 @@ exports[`tile ax portrait huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -288,7 +284,6 @@ exports[`tile ax portrait medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -357,7 +352,6 @@ exports[`tile ax portrait wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ay.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ay.test.js.snap
@@ -20,7 +20,6 @@ exports[`tile ay huge 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -102,7 +101,6 @@ exports[`tile ay medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -184,7 +182,6 @@ exports[`tile ay wide 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -266,7 +263,6 @@ exports[`tile ay without breakpoint should be like medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-az.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-az.test.js.snap
@@ -13,7 +13,6 @@ exports[`tile az portrait medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",
@@ -95,7 +94,6 @@ exports[`tile az portrait wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-b-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -608,7 +607,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -1203,7 +1201,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -1798,7 +1795,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -2392,7 +2388,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -2986,7 +2981,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -3580,7 +3574,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -4174,7 +4167,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -4768,7 +4760,6 @@ Array [
   >
     <Image
       aspectRatio={1.5}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-ba.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-ba.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile ba portrait medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -85,7 +84,6 @@ exports[`tile ba portrait wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "flex": 1,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bb.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bb.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile bb landscape huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -86,7 +85,6 @@ exports[`tile bb landscape medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -161,7 +159,6 @@ exports[`tile bb landscape wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bc.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bc.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile bc huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -87,7 +86,6 @@ exports[`tile bc medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -162,7 +160,6 @@ exports[`tile bc wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -237,7 +234,6 @@ exports[`tile bc without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bd.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bd.test.js.snap
@@ -30,7 +30,6 @@ exports[`tile bd medium 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -130,7 +129,6 @@ exports[`tile bd wide 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -230,7 +228,6 @@ exports[`tile bd without breakpoint 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-be.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-be.test.js.snap
@@ -19,7 +19,6 @@ exports[`tile be without breakpoint 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       resizeMode="cover"
       rounded={true}
       style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-bf.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-bf.test.js.snap
@@ -76,7 +76,6 @@ exports[`tile bf huge 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -159,7 +158,6 @@ exports[`tile bf medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -242,7 +240,6 @@ exports[`tile bf wide 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>
@@ -325,7 +322,6 @@ exports[`tile bf without breakpoint should be like medium 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-c.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-c.test.js.snap
@@ -19,7 +19,6 @@ exports[`tile c without breakpoint 1`] = `
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       uri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd3abdbfc-1776-11e6-b4ba-d249b128bacc.jpg?crop=620%2C348%2C0%2C32"
     />
   </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-d.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-d.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile d medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -86,7 +85,6 @@ exports[`tile d small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -161,7 +159,6 @@ exports[`tile d without breakpoint should be like small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-e.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-e.test.js.snap
@@ -67,7 +67,6 @@ exports[`tile e huge 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -147,7 +146,6 @@ exports[`tile e medium 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -252,7 +250,6 @@ exports[`tile e small 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "width": "50%",
@@ -330,7 +327,6 @@ exports[`tile e wide 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -435,7 +431,6 @@ exports[`tile e without breakpoint should be like small 1`] = `
   </View>
   <Image
     aspectRatio={0.8}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-f-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "width": "100%",
@@ -626,7 +625,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "width": "100%",
@@ -1239,7 +1237,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "width": "100%",
@@ -1852,7 +1849,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 15,
@@ -2466,7 +2462,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 5,
@@ -3071,7 +3066,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -3676,7 +3670,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4281,7 +4274,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,
@@ -4886,7 +4878,6 @@ Array [
   >
     <Image
       aspectRatio={1.7777777777777777}
-      fill={true}
       style={
         Object {
           "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -13,7 +13,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -617,7 +616,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1221,7 +1219,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -1825,7 +1822,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -2428,7 +2424,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -3031,7 +3026,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -3634,7 +3628,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -4237,7 +4230,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,
@@ -4840,7 +4832,6 @@ Array [
   >
     <Image
       aspectRatio={0.8}
-      fill={true}
       style={
         Object {
           "marginBottom": 0,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g.test.js.snap
@@ -30,7 +30,6 @@ exports[`tile g huge 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -130,7 +129,6 @@ exports[`tile g medium 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -228,7 +226,6 @@ exports[`tile g small 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -328,7 +325,6 @@ exports[`tile g wide 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={
@@ -428,7 +424,6 @@ exports[`tile g without breakpoint should be like small 1`] = `
     >
       <Image
         aspectRatio={1}
-        fill={true}
         resizeMode="cover"
         rounded={true}
         style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-h.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-h.test.js.snap
@@ -121,7 +121,6 @@ exports[`tile h without breakpoint 1`] = `
   </View>
   <Image
     aspectRatio={0.6666666666666666}
-    fill={true}
     style={
       Object {
         "flexDirection": "column",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-i.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-i.test.js.snap
@@ -4,7 +4,6 @@ exports[`tile i without breakpoint 1`] = `
 <Link>
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "100%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-j.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-j.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile j without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "40%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-k.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-k.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile k huge 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -85,7 +84,6 @@ exports[`tile k medium 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -159,7 +157,6 @@ exports[`tile k small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -233,7 +230,6 @@ exports[`tile k wide 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,
@@ -307,7 +303,6 @@ exports[`tile k without breakpoint should be like small 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "paddingRight": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-n.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-n.test.js.snap
@@ -19,7 +19,6 @@ exports[`tile n huge 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -104,7 +103,6 @@ exports[`tile n medium 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -205,7 +203,6 @@ exports[`tile n small 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -305,7 +302,6 @@ exports[`tile n wide 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -406,7 +402,6 @@ exports[`tile n with default star 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,
@@ -507,7 +502,6 @@ exports[`tile n without breakpoint should be like small 1`] = `
   >
     <Image
       aspectRatio={1}
-      fill={true}
       style={
         Object {
           "flex": 1,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-p.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-p.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile p without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1}
-    fill={true}
     resizeMode="cover"
     rounded={true}
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-q.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-q.test.js.snap
@@ -10,7 +10,6 @@ exports[`tile q without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-r.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile r huge 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 15,
@@ -81,7 +80,6 @@ exports[`tile r medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -150,7 +148,6 @@ exports[`tile r wide 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 15,
@@ -219,7 +216,6 @@ exports[`tile r without breakpoint should be like medium 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-t.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-t.test.js.snap
@@ -11,7 +11,6 @@ exports[`tile t without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "width": "50%",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-u.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-u.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile u with headline style 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,
@@ -82,7 +81,6 @@ exports[`tile u without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-v.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-v.test.js.snap
@@ -12,7 +12,6 @@ exports[`tile v without breakpoint 1`] = `
 >
   <Image
     aspectRatio={1.7777777777777777}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-vertical-a.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-vertical-a.test.js.snap
@@ -186,7 +186,6 @@ exports[`tile vertical a shows an image 1`] = `
 >
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "marginBottom": 10,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-w.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-w.test.js.snap
@@ -97,7 +97,6 @@ exports[`tile w huge 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -205,7 +204,6 @@ exports[`tile w medium 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -313,7 +311,6 @@ exports[`tile w wide 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,
@@ -421,7 +418,6 @@ exports[`tile w without breakpoint should be like medium 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "flex": 1,

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-z.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-z.test.js.snap
@@ -97,7 +97,6 @@ exports[`tile z huge 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "59%",
@@ -205,7 +204,6 @@ exports[`tile z wide 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "59%",
@@ -313,7 +311,6 @@ exports[`tile z without breakpoint should be like wide 1`] = `
   </View>
   <Image
     aspectRatio={1.5}
-    fill={true}
     style={
       Object {
         "width": "59%",

--- a/packages/edition-slices/src/configured-tiles/tile-vertical-a/index.tsx
+++ b/packages/edition-slices/src/configured-tiles/tile-vertical-a/index.tsx
@@ -38,7 +38,6 @@ const TileVerticalA: FC<Props> = ({ onPress, tile, breakpoint }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
           style={styles.imageContainer}
           uri={crop.url}
-          fill
           hasVideo={hasVideo}
         />
       )}

--- a/packages/edition-slices/src/tiles/shared/tile-image.tsx
+++ b/packages/edition-slices/src/tiles/shared/tile-image.tsx
@@ -3,18 +3,12 @@ import { LayoutChangeEvent, View, ViewStyle } from "react-native";
 import { PlayIcon } from "@times-components-native/video";
 import Image from "@times-components-native/image";
 import { playIconStyles } from "./styles";
+import { ResponsiveImageProps } from "@times-components-native/responsive-image/src";
 
-interface Props {
+interface Props extends ResponsiveImageProps {
   hasVideo?: boolean | null;
-  aspectRatio: number;
-  relativeWidth: number;
-  relativeHeight: number;
-  relativeVerticalOffset: number;
-  relativeHorizontalOffset: number;
-  fill: boolean;
   style: ViewStyle;
   onLayout?: () => void;
-  uri: string;
 }
 
 const TileImage: FC<Props> = ({ hasVideo, style, onLayout, ...props }) => {

--- a/packages/edition-slices/src/tiles/tile-a-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/index.js
@@ -37,7 +37,6 @@ const TileAFront = ({ onPress, tile, orientation }) => {
         relativeVerticalOffset={imageCrop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={imageCrop.url}
-        fill
         hasVideo={article.hasVideo}
       />
       <FrontTileSummary

--- a/packages/edition-slices/src/tiles/tile-a/index.js
+++ b/packages/edition-slices/src/tiles/tile-a/index.js
@@ -36,7 +36,6 @@ const TileA = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-ab/index.js
+++ b/packages/edition-slices/src/tiles/tile-ab/index.js
@@ -52,7 +52,6 @@ const TileAB = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-ac/index.js
+++ b/packages/edition-slices/src/tiles/tile-ac/index.js
@@ -33,7 +33,6 @@ const TileAC = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-ah/index.js
+++ b/packages/edition-slices/src/tiles/tile-ah/index.js
@@ -31,7 +31,6 @@ const TileAH = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-ai/index.js
+++ b/packages/edition-slices/src/tiles/tile-ai/index.js
@@ -27,7 +27,6 @@ const TileAI = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-aj/index.js
+++ b/packages/edition-slices/src/tiles/tile-aj/index.js
@@ -35,7 +35,6 @@ const TileAJ = ({ id, image, onPress, title, url }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={imageContainer}
         uri={crop.url}
-        fill
       />
     </Link>
   );

--- a/packages/edition-slices/src/tiles/tile-ak/index.js
+++ b/packages/edition-slices/src/tiles/tile-ak/index.js
@@ -44,7 +44,6 @@ const TileAK = ({
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={imageContainer}
         uri={crop.url}
-        fill
       />
     </Link>
   );

--- a/packages/edition-slices/src/tiles/tile-al/index.js
+++ b/packages/edition-slices/src/tiles/tile-al/index.js
@@ -36,7 +36,6 @@ const TileAL = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <WithoutWhiteSpace

--- a/packages/edition-slices/src/tiles/tile-am/index.js
+++ b/packages/edition-slices/src/tiles/tile-am/index.js
@@ -33,7 +33,6 @@ const TileAM = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <WithoutWhiteSpace

--- a/packages/edition-slices/src/tiles/tile-an/index.js
+++ b/packages/edition-slices/src/tiles/tile-an/index.js
@@ -27,7 +27,6 @@ const TileAN = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-ar/index.js
+++ b/packages/edition-slices/src/tiles/tile-ar/index.js
@@ -33,7 +33,6 @@ const TileAR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         <TileImage
           aspectRatio={16 / 9}
           uri={crop.url}
-          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-as/index.js
+++ b/packages/edition-slices/src/tiles/tile-as/index.js
@@ -29,7 +29,6 @@ const TileAS = ({ onPress, tile, breakpoint }) => {
         <TileImage
           aspectRatio={3 / 2}
           uri={crop.url}
-          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-at/index.js
+++ b/packages/edition-slices/src/tiles/tile-at/index.js
@@ -34,7 +34,6 @@ const TileAT = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <WithoutWhiteSpace

--- a/packages/edition-slices/src/tiles/tile-au/index.js
+++ b/packages/edition-slices/src/tiles/tile-au/index.js
@@ -32,7 +32,6 @@ const TileAT = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary headlineStyle={styles.headline} tile={tile} />

--- a/packages/edition-slices/src/tiles/tile-aw/index.js
+++ b/packages/edition-slices/src/tiles/tile-aw/index.js
@@ -30,7 +30,6 @@ const TileAW = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-ax/index.js
+++ b/packages/edition-slices/src/tiles/tile-ax/index.js
@@ -37,7 +37,6 @@ const TileAX = ({
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-ay/index.js
+++ b/packages/edition-slices/src/tiles/tile-ay/index.js
@@ -32,7 +32,6 @@ const TileAY = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         <TileImage
           aspectRatio={16 / 9}
           uri={crop.url}
-          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-az/index.js
+++ b/packages/edition-slices/src/tiles/tile-az/index.js
@@ -30,7 +30,6 @@ const TileAZ = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-b-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-b-front/index.js
@@ -28,7 +28,6 @@ const TileBFront = ({ onPress, tile, orientation }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={article.hasVideo}
       />
       <FrontTileSummary

--- a/packages/edition-slices/src/tiles/tile-ba/index.js
+++ b/packages/edition-slices/src/tiles/tile-ba/index.js
@@ -31,7 +31,6 @@ const TileBA = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-bb/index.js
+++ b/packages/edition-slices/src/tiles/tile-bb/index.js
@@ -31,7 +31,6 @@ const TileBB = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-bc/index.js
+++ b/packages/edition-slices/src/tiles/tile-bc/index.js
@@ -32,7 +32,6 @@ const TileBC = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-bd/index.js
+++ b/packages/edition-slices/src/tiles/tile-bd/index.js
@@ -31,7 +31,6 @@ const TileBD = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
             relativeVerticalOffset={crop.relativeVerticalOffset}
             style={styles.imageContainer}
             uri={crop.url}
-            fill
             rounded
             resizeMode="cover"
           />

--- a/packages/edition-slices/src/tiles/tile-be/index.js
+++ b/packages/edition-slices/src/tiles/tile-be/index.js
@@ -31,7 +31,6 @@ const TileBE = ({ onPress, tile }) => {
           relativeVerticalOffset={crop.relativeVerticalOffset}
           style={styles.imageContainer}
           uri={crop.url}
-          fill
           rounded
           resizeMode="cover"
         />

--- a/packages/edition-slices/src/tiles/tile-bf/index.js
+++ b/packages/edition-slices/src/tiles/tile-bf/index.js
@@ -42,7 +42,6 @@ const TileBF = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
           relativeHorizontalOffset={crop.relativeHorizontalOffset}
           relativeVerticalOffset={crop.relativeVerticalOffset}
           uri={crop.url}
-          fill
           hasVideo={hasVideo}
         />
       </View>

--- a/packages/edition-slices/src/tiles/tile-c/index.js
+++ b/packages/edition-slices/src/tiles/tile-c/index.js
@@ -27,7 +27,6 @@ const TileC = ({ onPress, tile }) => {
         <TileImage
           aspectRatio={16 / 9}
           uri={crop.url}
-          fill
           relativeWidth={crop.relativeWidth}
           relativeHeight={crop.relativeHeight}
           relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-d/index.js
+++ b/packages/edition-slices/src/tiles/tile-d/index.js
@@ -33,7 +33,6 @@ const TileD = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-e/index.js
+++ b/packages/edition-slices/src/tiles/tile-e/index.js
@@ -50,7 +50,6 @@ const TileE = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-f-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-f-front/index.js
@@ -31,7 +31,6 @@ const TileFFront = ({ onPress, tile, orientation }) => {
         relativeVerticalOffset={imageCrop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={imageCrop.url}
-        fill
         hasVideo={article.hasVideo}
       />
       <FrontTileSummary

--- a/packages/edition-slices/src/tiles/tile-g-front/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/index.js
@@ -29,7 +29,6 @@ const TileGFront = ({ onPress, tile, orientation }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={article.hasVideo}
       />
       <FrontTileSummary

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -33,7 +33,6 @@ const TileG = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
             relativeVerticalOffset={crop.relativeVerticalOffset}
             style={styles.imageContainer}
             uri={crop.url}
-            fill
             rounded
             resizeMode="cover"
           />

--- a/packages/edition-slices/src/tiles/tile-h/index.js
+++ b/packages/edition-slices/src/tiles/tile-h/index.js
@@ -38,7 +38,6 @@ const TileH = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -30,7 +30,6 @@ const TileI = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-j/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/index.js
@@ -30,7 +30,6 @@ const TileJ = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-k/index.js
+++ b/packages/edition-slices/src/tiles/tile-k/index.js
@@ -33,7 +33,6 @@ const TileK = ({ onPress, tile, breakpoint = editionBreakpoints.small }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-n/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/index.js
@@ -47,7 +47,6 @@ const TileN = ({
           relativeVerticalOffset={crop.relativeVerticalOffset}
           style={styles.imageContainer}
           uri={crop.url}
-          fill
           hasVideo={hasVideo}
         />
         <TileSummary

--- a/packages/edition-slices/src/tiles/tile-p/index.js
+++ b/packages/edition-slices/src/tiles/tile-p/index.js
@@ -28,7 +28,6 @@ const TileP = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         rounded
         resizeMode="cover"
       />

--- a/packages/edition-slices/src/tiles/tile-q/index.js
+++ b/packages/edition-slices/src/tiles/tile-q/index.js
@@ -25,7 +25,6 @@ const TileQ = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <PositionedTileStar articleId={tile.article.id} centeredStar />

--- a/packages/edition-slices/src/tiles/tile-r/index.js
+++ b/packages/edition-slices/src/tiles/tile-r/index.js
@@ -28,7 +28,6 @@ const TileR = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
       <TileImage
         aspectRatio={16 / 9}
         uri={crop.url}
-        fill
         relativeWidth={crop.relativeWidth}
         relativeHeight={crop.relativeHeight}
         relativeHorizontalOffset={crop.relativeHorizontalOffset}

--- a/packages/edition-slices/src/tiles/tile-t/index.js
+++ b/packages/edition-slices/src/tiles/tile-t/index.js
@@ -30,7 +30,6 @@ const TileT = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-u/index.js
+++ b/packages/edition-slices/src/tiles/tile-u/index.js
@@ -31,7 +31,6 @@ const TileU = ({ onPress, tile, headlineStyle }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-v/index.js
+++ b/packages/edition-slices/src/tiles/tile-v/index.js
@@ -30,7 +30,6 @@ const TileV = ({ onPress, tile }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
       <TileSummary

--- a/packages/edition-slices/src/tiles/tile-w/index.js
+++ b/packages/edition-slices/src/tiles/tile-w/index.js
@@ -53,7 +53,6 @@ const TileW = ({ onPress, tile, breakpoint = editionBreakpoints.medium }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -53,7 +53,6 @@ const TileZ = ({ onPress, tile, breakpoint = editionBreakpoints.wide }) => {
         relativeVerticalOffset={crop.relativeVerticalOffset}
         style={styles.imageContainer}
         uri={crop.url}
-        fill
         hasVideo={hasVideo}
       />
     </TileLink>

--- a/packages/responsive-image/src/index.tsx
+++ b/packages/responsive-image/src/index.tsx
@@ -19,7 +19,7 @@ import { appendToImageURL } from "@times-components-native/utils";
 import findClosestWidth from "./utils/findClosestWidth";
 import styles from "./styles";
 
-interface ResponsiveImageProps {
+export interface ResponsiveImageProps {
   readonly aspectRatio?: number;
   readonly onImagePress?: () => void;
   readonly caption?: JSX.Element;


### PR DESCRIPTION
1. Removed redundant `fill` prop
2. Extends the ResponsiveImageProps in TileImage to provide better typescript support 