### PR TITLE
fix(TNLT-6347): changes front lead2 portrait grid

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1866,7 +1866,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View
         style={
           Object {
-            "width": "32.751937984496124%",
+            "width": "41.33963178294574%",
           }
         }
       >
@@ -1885,7 +1885,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View
         style={
           Object {
-            "width": "67.10271317829458%",
+            "width": "58.515019379844965%",
           }
         }
       >
@@ -4471,7 +4471,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View
         style={
           Object {
-            "width": "32.89855072463767%",
+            "width": "41.42210144927536%",
           }
         }
       >
@@ -4490,7 +4490,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View
         style={
           Object {
-            "width": "66.99275362318839%",
+            "width": "58.46920289855072%",
           }
         }
       >
@@ -7362,7 +7362,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View
           style={
             Object {
-              "width": "32.89855072463767%",
+              "width": "41.42210144927536%",
             }
           }
         >
@@ -7381,7 +7381,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View
           style={
             Object {
-              "width": "66.99275362318839%",
+              "width": "58.46920289855072%",
             }
           }
         >

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-a-front.test.js.snap
@@ -687,7 +687,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={15}
+      headlineMarginBottom={10}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -2426,7 +2426,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -3028,7 +3028,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -3630,7 +3630,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -4232,7 +4232,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -4834,7 +4834,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }

--- a/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tile-g-front.test.js.snap
@@ -2484,7 +2484,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={10}
+      headlineMarginBottom={15}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",
@@ -3086,7 +3086,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={10}
+      headlineMarginBottom={15}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",
@@ -3688,7 +3688,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={10}
+      headlineMarginBottom={15}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -1865,7 +1865,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View
         style={
           Object {
-            "width": "32.751937984496124%",
+            "width": "41.33963178294574%",
           }
         }
       >
@@ -1884,7 +1884,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
       <View
         style={
           Object {
-            "width": "67.10271317829458%",
+            "width": "58.515019379844965%",
           }
         }
       >
@@ -4465,7 +4465,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View
         style={
           Object {
-            "width": "32.89855072463767%",
+            "width": "41.42210144927536%",
           }
         }
       >
@@ -4484,7 +4484,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
       <View
         style={
           Object {
-            "width": "66.99275362318839%",
+            "width": "58.46920289855072%",
           }
         }
       >
@@ -7352,7 +7352,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View
           style={
             Object {
-              "width": "32.89855072463767%",
+              "width": "41.42210144927536%",
             }
           }
         >
@@ -7371,7 +7371,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
         <View
           style={
             Object {
-              "width": "66.99275362318839%",
+              "width": "58.46920289855072%",
             }
           }
         >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-a-front.test.js.snap
@@ -687,7 +687,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={15}
+      headlineMarginBottom={10}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -2426,7 +2426,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -3028,7 +3028,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -3630,7 +3630,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -4232,7 +4232,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }
@@ -4834,7 +4834,7 @@ Array [
       aspectRatio={0.8}
       style={
         Object {
-          "marginBottom": 0,
+          "marginBottom": 10,
           "width": "100%",
         }
       }

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tile-g-front.test.js.snap
@@ -2484,7 +2484,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={10}
+      headlineMarginBottom={15}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",
@@ -3086,7 +3086,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={10}
+      headlineMarginBottom={15}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",
@@ -3688,7 +3688,7 @@ Array [
           "width": "100%",
         }
       }
-      headlineMarginBottom={10}
+      headlineMarginBottom={15}
       headlineStyle={
         Object {
           "fontFamily": "TimesModern-Bold",

--- a/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-a-front/styles/index.js
@@ -96,7 +96,7 @@ const styles = {
     },
     "1080": {
       ...sharedLandscapeStyles,
-      headlineMarginBottom: spacing(3),
+      headlineMarginBottom: spacing(2),
       straplineMarginTop: spacing(2),
       straplineMarginBottom: spacing(3),
       headline: {

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -54,7 +54,7 @@ const sharedPortraitStyles = {
     width: "100%",
     marginBottom: spacing(2),
   },
-  headlineMarginBottom: spacing(2),
+  headlineMarginBottom: spacing(3),
 };
 
 const styles = {

--- a/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g-front/styles/index.js
@@ -26,10 +26,6 @@ const sharedSummary = {
 
 const sharedStyles = {
   summaryContainer: { ...sharedSummaryContainer, paddingTop: spacing(1) },
-  imageContainer: {
-    width: "100%",
-    marginBottom: 0,
-  },
   summary: { ...sharedSummary },
   bylineMarginBottom: spacing(3),
 };
@@ -41,6 +37,10 @@ const sharedLandscapeStyles = {
     paddingRight: spacing(2),
     flex: 1,
   },
+  imageContainer: {
+    width: "100%",
+    marginBottom: 0,
+  },
   headlineMarginBottom: spacing(1),
 };
 
@@ -49,6 +49,10 @@ const sharedPortraitStyles = {
   container: {
     paddingLeft: spacing(2),
     flex: 1,
+  },
+  imageContainer: {
+    width: "100%",
+    marginBottom: spacing(2),
   },
   headlineMarginBottom: spacing(2),
 };

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -210,7 +210,7 @@ describe("getFrontTileConfig", () => {
         show: false,
       },
       strapline: {
-        marginBottom: 15,
+        marginBottom: 0,
         show: false,
       },
       content: {
@@ -298,7 +298,7 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 25,
+        marginBottom: 0,
         show: false,
       },
       content: {
@@ -338,11 +338,11 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       byline: {
-        marginBottom: 20,
+        marginBottom: 0,
         show: false,
       },
       strapline: {
-        marginBottom: 20,
+        marginBottom: 0,
         show: false,
       },
       content: {

--- a/packages/front-page/__tests__/get-front-tile-config.test.ts
+++ b/packages/front-page/__tests__/get-front-tile-config.test.ts
@@ -92,19 +92,19 @@ describe("getFrontTileConfig", () => {
   it("fits headline, strapline and byline", () => {
     const summaryConfig = {
       container: {
-        height: 300,
+        height: 100,
       },
       headline: {
-        height: 80,
+        height: 40,
         marginBottom: 20,
       },
       strapline: {
-        height: 80,
+        height: 20,
         marginTop: 10,
-        marginBottom: 15,
+        marginBottom: 10,
       },
       bylines: {
-        height: 100,
+        height: 20,
         marginBottom: 20,
       },
       content: {
@@ -122,7 +122,7 @@ describe("getFrontTileConfig", () => {
         show: true,
       },
       strapline: {
-        marginBottom: 15,
+        marginBottom: 10,
         show: true,
       },
       content: {
@@ -177,22 +177,22 @@ describe("getFrontTileConfig", () => {
     });
   });
 
-  it("fits headline, strapline, byline and hides content if only 1 line fits", () => {
+  it("fits headline and 2 lines of content if there is no room for headline/byline and content", () => {
     const summaryConfig = {
       container: {
-        height: 320,
+        height: 100,
       },
       headline: {
-        height: 80,
+        height: 20,
         marginBottom: 20,
       },
       strapline: {
-        height: 80,
-        marginTop: 20,
+        height: 0,
+        marginTop: 10,
         marginBottom: 15,
       },
       bylines: {
-        height: 80,
+        height: 40,
         marginBottom: 20,
       },
       content: {
@@ -207,10 +207,54 @@ describe("getFrontTileConfig", () => {
       },
       byline: {
         marginBottom: 0,
-        show: true,
+        show: false,
       },
       strapline: {
         marginBottom: 15,
+        show: false,
+      },
+      content: {
+        marginBottom: 0,
+        numberOfLines: 3,
+        show: true,
+      },
+    });
+  });
+
+  it("fits headline, strapline, byline and hides content if only 1 line fits", () => {
+    const summaryConfig = {
+      container: {
+        height: 100,
+      },
+      headline: {
+        height: 20,
+        marginBottom: 20,
+      },
+      strapline: {
+        height: 10,
+        marginTop: 10,
+        marginBottom: 10,
+      },
+      bylines: {
+        height: 40,
+        marginBottom: 20,
+      },
+      content: {
+        lineHeight: 40,
+      },
+    };
+    const config = getFrontTileConfig(summaryConfig);
+    expect(config).toEqual({
+      headline: {
+        marginBottom: 10,
+        show: true,
+      },
+      byline: {
+        marginBottom: 0,
+        show: true,
+      },
+      strapline: {
+        marginBottom: 10,
         show: true,
       },
       content: {
@@ -224,10 +268,10 @@ describe("getFrontTileConfig", () => {
   it("fits headline and byline (when strapline is missing)", () => {
     const summaryConfig = {
       container: {
-        height: 200,
+        height: 100,
       },
       headline: {
-        height: 80,
+        height: 60,
         marginBottom: 20,
       },
       strapline: {
@@ -236,7 +280,7 @@ describe("getFrontTileConfig", () => {
         marginBottom: 25,
       },
       bylines: {
-        height: 100,
+        height: 20,
         marginBottom: 20,
       },
       content: {

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -22,18 +22,18 @@ interface SummaryConfig {
   };
 }
 
-function isLastItem(items: string[], item: string) {
+const shouldRemoveMarginBottom = (items: string[], item: string) => {
   const pos = items.indexOf(item);
 
   if (pos < 0) return true;
 
   return pos === items.length - 1;
-}
+};
 
-function getNumberOfLines(heightAvailable: number, lineHeight: number) {
+const getNumberOfLines = (heightAvailable: number, lineHeight: number) => {
   if (heightAvailable < 0) return 0;
   return Math.floor(heightAvailable / lineHeight);
-}
+};
 
 export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
   const { container, headline, strapline, bylines, content } = summaryConfig;
@@ -88,17 +88,19 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
   return {
     headline: {
       show: true,
-      marginBottom: isLastItem(itemsToRender, "headline") ? 0 : headlineMargin,
+      marginBottom: shouldRemoveMarginBottom(itemsToRender, "headline")
+        ? 0
+        : headlineMargin,
     },
     strapline: {
       show: itemsToRender.includes("strapline"),
-      marginBottom: isLastItem(itemsToRender, "strapline")
+      marginBottom: shouldRemoveMarginBottom(itemsToRender, "strapline")
         ? 0
         : strapline.marginBottom,
     },
     byline: {
       show: itemsToRender.includes("byline"),
-      marginBottom: isLastItem(itemsToRender, "byline")
+      marginBottom: shouldRemoveMarginBottom(itemsToRender, "byline")
         ? 0
         : bylines.marginBottom,
     },

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -22,7 +22,7 @@ interface SummaryConfig {
   };
 }
 
-function isLastItem(items: any[], item: string) {
+function isLastItem(items: string[], item: string) {
   const pos = items.indexOf(item);
 
   if (pos < 0) return true;
@@ -83,7 +83,7 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
       "byline",
     (canAccommodateContentWithByline || canAccommodateContentWithoutByline) &&
       "content",
-  ].filter(Boolean);
+  ].filter(Boolean) as string[];
 
   return {
     headline: {

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -67,14 +67,14 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
       marginBottom:
         canAccommodateStrapline ||
         canAccommodateByline ||
-        canAccommodateContentWithByline
+        canAccommodateContentWithoutByline
           ? headlineMargin
           : 0,
     },
     strapline: {
       show: strapline.height > 0 && canAccommodateStrapline,
       marginBottom:
-        canAccommodateByline || canAccommodateContentWithByline
+        canAccommodateByline || canAccommodateContentWithoutByline
           ? strapline.marginBottom
           : 0,
     },

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -22,17 +22,19 @@ interface SummaryConfig {
   };
 }
 
-const shouldRemoveMarginBottom = (items: string[], item: string) => {
-  const pos = items.indexOf(item);
-
-  if (pos < 0) return true;
-
-  return pos === items.length - 1;
-};
-
 const getNumberOfLines = (heightAvailable: number, lineHeight: number) => {
   if (heightAvailable < 0) return 0;
   return Math.floor(heightAvailable / lineHeight);
+};
+
+const calculateMarginBottom = (
+  items: string[],
+  item: string,
+  itemMargin: number,
+) => {
+  const pos = items.indexOf(item);
+
+  return pos < 0 || pos === items.length - 1 ? 0 : itemMargin;
 };
 
 export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
@@ -88,21 +90,27 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
   return {
     headline: {
       show: true,
-      marginBottom: shouldRemoveMarginBottom(itemsToRender, "headline")
-        ? 0
-        : headlineMargin,
+      marginBottom: calculateMarginBottom(
+        itemsToRender,
+        "headline",
+        headlineMargin,
+      ),
     },
     strapline: {
       show: itemsToRender.includes("strapline"),
-      marginBottom: shouldRemoveMarginBottom(itemsToRender, "strapline")
-        ? 0
-        : strapline.marginBottom,
+      marginBottom: calculateMarginBottom(
+        itemsToRender,
+        "strapline",
+        strapline.marginBottom,
+      ),
     },
     byline: {
       show: itemsToRender.includes("byline"),
-      marginBottom: shouldRemoveMarginBottom(itemsToRender, "byline")
-        ? 0
-        : bylines.marginBottom,
+      marginBottom: calculateMarginBottom(
+        itemsToRender,
+        "byline",
+        bylines.marginBottom,
+      ),
     },
     content: {
       show: itemsToRender.includes("content"),

--- a/packages/front-page/utils/get-front-tile-config.ts
+++ b/packages/front-page/utils/get-front-tile-config.ts
@@ -43,37 +43,68 @@ export const getFrontTileConfig = (summaryConfig: SummaryConfig) => {
     container.height >=
     headlineWithMargin + straplineWithMargin + bylines.height;
 
-  const heightForContent =
+  const heightForContentWithByline =
     container.height -
     (headlineWithMargin + straplineWithMargin + bylineWithMargin);
-  const canAccommodateContent =
-    heightForContent >= content.lineHeight * minimumNumberOfTeaserTextLines;
+
+  const heightForContentWithoutByline =
+    container.height - (headlineWithMargin + straplineWithMargin);
+
+  const canAccommodateContentWithByline =
+    heightForContentWithByline >=
+    content.lineHeight * minimumNumberOfTeaserTextLines;
+
+  const canAccommodateContentWithoutByline =
+    heightForContentWithoutByline >=
+    content.lineHeight * minimumNumberOfTeaserTextLines;
+
+  const shouldShowContentInsteadOfByline =
+    !canAccommodateContentWithByline && canAccommodateContentWithoutByline;
 
   return {
     headline: {
       show: true,
       marginBottom:
-        canAccommodateStrapline || canAccommodateByline || canAccommodateContent
+        canAccommodateStrapline ||
+        canAccommodateByline ||
+        canAccommodateContentWithByline
           ? headlineMargin
           : 0,
     },
     strapline: {
       show: strapline.height > 0 && canAccommodateStrapline,
       marginBottom:
-        canAccommodateByline || canAccommodateContent
+        canAccommodateByline || canAccommodateContentWithByline
           ? strapline.marginBottom
           : 0,
     },
     byline: {
-      show: bylines.height > 0 && canAccommodateByline,
-      marginBottom: canAccommodateContent ? bylines.marginBottom : 0,
+      show:
+        bylines.height > 0 &&
+        !shouldShowContentInsteadOfByline &&
+        canAccommodateByline,
+      marginBottom: canAccommodateContentWithByline ? bylines.marginBottom : 0,
     },
-    content: {
-      show: canAccommodateContent,
-      marginBottom: 0,
-      numberOfLines: canAccommodateContent
-        ? Math.floor(heightForContent / content.lineHeight)
-        : 0,
-    },
+    content: canAccommodateContentWithByline
+      ? {
+          show: true,
+          marginBottom: 0,
+          numberOfLines: Math.floor(
+            heightForContentWithByline / content.lineHeight,
+          ),
+        }
+      : canAccommodateContentWithoutByline
+      ? {
+          show: true,
+          marginBottom: 0,
+          numberOfLines: Math.floor(
+            heightForContentWithoutByline / content.lineHeight,
+          ),
+        }
+      : {
+          show: false,
+          marginBottom: 0,
+          numberOfLines: 0,
+        },
   };
 };

--- a/packages/slice-layout/__tests__/android/__snapshots__/front-l2-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/front-l2-with-style.android.test.js.snap
@@ -10,7 +10,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.751937984496124%",
+            "width": "41.33963178294574%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -20,7 +20,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.10271317829458%",
+            "width": "58.515019379844965%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -49,7 +49,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -59,7 +59,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -88,7 +88,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -98,7 +98,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -127,7 +127,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -137,7 +137,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -166,7 +166,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.89855072463767%",
+            "width": "41.42210144927536%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -176,7 +176,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
         },
         Object {
           "style": Object {
-            "width": "66.99275362318839%",
+            "width": "58.46920289855072%",
           },
           "tile": <ExampleChild
             id="lead2"

--- a/packages/slice-layout/__tests__/android/__snapshots__/front-l2.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/front-l2.android.test.js.snap
@@ -22,7 +22,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.751937984496124%",
+            "width": "41.33963178294574%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -32,7 +32,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.10271317829458%",
+            "width": "58.515019379844965%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -73,7 +73,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -83,7 +83,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -124,7 +124,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -134,7 +134,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -175,7 +175,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -185,7 +185,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -226,7 +226,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.89855072463767%",
+            "width": "41.42210144927536%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -236,7 +236,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
         },
         Object {
           "style": Object {
-            "width": "66.99275362318839%",
+            "width": "58.46920289855072%",
           },
           "tile": <ExampleChild
             id="lead2"

--- a/packages/slice-layout/__tests__/ios/__snapshots__/front-l2-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/front-l2-with-style.ios.test.js.snap
@@ -10,7 +10,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.751937984496124%",
+            "width": "41.33963178294574%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -20,7 +20,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.10271317829458%",
+            "width": "58.515019379844965%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -49,7 +49,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -59,7 +59,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -88,7 +88,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -98,7 +98,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -127,7 +127,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -137,7 +137,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -166,7 +166,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.89855072463767%",
+            "width": "41.42210144927536%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -176,7 +176,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
         },
         Object {
           "style": Object {
-            "width": "66.99275362318839%",
+            "width": "58.46920289855072%",
           },
           "tile": <ExampleChild
             id="lead2"

--- a/packages/slice-layout/__tests__/ios/__snapshots__/front-l2.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/front-l2.ios.test.js.snap
@@ -22,7 +22,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.751937984496124%",
+            "width": "41.33963178294574%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -32,7 +32,7 @@ exports[`1. front lead two - portrait - 768 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.10271317829458%",
+            "width": "58.515019379844965%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -73,7 +73,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -83,7 +83,7 @@ exports[`2. front lead two - portrait - 810 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -124,7 +124,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -134,7 +134,7 @@ exports[`3. front lead two - portrait - 834 - 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -175,7 +175,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.785388127853885%",
+            "width": "41.358447488584474%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -185,7 +185,7 @@ exports[`4. front lead two - portrait - 834 - less than 0.75 ratio 1`] = `
         },
         Object {
           "style": Object {
-            "width": "67.07762557077626%",
+            "width": "58.504566210045674%",
           },
           "tile": <ExampleChild
             id="lead2"
@@ -226,7 +226,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
       Array [
         Object {
           "style": Object {
-            "width": "32.89855072463767%",
+            "width": "41.42210144927536%",
           },
           "tile": <ExampleChild
             id="lead1"
@@ -236,7 +236,7 @@ exports[`5. front lead two - portrait - 1024 1`] = `
         },
         Object {
           "style": Object {
-            "width": "66.99275362318839%",
+            "width": "58.46920289855072%",
           },
           "tile": <ExampleChild
             id="lead2"

--- a/packages/slice-layout/src/templates/frontleadtwo/styles.js
+++ b/packages/slice-layout/src/templates/frontleadtwo/styles.js
@@ -56,10 +56,10 @@ const calculateStyles = (orientation, windowWidth) => {
       paddingTop: spacing(3),
     },
     lead1Container: {
-      width: columnToPercentageWithOrientation({ numberOfColumns: 4 }),
+      width: columnToPercentageWithOrientation({ numberOfColumns: 5 }),
     },
     lead2Container: {
-      width: columnToPercentageWithOrientation({ numberOfColumns: 8 }),
+      width: columnToPercentageWithOrientation({ numberOfColumns: 7 }),
     },
   };
 


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-6347

# Amendments to Dynamic Front Tile Logic
Previously, our front tiles rendered the following in order of priority, and anything that doesn't fit simply was removed from the tile `headline/strapline (if present) + byline + content`

This exposed an issue with the front lead2 when the design changed - whereby we were rendering headline+byline, and then with a large space underneath as there's not enough room for content. To better fill the tile in this context, it's better to render headline+content. So the new rules are as follows:

1. If there is not enough room for headline+byline+content, but there is room for headline+content, then we show headline+content
2. If there is not enough room for headline+byline+content, and there’s only room for headline+byline, then we show headline+byline
3. If there is room for headline+byline+content, then show headline+byline+content

You can see the impact of this change in the Lead Two screenshots with the 1-deck and 2-deck headlines.

# Lead Two 
## Before - iPad (8th gen 768x1024)
![Simulator Screen Shot - iPad (8th generation) - 2021-01-20 at 13 55 44](https://user-images.githubusercontent.com/6280629/105185208-273c1300-5b28-11eb-86be-24c1ce9aa048.png)

## After - iPad (8th gen 768x1024)
![Simulator Screen Shot - iPad (8th generation) - 2021-01-21 at 13 09 14](https://user-images.githubusercontent.com/6280629/105355378-f91f0780-5be9-11eb-8b9a-c61e98e65002.png)
![Simulator Screen Shot - iPad (8th generation) - 2021-01-21 at 13 09 01](https://user-images.githubusercontent.com/6280629/105355392-fde3bb80-5be9-11eb-8dd6-985845a955bd.png)

# Lead One And One
## Before - iPad (8th gen 768x1024)
![image](https://user-images.githubusercontent.com/6280629/105355833-90845a80-5bea-11eb-8585-d4b14afda190.png)

## After - iPad (8th gen 768x1024)
![Simulator Screen Shot - iPad (8th generation) - 2021-01-21 at 13 08 41](https://user-images.githubusercontent.com/6280629/105355492-25d31f00-5bea-11eb-921b-c4739a4e7cb5.png)
