### PR TITLE
feat: (TNLT-6336/TNLT-6352) secondary-four right-aligned variants (tablet only)

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2436,80 +2436,7 @@ exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "flexDirection": "row",
-        "marginHorizontal": 20,
-        "paddingVertical": 5,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "width": "66.6%",
-        }
-      }
-    >
-      <TileAT />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.3%",
-        }
-      }
-    >
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2582,7 +2509,7 @@ exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`33. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2655,7 +2582,7 @@ exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`34. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2728,7 +2655,7 @@ exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2801,7 +2728,7 @@ exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`37. comment lead and cartoon - wide 1`] = `
+exports[`36. comment lead and cartoon - wide 1`] = `
 <View
   style={
     Object {
@@ -2854,7 +2781,7 @@ exports[`37. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`38. daily universal register - wide 1`] = `
+exports[`37. daily universal register - wide 1`] = `
 <View
   style={
     Object {
@@ -2963,7 +2890,7 @@ exports[`38. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one and one - wide 1`] = `
+exports[`38. lead one and one - wide 1`] = `
 <View
   style={
     Object {
@@ -3015,7 +2942,7 @@ exports[`39. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead one and one - supplement - wide 1`] = `
+exports[`39. lead one and one - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -3067,7 +2994,7 @@ exports[`40. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead one full width - wide 1`] = `
+exports[`40. lead one full width - wide 1`] = `
 <View
   style={
     Object {
@@ -3082,7 +3009,7 @@ exports[`41. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`42. lead two no pic and two - wide 1`] = `
+exports[`41. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3163,7 +3090,7 @@ exports[`42. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`43. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3235,7 +3162,7 @@ exports[`43. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`44. leaders slice - wide 1`] = `
+exports[`43. leaders slice - wide 1`] = `
 <View
   style={
     Object {
@@ -3360,7 +3287,7 @@ exports[`44. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`45. secondary one and four - wide 1`] = `
+exports[`44. secondary one and four - wide 1`] = `
 <View
   style={
     Object {
@@ -3528,7 +3455,7 @@ exports[`45. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary one - wide 1`] = `
+exports[`45. secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3543,7 +3470,7 @@ exports[`46. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`47. supplement secondary one - wide 1`] = `
+exports[`46. supplement secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3558,7 +3485,7 @@ exports[`47. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary four - wide 1`] = `
+exports[`47. secondary four - wide 1`] = `
 <View
   style={
     Object {
@@ -3649,7 +3576,7 @@ exports[`48. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary four - consecutive - wide 1`] = `
+exports[`48. secondary four - consecutive - wide 1`] = `
 <View
   style={
     Object {
@@ -3740,7 +3667,7 @@ exports[`49. secondary four - consecutive - wide 1`] = `
 </View>
 `;
 
-exports[`50. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -3839,7 +3766,7 @@ exports[`50. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`51. secondary one and columnist - wide 1`] = `
+exports[`50. secondary one and columnist - wide 1`] = `
 <View
   style={
     Object {
@@ -3892,7 +3819,7 @@ exports[`51. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`52. secondary two and two - wide 1`] = `
+exports[`51. secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3982,7 +3909,7 @@ exports[`52. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`53. supplement secondary two and two - wide 1`] = `
+exports[`52. supplement secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -4090,7 +4017,7 @@ exports[`53. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`54. lead one and four slice - wide 1`] = `
+exports[`53. lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4173,7 +4100,7 @@ exports[`54. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`55. supplement lead one and four slice - wide 1`] = `
+exports[`54. supplement lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4279,7 +4206,7 @@ exports[`55. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`56. standard slice - wide 1`] = `
+exports[`55. standard slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4346,7 +4273,7 @@ exports[`56. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`57. secondary two no pic and two - wide 1`] = `
+exports[`56. secondary two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -4437,7 +4364,7 @@ exports[`57. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`58. list two and six no pic - wide 1`] = `
+exports[`57. list two and six no pic - wide 1`] = `
 <View
   style={
     Object {
@@ -4637,7 +4564,7 @@ exports[`58. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`59. puzzle - wide 1`] = `
+exports[`58. puzzle - wide 1`] = `
 <View
   style={
     Object {
@@ -4689,7 +4616,7 @@ exports[`59. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead two - portrait - wide 1`] = `
+exports[`59. front lead two - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4767,7 +4694,7 @@ exports[`60. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead two - landscape - wide 1`] = `
+exports[`60. front lead two - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4853,7 +4780,7 @@ exports[`61. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one and one - portrait - wide 1`] = `
+exports[`61. front lead one and one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4932,7 +4859,7 @@ exports[`62. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`63. front lead one and one - landscape - wide 1`] = `
+exports[`62. front lead one and one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -5018,7 +4945,7 @@ exports[`63. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`64. front lead one - portrait - wide 1`] = `
+exports[`63. front lead one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -5067,7 +4994,7 @@ exports[`64. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`65. front lead one - landscape - wide 1`] = `
+exports[`64. front lead one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -5134,7 +5061,7 @@ exports[`65. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`65. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5207,7 +5134,7 @@ exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5280,80 +5207,7 @@ exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 30,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "flexDirection": "row",
-        "marginHorizontal": 20,
-        "paddingVertical": 5,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "width": "66.6%",
-        }
-      }
-    >
-      <TileAT />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.3%",
-        }
-      }
-    >
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`67. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5426,7 +5280,7 @@ exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5499,7 +5353,7 @@ exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`69. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5572,7 +5426,7 @@ exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5645,7 +5499,7 @@ exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`73. comment lead and cartoon - huge 1`] = `
+exports[`71. comment lead and cartoon - huge 1`] = `
 <View
   style={
     Object {
@@ -5708,7 +5562,7 @@ exports[`73. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`74. daily universal register - huge 1`] = `
+exports[`72. daily universal register - huge 1`] = `
 <View
   style={
     Object {
@@ -5827,7 +5681,7 @@ exports[`74. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead one and one - huge 1`] = `
+exports[`73. lead one and one - huge 1`] = `
 <View
   style={
     Object {
@@ -5889,7 +5743,7 @@ exports[`75. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`76. lead one and one - supplement - huge 1`] = `
+exports[`74. lead one and one - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -5951,7 +5805,7 @@ exports[`76. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`77. lead one full width - huge 1`] = `
+exports[`75. lead one full width - huge 1`] = `
 <View
   style={
     Object {
@@ -5976,7 +5830,7 @@ exports[`77. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`78. lead two no pic and two - huge 1`] = `
+exports[`76. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6067,7 +5921,7 @@ exports[`78. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`79. lead two no pic and two - huge 1`] = `
+exports[`77. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6149,7 +6003,7 @@ exports[`79. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`80. leaders slice - huge 1`] = `
+exports[`78. leaders slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6284,7 +6138,7 @@ exports[`80. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary one and four - huge 1`] = `
+exports[`79. secondary one and four - huge 1`] = `
 <View
   style={
     Object {
@@ -6462,7 +6316,7 @@ exports[`81. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one - huge 1`] = `
+exports[`80. secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6487,7 +6341,7 @@ exports[`82. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`83. supplement secondary one - huge 1`] = `
+exports[`81. supplement secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6512,7 +6366,7 @@ exports[`83. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`84. secondary four - huge 1`] = `
+exports[`82. secondary four - huge 1`] = `
 <View
   style={
     Object {
@@ -6613,7 +6467,7 @@ exports[`84. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`85. secondary four - consecutive - huge 1`] = `
+exports[`83. secondary four - consecutive - huge 1`] = `
 <View
   style={
     Object {
@@ -6714,7 +6568,7 @@ exports[`85. secondary four - consecutive - huge 1`] = `
 </View>
 `;
 
-exports[`86. secondary four - supplement - huge 1`] = `
+exports[`84. secondary four - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -6823,7 +6677,7 @@ exports[`86. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`87. secondary one and columnist - huge 1`] = `
+exports[`85. secondary one and columnist - huge 1`] = `
 <View
   style={
     Object {
@@ -6886,7 +6740,7 @@ exports[`87. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two and two - huge 1`] = `
+exports[`86. secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6986,7 +6840,7 @@ exports[`88. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. supplement secondary two and two - huge 1`] = `
+exports[`87. supplement secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -7086,7 +6940,7 @@ exports[`89. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`90. lead one and four slice - huge 1`] = `
+exports[`88. lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -7179,7 +7033,7 @@ exports[`90. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`91. supplement lead one and four slice - huge 1`] = `
+exports[`89. supplement lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -7295,7 +7149,7 @@ exports[`91. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`92. standard slice - huge 1`] = `
+exports[`90. standard slice - huge 1`] = `
 <View
   style={
     Object {
@@ -7372,7 +7226,7 @@ exports[`92. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`93. secondary two no pic and two - huge 1`] = `
+exports[`91. secondary two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -7473,7 +7327,7 @@ exports[`93. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`94. list two and six no pic - huge 1`] = `
+exports[`92. list two and six no pic - huge 1`] = `
 <View
   style={
     Object {
@@ -7683,7 +7537,7 @@ exports[`94. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`95. puzzle - huge 1`] = `
+exports[`93. puzzle - huge 1`] = `
 <View
   style={
     Object {
@@ -7745,7 +7599,7 @@ exports[`95. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead two - portrait - huge 1`] = `
+exports[`94. front lead two - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7833,7 +7687,7 @@ exports[`96. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`97. front lead two - landscape - huge 1`] = `
+exports[`95. front lead two - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7929,7 +7783,7 @@ exports[`97. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`98. front lead one and one - portrait - huge 1`] = `
+exports[`96. front lead one and one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -8018,7 +7872,7 @@ exports[`98. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`99. front lead one and one - landscape - huge 1`] = `
+exports[`97. front lead one and one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -8114,7 +7968,7 @@ exports[`99. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`100. front lead one - portrait - huge 1`] = `
+exports[`98. front lead one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -8173,7 +8027,7 @@ exports[`100. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`101. front lead one - landscape - huge 1`] = `
+exports[`99. front lead one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -8251,7 +8105,7 @@ exports[`101. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`100. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8334,7 +8188,7 @@ exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = 
 </View>
 `;
 
-exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`101. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8417,90 +8271,7 @@ exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 1180,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "flexDirection": "row",
-          "marginHorizontal": 20,
-          "paddingVertical": 5,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "width": "66.6%",
-          }
-        }
-      >
-        <TileAT />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "width": "33.3%",
-          }
-        }
-      >
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8583,7 +8354,7 @@ exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1
 </View>
 `;
 
-exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8666,7 +8437,7 @@ exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`104. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8749,7 +8520,7 @@ exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View
   style={
     Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -845,7 +845,98 @@ exports[`12. secondary four - medium 1`] = `
 </View>
 `;
 
-exports[`13. secondary four - supplement - medium 1`] = `
+exports[`13. secondary four - consecutive - medium 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row-reverse",
+        "marginHorizontal": 20,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 2,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 15,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 15,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <TileB />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileB />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`14. secondary four - supplement - medium 1`] = `
 <View
   style={
     Object {
@@ -944,7 +1035,7 @@ exports[`13. secondary four - supplement - medium 1`] = `
 </View>
 `;
 
-exports[`14. secondary one and columnist - medium 1`] = `
+exports[`15. secondary one and columnist - medium 1`] = `
 <View
   style={
     Object {
@@ -997,7 +1088,7 @@ exports[`14. secondary one and columnist - medium 1`] = `
 </View>
 `;
 
-exports[`15. secondary two and two - medium 1`] = `
+exports[`16. secondary two and two - medium 1`] = `
 <View
   style={
     Object {
@@ -1105,7 +1196,7 @@ exports[`15. secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`16. supplement secondary two and two - medium 1`] = `
+exports[`17. supplement secondary two and two - medium 1`] = `
 <View
   style={
     Object {
@@ -1213,7 +1304,7 @@ exports[`16. supplement secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`17. lead one and four slice - medium 1`] = `
+exports[`18. lead one and four slice - medium 1`] = `
 <View
   style={
     Object {
@@ -1296,7 +1387,7 @@ exports[`17. lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`18. supplement lead one and four slice - medium 1`] = `
+exports[`19. supplement lead one and four slice - medium 1`] = `
 <View
   style={
     Object {
@@ -1403,7 +1494,7 @@ exports[`18. supplement lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`19. standard slice - medium 1`] = `
+exports[`20. standard slice - medium 1`] = `
 <View
   style={
     Object {
@@ -1470,7 +1561,7 @@ exports[`19. standard slice - medium 1`] = `
 </View>
 `;
 
-exports[`20. secondary two no pic and two - medium 1`] = `
+exports[`21. secondary two no pic and two - medium 1`] = `
 <View
   style={
     Object {
@@ -1577,7 +1668,7 @@ exports[`20. secondary two no pic and two - medium 1`] = `
 </View>
 `;
 
-exports[`21. list two and six no pic - medium 1`] = `
+exports[`22. list two and six no pic - medium 1`] = `
 <View
   style={
     Object {
@@ -1777,7 +1868,7 @@ exports[`21. list two and six no pic - medium 1`] = `
 </View>
 `;
 
-exports[`22. puzzle - medium 1`] = `
+exports[`23. puzzle - medium 1`] = `
 <View
   style={
     Object {
@@ -1829,7 +1920,7 @@ exports[`22. puzzle - medium 1`] = `
 </View>
 `;
 
-exports[`23. front lead two - portrait - medium 1`] = `
+exports[`24. front lead two - portrait - medium 1`] = `
 <View
   style={
     Object {
@@ -1907,7 +1998,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`24. front lead two - landscape - medium 1`] = `
+exports[`25. front lead two - landscape - medium 1`] = `
 <View
   style={
     Object {
@@ -1966,7 +2057,7 @@ exports[`24. front lead two - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`25. front lead one and one - portrait - medium 1`] = `
+exports[`26. front lead one and one - portrait - medium 1`] = `
 <View
   style={
     Object {
@@ -2045,7 +2136,7 @@ exports[`25. front lead one and one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`26. front lead one and one - landscape - medium 1`] = `
+exports[`27. front lead one and one - landscape - medium 1`] = `
 <View
   style={
     Object {
@@ -2104,7 +2195,7 @@ exports[`26. front lead one and one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`27. front lead one - portrait - medium 1`] = `
+exports[`28. front lead one - portrait - medium 1`] = `
 <View
   style={
     Object {
@@ -2153,7 +2244,7 @@ exports[`27. front lead one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`28. front lead one - landscape - medium 1`] = `
+exports[`29. front lead one - landscape - medium 1`] = `
 <View
   style={
     Object {
@@ -2199,7 +2290,7 @@ exports[`28. front lead one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
+exports[`30. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2272,7 +2363,7 @@ exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] =
 </View>
 `;
 
-exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2345,7 +2436,80 @@ exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "marginHorizontal": 20,
+        "paddingVertical": 5,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "66.6%",
+        }
+      }
+    >
+      <TileAT />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "33.3%",
+        }
+      }
+    >
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2418,7 +2582,7 @@ exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2491,7 +2655,7 @@ exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2564,7 +2728,7 @@ exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2637,7 +2801,7 @@ exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`35. comment lead and cartoon - wide 1`] = `
+exports[`37. comment lead and cartoon - wide 1`] = `
 <View
   style={
     Object {
@@ -2690,7 +2854,7 @@ exports[`35. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`36. daily universal register - wide 1`] = `
+exports[`38. daily universal register - wide 1`] = `
 <View
   style={
     Object {
@@ -2799,7 +2963,7 @@ exports[`36. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`37. lead one and one - wide 1`] = `
+exports[`39. lead one and one - wide 1`] = `
 <View
   style={
     Object {
@@ -2851,7 +3015,7 @@ exports[`37. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`38. lead one and one - supplement - wide 1`] = `
+exports[`40. lead one and one - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -2903,7 +3067,7 @@ exports[`38. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one full width - wide 1`] = `
+exports[`41. lead one full width - wide 1`] = `
 <View
   style={
     Object {
@@ -2918,7 +3082,7 @@ exports[`39. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -2999,7 +3163,7 @@ exports[`40. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead two no pic and two - wide 1`] = `
+exports[`43. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3071,7 +3235,7 @@ exports[`41. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`42. leaders slice - wide 1`] = `
+exports[`44. leaders slice - wide 1`] = `
 <View
   style={
     Object {
@@ -3196,7 +3360,7 @@ exports[`42. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`43. secondary one and four - wide 1`] = `
+exports[`45. secondary one and four - wide 1`] = `
 <View
   style={
     Object {
@@ -3364,7 +3528,7 @@ exports[`43. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`44. secondary one - wide 1`] = `
+exports[`46. secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3379,7 +3543,7 @@ exports[`44. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`45. supplement secondary one - wide 1`] = `
+exports[`47. supplement secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3394,7 +3558,7 @@ exports[`45. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary four - wide 1`] = `
+exports[`48. secondary four - wide 1`] = `
 <View
   style={
     Object {
@@ -3485,7 +3649,98 @@ exports[`46. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`47. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - consecutive - wide 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 30,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row-reverse",
+        "marginHorizontal": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 2,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 15,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 15,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <TileB />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileB />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`50. secondary four - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -3584,7 +3839,7 @@ exports[`47. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary one and columnist - wide 1`] = `
+exports[`51. secondary one and columnist - wide 1`] = `
 <View
   style={
     Object {
@@ -3637,7 +3892,7 @@ exports[`48. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary two and two - wide 1`] = `
+exports[`52. secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3727,7 +3982,7 @@ exports[`49. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`50. supplement secondary two and two - wide 1`] = `
+exports[`53. supplement secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3835,7 +4090,7 @@ exports[`50. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`51. lead one and four slice - wide 1`] = `
+exports[`54. lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -3918,7 +4173,7 @@ exports[`51. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`52. supplement lead one and four slice - wide 1`] = `
+exports[`55. supplement lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4024,7 +4279,7 @@ exports[`52. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`53. standard slice - wide 1`] = `
+exports[`56. standard slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4091,7 +4346,7 @@ exports[`53. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`54. secondary two no pic and two - wide 1`] = `
+exports[`57. secondary two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -4182,7 +4437,7 @@ exports[`54. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`55. list two and six no pic - wide 1`] = `
+exports[`58. list two and six no pic - wide 1`] = `
 <View
   style={
     Object {
@@ -4382,7 +4637,7 @@ exports[`55. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`56. puzzle - wide 1`] = `
+exports[`59. puzzle - wide 1`] = `
 <View
   style={
     Object {
@@ -4434,7 +4689,7 @@ exports[`56. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`57. front lead two - portrait - wide 1`] = `
+exports[`60. front lead two - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4512,7 +4767,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`58. front lead two - landscape - wide 1`] = `
+exports[`61. front lead two - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4598,7 +4853,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`59. front lead one and one - portrait - wide 1`] = `
+exports[`62. front lead one and one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4677,7 +4932,7 @@ exports[`59. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead one and one - landscape - wide 1`] = `
+exports[`63. front lead one and one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4763,7 +5018,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead one - portrait - wide 1`] = `
+exports[`64. front lead one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4812,7 +5067,7 @@ exports[`61. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one - landscape - wide 1`] = `
+exports[`65. front lead one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4879,7 +5134,7 @@ exports[`62. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -4952,7 +5207,7 @@ exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5025,7 +5280,80 @@ exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 30,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "marginHorizontal": 20,
+        "paddingVertical": 5,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "66.6%",
+        }
+      }
+    >
+      <TileAT />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "33.3%",
+        }
+      }
+    >
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5098,7 +5426,7 @@ exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5171,7 +5499,7 @@ exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5244,7 +5572,7 @@ exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5317,7 +5645,7 @@ exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`69. comment lead and cartoon - huge 1`] = `
+exports[`73. comment lead and cartoon - huge 1`] = `
 <View
   style={
     Object {
@@ -5380,7 +5708,7 @@ exports[`69. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`70. daily universal register - huge 1`] = `
+exports[`74. daily universal register - huge 1`] = `
 <View
   style={
     Object {
@@ -5499,7 +5827,7 @@ exports[`70. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`71. lead one and one - huge 1`] = `
+exports[`75. lead one and one - huge 1`] = `
 <View
   style={
     Object {
@@ -5561,7 +5889,7 @@ exports[`71. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`72. lead one and one - supplement - huge 1`] = `
+exports[`76. lead one and one - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -5623,7 +5951,7 @@ exports[`72. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`73. lead one full width - huge 1`] = `
+exports[`77. lead one full width - huge 1`] = `
 <View
   style={
     Object {
@@ -5648,7 +5976,7 @@ exports[`73. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`74. lead two no pic and two - huge 1`] = `
+exports[`78. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -5739,7 +6067,7 @@ exports[`74. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead two no pic and two - huge 1`] = `
+exports[`79. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -5821,7 +6149,7 @@ exports[`75. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`76. leaders slice - huge 1`] = `
+exports[`80. leaders slice - huge 1`] = `
 <View
   style={
     Object {
@@ -5956,7 +6284,7 @@ exports[`76. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`77. secondary one and four - huge 1`] = `
+exports[`81. secondary one and four - huge 1`] = `
 <View
   style={
     Object {
@@ -6134,7 +6462,7 @@ exports[`77. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`78. secondary one - huge 1`] = `
+exports[`82. secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6159,7 +6487,7 @@ exports[`78. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`79. supplement secondary one - huge 1`] = `
+exports[`83. supplement secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6184,7 +6512,7 @@ exports[`79. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`80. secondary four - huge 1`] = `
+exports[`84. secondary four - huge 1`] = `
 <View
   style={
     Object {
@@ -6285,7 +6613,108 @@ exports[`80. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary four - supplement - huge 1`] = `
+exports[`85. secondary four - consecutive - huge 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row-reverse",
+          "marginHorizontal": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 2,
+            "flexDirection": "row",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <TileAR />
+        </View>
+        <View
+          style={
+            Object {
+              "borderColor": "#DBDBDB",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "marginVertical": 15,
+            }
+          }
+        />
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <TileAR />
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 15,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingVertical": 5,
+          }
+        }
+      >
+        <TileB />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileB />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`86. secondary four - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -6394,7 +6823,7 @@ exports[`81. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one and columnist - huge 1`] = `
+exports[`87. secondary one and columnist - huge 1`] = `
 <View
   style={
     Object {
@@ -6457,7 +6886,7 @@ exports[`82. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`83. secondary two and two - huge 1`] = `
+exports[`88. secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6557,7 +6986,7 @@ exports[`83. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`84. supplement secondary two and two - huge 1`] = `
+exports[`89. supplement secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6657,7 +7086,7 @@ exports[`84. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`85. lead one and four slice - huge 1`] = `
+exports[`90. lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6750,7 +7179,7 @@ exports[`85. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`86. supplement lead one and four slice - huge 1`] = `
+exports[`91. supplement lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6866,7 +7295,7 @@ exports[`86. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`87. standard slice - huge 1`] = `
+exports[`92. standard slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6943,7 +7372,7 @@ exports[`87. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two no pic and two - huge 1`] = `
+exports[`93. secondary two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -7044,7 +7473,7 @@ exports[`88. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. list two and six no pic - huge 1`] = `
+exports[`94. list two and six no pic - huge 1`] = `
 <View
   style={
     Object {
@@ -7254,7 +7683,7 @@ exports[`89. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`90. puzzle - huge 1`] = `
+exports[`95. puzzle - huge 1`] = `
 <View
   style={
     Object {
@@ -7316,7 +7745,7 @@ exports[`90. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`91. front lead two - portrait - huge 1`] = `
+exports[`96. front lead two - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7404,7 +7833,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`92. front lead two - landscape - huge 1`] = `
+exports[`97. front lead two - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7500,7 +7929,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`93. front lead one and one - portrait - huge 1`] = `
+exports[`98. front lead one and one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7589,7 +8018,7 @@ exports[`93. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`94. front lead one and one - landscape - huge 1`] = `
+exports[`99. front lead one and one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7685,7 +8114,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`95. front lead one - portrait - huge 1`] = `
+exports[`100. front lead one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7744,7 +8173,7 @@ exports[`95. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead one - landscape - huge 1`] = `
+exports[`101. front lead one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7822,7 +8251,7 @@ exports[`96. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -7905,7 +8334,7 @@ exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -7988,90 +8417,7 @@ exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`99. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 1180,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "flexDirection": "row",
-          "marginHorizontal": 20,
-          "paddingVertical": 5,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "width": "66.6%",
-          }
-        }
-      >
-        <TileAU />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "width": "33.3%",
-          }
-        }
-      >
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8154,7 +8500,7 @@ exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8237,7 +8583,173 @@ exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`102. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 20,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "width": "66.6%",
+          }
+        }
+      >
+        <TileAT />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "width": "33.3%",
+          }
+        }
+      >
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 20,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "width": "66.6%",
+          }
+        }
+      >
+        <TileAU />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "width": "33.3%",
+          }
+        }
+      >
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View
   style={
     Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -344,7 +344,41 @@ exports[`12. secondary four - medium 1`] = `
 </View>
 `;
 
-exports[`13. secondary four - supplement - medium 1`] = `
+exports[`13. secondary four - consecutive - medium 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAR
+          breakpoint="medium"
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAR
+          breakpoint="medium"
+          tileName="secondary2"
+        />
+      </View>
+    </View>
+    <View />
+    <View>
+      <TileB
+        breakpoint="medium"
+        tileName="secondary3"
+      />
+      <View />
+      <TileB
+        breakpoint="medium"
+        tileName="secondary4"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`14. secondary four - supplement - medium 1`] = `
 <View>
   <View>
     <View>
@@ -380,7 +414,7 @@ exports[`13. secondary four - supplement - medium 1`] = `
 </View>
 `;
 
-exports[`14. secondary one and columnist - medium 1`] = `
+exports[`15. secondary one and columnist - medium 1`] = `
 <View>
   <View>
     <View>
@@ -401,7 +435,7 @@ exports[`14. secondary one and columnist - medium 1`] = `
 </View>
 `;
 
-exports[`15. secondary two and two - medium 1`] = `
+exports[`16. secondary two and two - medium 1`] = `
 <View>
   <View>
     <View>
@@ -437,7 +471,7 @@ exports[`15. secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`16. supplement secondary two and two - medium 1`] = `
+exports[`17. supplement secondary two and two - medium 1`] = `
 <View>
   <View>
     <View>
@@ -475,7 +509,7 @@ exports[`16. supplement secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`17. lead one and four slice - medium 1`] = `
+exports[`18. lead one and four slice - medium 1`] = `
 <View>
   <View>
     <View>
@@ -510,7 +544,7 @@ exports[`17. lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`18. supplement lead one and four slice - medium 1`] = `
+exports[`19. supplement lead one and four slice - medium 1`] = `
 <View>
   <View>
     <View>
@@ -552,7 +586,7 @@ exports[`18. supplement lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`19. standard slice - medium 1`] = `
+exports[`20. standard slice - medium 1`] = `
 <View>
   <View>
     <View>
@@ -585,7 +619,7 @@ exports[`19. standard slice - medium 1`] = `
 </View>
 `;
 
-exports[`20. secondary two no pic and two - medium 1`] = `
+exports[`21. secondary two no pic and two - medium 1`] = `
 <View>
   <View>
     <View>
@@ -623,7 +657,7 @@ exports[`20. secondary two no pic and two - medium 1`] = `
 </View>
 `;
 
-exports[`21. list two and six no pic - medium 1`] = `
+exports[`22. list two and six no pic - medium 1`] = `
 <View>
   <View>
     <View>
@@ -693,7 +727,7 @@ exports[`21. list two and six no pic - medium 1`] = `
 </View>
 `;
 
-exports[`22. puzzle - medium 1`] = `
+exports[`23. puzzle - medium 1`] = `
 <View>
   <View>
     <View>
@@ -766,7 +800,7 @@ exports[`22. puzzle - medium 1`] = `
 </View>
 `;
 
-exports[`23. front lead two - portrait - medium 1`] = `
+exports[`24. front lead two - portrait - medium 1`] = `
 <View>
   <View>
     <View>
@@ -793,7 +827,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`24. front lead two - landscape - medium 1`] = `
+exports[`25. front lead two - landscape - medium 1`] = `
 <View>
   <View>
     <View>
@@ -821,7 +855,7 @@ exports[`24. front lead two - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`25. front lead one and one - portrait - medium 1`] = `
+exports[`26. front lead one and one - portrait - medium 1`] = `
 <View>
   <View>
     <View>
@@ -849,7 +883,7 @@ exports[`25. front lead one and one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`26. front lead one and one - landscape - medium 1`] = `
+exports[`27. front lead one and one - landscape - medium 1`] = `
 <View>
   <View>
     <View>
@@ -878,7 +912,7 @@ exports[`26. front lead one and one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`27. front lead one - portrait - medium 1`] = `
+exports[`28. front lead one - portrait - medium 1`] = `
 <View>
   <View>
     <View>
@@ -896,7 +930,7 @@ exports[`27. front lead one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`28. front lead one - landscape - medium 1`] = `
+exports[`29. front lead one - landscape - medium 1`] = `
 <View>
   <View>
     <View>
@@ -917,7 +951,7 @@ exports[`28. front lead one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
+exports[`30. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -947,7 +981,7 @@ exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] =
 </View>
 `;
 
-exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -977,7 +1011,37 @@ exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+<View>
+  <View>
+    <View>
+      <TileAT
+        breakpoint="medium"
+        tileName="lead"
+      />
+    </View>
+    <View />
+    <View>
+      <TileAV
+        breakpoint="medium"
+        tileName="support1"
+      />
+      <View />
+      <TileAV
+        breakpoint="medium"
+        tileName="support2"
+      />
+      <View />
+      <TileAV
+        breakpoint="medium"
+        tileName="support3"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1007,7 +1071,7 @@ exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1037,7 +1101,7 @@ exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1067,7 +1131,7 @@ exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1097,7 +1161,7 @@ exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`35. comment lead and cartoon - wide 1`] = `
+exports[`37. comment lead and cartoon - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1117,7 +1181,7 @@ exports[`35. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`36. daily universal register - wide 1`] = `
+exports[`38. daily universal register - wide 1`] = `
 <View>
   <View>
     <Image
@@ -1170,7 +1234,7 @@ exports[`36. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`37. lead one and one - wide 1`] = `
+exports[`39. lead one and one - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1190,7 +1254,7 @@ exports[`37. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`38. lead one and one - supplement - wide 1`] = `
+exports[`40. lead one and one - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1219,7 +1283,7 @@ exports[`38. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one full width - wide 1`] = `
+exports[`41. lead one full width - wide 1`] = `
 <View>
   <TileR
     breakpoint="wide"
@@ -1228,7 +1292,7 @@ exports[`39. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1260,7 +1324,7 @@ exports[`40. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead two no pic and two - wide 1`] = `
+exports[`43. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1290,7 +1354,7 @@ exports[`41. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`42. leaders slice - wide 1`] = `
+exports[`44. leaders slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1334,7 +1398,7 @@ exports[`42. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`43. secondary one and four - wide 1`] = `
+exports[`45. secondary one and four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1390,7 +1454,7 @@ exports[`43. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`44. secondary one - wide 1`] = `
+exports[`46. secondary one - wide 1`] = `
 <View>
   <TileW
     breakpoint="wide"
@@ -1399,7 +1463,7 @@ exports[`44. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`45. supplement secondary one - wide 1`] = `
+exports[`47. supplement secondary one - wide 1`] = `
 <View>
   <TileBF
     breakpoint="wide"
@@ -1408,7 +1472,7 @@ exports[`45. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary four - wide 1`] = `
+exports[`48. secondary four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1454,7 +1518,53 @@ exports[`46. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`47. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - consecutive - wide 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAR
+          breakpoint="wide"
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAR
+          breakpoint="wide"
+          tileName="secondary2"
+        />
+      </View>
+    </View>
+    <View />
+    <View>
+      <TileB
+        additionalHeadlineStyles={
+          Object {
+            "fontSize": 20,
+            "lineHeight": 20,
+          }
+        }
+        breakpoint="wide"
+        tileName="secondary3"
+      />
+      <View />
+      <TileB
+        additionalHeadlineStyles={
+          Object {
+            "fontSize": 20,
+            "lineHeight": 20,
+          }
+        }
+        breakpoint="wide"
+        tileName="secondary4"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`50. secondary four - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1490,7 +1600,7 @@ exports[`47. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary one and columnist - wide 1`] = `
+exports[`51. secondary one and columnist - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1511,7 +1621,7 @@ exports[`48. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary two and two - wide 1`] = `
+exports[`52. secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1541,7 +1651,7 @@ exports[`49. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`50. supplement secondary two and two - wide 1`] = `
+exports[`53. supplement secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1579,7 +1689,7 @@ exports[`50. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`51. lead one and four slice - wide 1`] = `
+exports[`54. lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1614,7 +1724,7 @@ exports[`51. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`52. supplement lead one and four slice - wide 1`] = `
+exports[`55. supplement lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1656,7 +1766,7 @@ exports[`52. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`53. standard slice - wide 1`] = `
+exports[`56. standard slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1689,7 +1799,7 @@ exports[`53. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`54. secondary two no pic and two - wide 1`] = `
+exports[`57. secondary two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1723,7 +1833,7 @@ exports[`54. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`55. list two and six no pic - wide 1`] = `
+exports[`58. list two and six no pic - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1793,7 +1903,7 @@ exports[`55. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`56. puzzle - wide 1`] = `
+exports[`59. puzzle - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1866,7 +1976,7 @@ exports[`56. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`57. front lead two - portrait - wide 1`] = `
+exports[`60. front lead two - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1893,7 +2003,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`58. front lead two - landscape - wide 1`] = `
+exports[`61. front lead two - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1921,7 +2031,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`59. front lead one and one - portrait - wide 1`] = `
+exports[`62. front lead one and one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1949,7 +2059,7 @@ exports[`59. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead one and one - landscape - wide 1`] = `
+exports[`63. front lead one and one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1978,7 +2088,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead one - portrait - wide 1`] = `
+exports[`64. front lead one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1996,7 +2106,7 @@ exports[`61. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one - landscape - wide 1`] = `
+exports[`65. front lead one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2017,7 +2127,7 @@ exports[`62. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2047,7 +2157,7 @@ exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2077,7 +2187,37 @@ exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+<View>
+  <View>
+    <View>
+      <TileAT
+        breakpoint="wide"
+        tileName="lead"
+      />
+    </View>
+    <View />
+    <View>
+      <TileAV
+        breakpoint="wide"
+        tileName="support1"
+      />
+      <View />
+      <TileAV
+        breakpoint="wide"
+        tileName="support2"
+      />
+      <View />
+      <TileAV
+        breakpoint="wide"
+        tileName="support3"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2107,7 +2247,7 @@ exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2137,7 +2277,7 @@ exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2167,7 +2307,7 @@ exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2197,7 +2337,7 @@ exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`69. comment lead and cartoon - huge 1`] = `
+exports[`73. comment lead and cartoon - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2219,7 +2359,7 @@ exports[`69. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`70. daily universal register - huge 1`] = `
+exports[`74. daily universal register - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2274,7 +2414,7 @@ exports[`70. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`71. lead one and one - huge 1`] = `
+exports[`75. lead one and one - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2296,7 +2436,7 @@ exports[`71. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`72. lead one and one - supplement - huge 1`] = `
+exports[`76. lead one and one - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2327,7 +2467,7 @@ exports[`72. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`73. lead one full width - huge 1`] = `
+exports[`77. lead one full width - huge 1`] = `
 <View>
   <View>
     <TileR
@@ -2338,7 +2478,7 @@ exports[`73. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`74. lead two no pic and two - huge 1`] = `
+exports[`78. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2372,7 +2512,7 @@ exports[`74. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead two no pic and two - huge 1`] = `
+exports[`79. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2404,7 +2544,7 @@ exports[`75. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`76. leaders slice - huge 1`] = `
+exports[`80. leaders slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2450,7 +2590,7 @@ exports[`76. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`77. secondary one and four - huge 1`] = `
+exports[`81. secondary one and four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2508,7 +2648,7 @@ exports[`77. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`78. secondary one - huge 1`] = `
+exports[`82. secondary one - huge 1`] = `
 <View>
   <View>
     <TileW
@@ -2519,7 +2659,7 @@ exports[`78. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`79. supplement secondary one - huge 1`] = `
+exports[`83. supplement secondary one - huge 1`] = `
 <View>
   <View>
     <TileBF
@@ -2530,7 +2670,7 @@ exports[`79. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`80. secondary four - huge 1`] = `
+exports[`84. secondary four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2578,7 +2718,55 @@ exports[`80. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary four - supplement - huge 1`] = `
+exports[`85. secondary four - consecutive - huge 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <View>
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary1"
+          />
+        </View>
+        <View />
+        <View>
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary2"
+          />
+        </View>
+      </View>
+      <View />
+      <View>
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary3"
+        />
+        <View />
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary4"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`86. secondary four - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2616,7 +2804,7 @@ exports[`81. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one and columnist - huge 1`] = `
+exports[`87. secondary one and columnist - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2639,7 +2827,7 @@ exports[`82. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`83. secondary two and two - huge 1`] = `
+exports[`88. secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2671,7 +2859,7 @@ exports[`83. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`84. supplement secondary two and two - huge 1`] = `
+exports[`89. supplement secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2705,7 +2893,7 @@ exports[`84. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`85. lead one and four slice - huge 1`] = `
+exports[`90. lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2742,7 +2930,7 @@ exports[`85. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`86. supplement lead one and four slice - huge 1`] = `
+exports[`91. supplement lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2786,7 +2974,7 @@ exports[`86. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`87. standard slice - huge 1`] = `
+exports[`92. standard slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2821,7 +3009,7 @@ exports[`87. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two no pic and two - huge 1`] = `
+exports[`93. secondary two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2857,7 +3045,7 @@ exports[`88. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. list two and six no pic - huge 1`] = `
+exports[`94. list two and six no pic - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2929,7 +3117,7 @@ exports[`89. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`90. puzzle - huge 1`] = `
+exports[`95. puzzle - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3004,7 +3192,7 @@ exports[`90. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`91. front lead two - portrait - huge 1`] = `
+exports[`96. front lead two - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3033,7 +3221,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`92. front lead two - landscape - huge 1`] = `
+exports[`97. front lead two - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3063,7 +3251,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`93. front lead one and one - portrait - huge 1`] = `
+exports[`98. front lead one and one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3093,7 +3281,7 @@ exports[`93. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`94. front lead one and one - landscape - huge 1`] = `
+exports[`99. front lead one and one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3124,7 +3312,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`95. front lead one - portrait - huge 1`] = `
+exports[`100. front lead one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3144,7 +3332,7 @@ exports[`95. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead one - landscape - huge 1`] = `
+exports[`101. front lead one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3167,7 +3355,7 @@ exports[`96. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3199,7 +3387,7 @@ exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3231,39 +3419,7 @@ exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`99. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
-<View>
-  <View>
-    <View>
-      <View>
-        <TileAU
-          breakpoint="huge"
-          tileName="lead"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAV
-          breakpoint="huge"
-          tileName="support1"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support2"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support3"
-        />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3295,7 +3451,7 @@ exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3327,7 +3483,71 @@ exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`102. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAT
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAV
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support3"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAU
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAV
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support3"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tablet-slices.test.js.snap
@@ -1011,37 +1011,7 @@ exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
-<View>
-  <View>
-    <View>
-      <TileAT
-        breakpoint="medium"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAV
-        breakpoint="medium"
-        tileName="support1"
-      />
-      <View />
-      <TileAV
-        breakpoint="medium"
-        tileName="support2"
-      />
-      <View />
-      <TileAV
-        breakpoint="medium"
-        tileName="support3"
-      />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1071,7 +1041,7 @@ exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`33. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1101,7 +1071,7 @@ exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`34. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1131,7 +1101,7 @@ exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1161,7 +1131,7 @@ exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`37. comment lead and cartoon - wide 1`] = `
+exports[`36. comment lead and cartoon - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1181,7 +1151,7 @@ exports[`37. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`38. daily universal register - wide 1`] = `
+exports[`37. daily universal register - wide 1`] = `
 <View>
   <View>
     <Image
@@ -1234,7 +1204,7 @@ exports[`38. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one and one - wide 1`] = `
+exports[`38. lead one and one - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1254,7 +1224,7 @@ exports[`39. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead one and one - supplement - wide 1`] = `
+exports[`39. lead one and one - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1283,7 +1253,7 @@ exports[`40. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead one full width - wide 1`] = `
+exports[`40. lead one full width - wide 1`] = `
 <View>
   <TileR
     breakpoint="wide"
@@ -1292,7 +1262,7 @@ exports[`41. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`42. lead two no pic and two - wide 1`] = `
+exports[`41. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1324,7 +1294,7 @@ exports[`42. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`43. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1354,7 +1324,7 @@ exports[`43. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`44. leaders slice - wide 1`] = `
+exports[`43. leaders slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1398,7 +1368,7 @@ exports[`44. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`45. secondary one and four - wide 1`] = `
+exports[`44. secondary one and four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1454,7 +1424,7 @@ exports[`45. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary one - wide 1`] = `
+exports[`45. secondary one - wide 1`] = `
 <View>
   <TileW
     breakpoint="wide"
@@ -1463,7 +1433,7 @@ exports[`46. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`47. supplement secondary one - wide 1`] = `
+exports[`46. supplement secondary one - wide 1`] = `
 <View>
   <TileBF
     breakpoint="wide"
@@ -1472,7 +1442,7 @@ exports[`47. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary four - wide 1`] = `
+exports[`47. secondary four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1518,7 +1488,7 @@ exports[`48. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary four - consecutive - wide 1`] = `
+exports[`48. secondary four - consecutive - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1564,7 +1534,7 @@ exports[`49. secondary four - consecutive - wide 1`] = `
 </View>
 `;
 
-exports[`50. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1600,7 +1570,7 @@ exports[`50. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`51. secondary one and columnist - wide 1`] = `
+exports[`50. secondary one and columnist - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1621,7 +1591,7 @@ exports[`51. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`52. secondary two and two - wide 1`] = `
+exports[`51. secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1651,7 +1621,7 @@ exports[`52. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`53. supplement secondary two and two - wide 1`] = `
+exports[`52. supplement secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1689,7 +1659,7 @@ exports[`53. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`54. lead one and four slice - wide 1`] = `
+exports[`53. lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1724,7 +1694,7 @@ exports[`54. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`55. supplement lead one and four slice - wide 1`] = `
+exports[`54. supplement lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1766,7 +1736,7 @@ exports[`55. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`56. standard slice - wide 1`] = `
+exports[`55. standard slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1799,7 +1769,7 @@ exports[`56. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`57. secondary two no pic and two - wide 1`] = `
+exports[`56. secondary two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1833,7 +1803,7 @@ exports[`57. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`58. list two and six no pic - wide 1`] = `
+exports[`57. list two and six no pic - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1903,7 +1873,7 @@ exports[`58. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`59. puzzle - wide 1`] = `
+exports[`58. puzzle - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1976,7 +1946,7 @@ exports[`59. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead two - portrait - wide 1`] = `
+exports[`59. front lead two - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2003,7 +1973,7 @@ exports[`60. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead two - landscape - wide 1`] = `
+exports[`60. front lead two - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2031,7 +2001,7 @@ exports[`61. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one and one - portrait - wide 1`] = `
+exports[`61. front lead one and one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2059,7 +2029,7 @@ exports[`62. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`63. front lead one and one - landscape - wide 1`] = `
+exports[`62. front lead one and one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2088,7 +2058,7 @@ exports[`63. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`64. front lead one - portrait - wide 1`] = `
+exports[`63. front lead one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2106,7 +2076,7 @@ exports[`64. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`65. front lead one - landscape - wide 1`] = `
+exports[`64. front lead one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2127,7 +2097,7 @@ exports[`65. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`65. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2157,7 +2127,7 @@ exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2187,37 +2157,7 @@ exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
-<View>
-  <View>
-    <View>
-      <TileAT
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAV
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <View />
-      <TileAV
-        breakpoint="wide"
-        tileName="support2"
-      />
-      <View />
-      <TileAV
-        breakpoint="wide"
-        tileName="support3"
-      />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`67. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2247,7 +2187,7 @@ exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2277,7 +2217,7 @@ exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`69. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2307,7 +2247,7 @@ exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2337,7 +2277,7 @@ exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`73. comment lead and cartoon - huge 1`] = `
+exports[`71. comment lead and cartoon - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2359,7 +2299,7 @@ exports[`73. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`74. daily universal register - huge 1`] = `
+exports[`72. daily universal register - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2414,7 +2354,7 @@ exports[`74. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead one and one - huge 1`] = `
+exports[`73. lead one and one - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2436,7 +2376,7 @@ exports[`75. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`76. lead one and one - supplement - huge 1`] = `
+exports[`74. lead one and one - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2467,7 +2407,7 @@ exports[`76. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`77. lead one full width - huge 1`] = `
+exports[`75. lead one full width - huge 1`] = `
 <View>
   <View>
     <TileR
@@ -2478,7 +2418,7 @@ exports[`77. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`78. lead two no pic and two - huge 1`] = `
+exports[`76. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2512,7 +2452,7 @@ exports[`78. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`79. lead two no pic and two - huge 1`] = `
+exports[`77. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2544,7 +2484,7 @@ exports[`79. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`80. leaders slice - huge 1`] = `
+exports[`78. leaders slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2590,7 +2530,7 @@ exports[`80. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary one and four - huge 1`] = `
+exports[`79. secondary one and four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2648,7 +2588,7 @@ exports[`81. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one - huge 1`] = `
+exports[`80. secondary one - huge 1`] = `
 <View>
   <View>
     <TileW
@@ -2659,7 +2599,7 @@ exports[`82. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`83. supplement secondary one - huge 1`] = `
+exports[`81. supplement secondary one - huge 1`] = `
 <View>
   <View>
     <TileBF
@@ -2670,7 +2610,7 @@ exports[`83. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`84. secondary four - huge 1`] = `
+exports[`82. secondary four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2718,7 +2658,7 @@ exports[`84. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`85. secondary four - consecutive - huge 1`] = `
+exports[`83. secondary four - consecutive - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2766,7 +2706,7 @@ exports[`85. secondary four - consecutive - huge 1`] = `
 </View>
 `;
 
-exports[`86. secondary four - supplement - huge 1`] = `
+exports[`84. secondary four - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2804,7 +2744,7 @@ exports[`86. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`87. secondary one and columnist - huge 1`] = `
+exports[`85. secondary one and columnist - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2827,7 +2767,7 @@ exports[`87. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two and two - huge 1`] = `
+exports[`86. secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2859,7 +2799,7 @@ exports[`88. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. supplement secondary two and two - huge 1`] = `
+exports[`87. supplement secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2893,7 +2833,7 @@ exports[`89. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`90. lead one and four slice - huge 1`] = `
+exports[`88. lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2930,7 +2870,7 @@ exports[`90. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`91. supplement lead one and four slice - huge 1`] = `
+exports[`89. supplement lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2974,7 +2914,7 @@ exports[`91. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`92. standard slice - huge 1`] = `
+exports[`90. standard slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3009,7 +2949,7 @@ exports[`92. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`93. secondary two no pic and two - huge 1`] = `
+exports[`91. secondary two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3045,7 +2985,7 @@ exports[`93. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`94. list two and six no pic - huge 1`] = `
+exports[`92. list two and six no pic - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3117,7 +3057,7 @@ exports[`94. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`95. puzzle - huge 1`] = `
+exports[`93. puzzle - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3192,7 +3132,7 @@ exports[`95. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead two - portrait - huge 1`] = `
+exports[`94. front lead two - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3221,7 +3161,7 @@ exports[`96. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`97. front lead two - landscape - huge 1`] = `
+exports[`95. front lead two - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3251,7 +3191,7 @@ exports[`97. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`98. front lead one and one - portrait - huge 1`] = `
+exports[`96. front lead one and one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3281,7 +3221,7 @@ exports[`98. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`99. front lead one and one - landscape - huge 1`] = `
+exports[`97. front lead one and one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3312,7 +3252,7 @@ exports[`99. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`100. front lead one - portrait - huge 1`] = `
+exports[`98. front lead one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3332,7 +3272,7 @@ exports[`100. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`101. front lead one - landscape - huge 1`] = `
+exports[`99. front lead one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3355,7 +3295,7 @@ exports[`101. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`100. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3387,7 +3327,7 @@ exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = 
 </View>
 `;
 
-exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`101. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3419,39 +3359,7 @@ exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
-<View>
-  <View>
-    <View>
-      <View>
-        <TileAT
-          breakpoint="huge"
-          tileName="lead"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAV
-          breakpoint="huge"
-          tileName="support1"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support2"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support3"
-        />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3483,7 +3391,7 @@ exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1
 </View>
 `;
 
-exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3515,7 +3423,7 @@ exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`104. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3547,7 +3455,7 @@ exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -2431,80 +2431,7 @@ exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "flexDirection": "row",
-        "marginHorizontal": 20,
-        "paddingVertical": 5,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "width": "66.6%",
-        }
-      }
-    >
-      <TileAT />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.3%",
-        }
-      }
-    >
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2577,7 +2504,7 @@ exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`33. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2650,7 +2577,7 @@ exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`34. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2723,7 +2650,7 @@ exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2796,7 +2723,7 @@ exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`37. comment lead and cartoon - wide 1`] = `
+exports[`36. comment lead and cartoon - wide 1`] = `
 <View
   style={
     Object {
@@ -2849,7 +2776,7 @@ exports[`37. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`38. daily universal register - wide 1`] = `
+exports[`37. daily universal register - wide 1`] = `
 <View
   style={
     Object {
@@ -2958,7 +2885,7 @@ exports[`38. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one and one - wide 1`] = `
+exports[`38. lead one and one - wide 1`] = `
 <View
   style={
     Object {
@@ -3010,7 +2937,7 @@ exports[`39. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead one and one - supplement - wide 1`] = `
+exports[`39. lead one and one - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -3062,7 +2989,7 @@ exports[`40. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead one full width - wide 1`] = `
+exports[`40. lead one full width - wide 1`] = `
 <View
   style={
     Object {
@@ -3077,7 +3004,7 @@ exports[`41. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`42. lead two no pic and two - wide 1`] = `
+exports[`41. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3158,7 +3085,7 @@ exports[`42. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`43. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3230,7 +3157,7 @@ exports[`43. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`44. leaders slice - wide 1`] = `
+exports[`43. leaders slice - wide 1`] = `
 <View
   style={
     Object {
@@ -3355,7 +3282,7 @@ exports[`44. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`45. secondary one and four - wide 1`] = `
+exports[`44. secondary one and four - wide 1`] = `
 <View
   style={
     Object {
@@ -3523,7 +3450,7 @@ exports[`45. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary one - wide 1`] = `
+exports[`45. secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3538,7 +3465,7 @@ exports[`46. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`47. supplement secondary one - wide 1`] = `
+exports[`46. supplement secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3553,7 +3480,7 @@ exports[`47. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary four - wide 1`] = `
+exports[`47. secondary four - wide 1`] = `
 <View
   style={
     Object {
@@ -3644,7 +3571,7 @@ exports[`48. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary four - consecutive - wide 1`] = `
+exports[`48. secondary four - consecutive - wide 1`] = `
 <View
   style={
     Object {
@@ -3735,7 +3662,7 @@ exports[`49. secondary four - consecutive - wide 1`] = `
 </View>
 `;
 
-exports[`50. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -3834,7 +3761,7 @@ exports[`50. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`51. secondary one and columnist - wide 1`] = `
+exports[`50. secondary one and columnist - wide 1`] = `
 <View
   style={
     Object {
@@ -3887,7 +3814,7 @@ exports[`51. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`52. secondary two and two - wide 1`] = `
+exports[`51. secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3977,7 +3904,7 @@ exports[`52. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`53. supplement secondary two and two - wide 1`] = `
+exports[`52. supplement secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -4085,7 +4012,7 @@ exports[`53. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`54. lead one and four slice - wide 1`] = `
+exports[`53. lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4168,7 +4095,7 @@ exports[`54. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`55. supplement lead one and four slice - wide 1`] = `
+exports[`54. supplement lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4274,7 +4201,7 @@ exports[`55. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`56. standard slice - wide 1`] = `
+exports[`55. standard slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4341,7 +4268,7 @@ exports[`56. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`57. secondary two no pic and two - wide 1`] = `
+exports[`56. secondary two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -4432,7 +4359,7 @@ exports[`57. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`58. list two and six no pic - wide 1`] = `
+exports[`57. list two and six no pic - wide 1`] = `
 <View
   style={
     Object {
@@ -4632,7 +4559,7 @@ exports[`58. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`59. puzzle - wide 1`] = `
+exports[`58. puzzle - wide 1`] = `
 <View
   style={
     Object {
@@ -4684,7 +4611,7 @@ exports[`59. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead two - portrait - wide 1`] = `
+exports[`59. front lead two - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4761,7 +4688,7 @@ exports[`60. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead two - landscape - wide 1`] = `
+exports[`60. front lead two - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4846,7 +4773,7 @@ exports[`61. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one and one - portrait - wide 1`] = `
+exports[`61. front lead one and one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4925,7 +4852,7 @@ exports[`62. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`63. front lead one and one - landscape - wide 1`] = `
+exports[`62. front lead one and one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -5011,7 +4938,7 @@ exports[`63. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`64. front lead one - portrait - wide 1`] = `
+exports[`63. front lead one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -5059,7 +4986,7 @@ exports[`64. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`65. front lead one - landscape - wide 1`] = `
+exports[`64. front lead one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -5125,7 +5052,7 @@ exports[`65. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`65. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5198,7 +5125,7 @@ exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5271,80 +5198,7 @@ exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 30,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "flexDirection": "row",
-        "marginHorizontal": 20,
-        "paddingVertical": 5,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "width": "66.6%",
-        }
-      }
-    >
-      <TileAT />
-    </View>
-    <View
-      style={
-        Object {
-          "borderColor": "#DBDBDB",
-          "borderRightWidth": 1,
-          "borderStyle": "solid",
-          "marginVertical": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "width": "33.3%",
-        }
-      }
-    >
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-      <View
-        style={
-          Object {
-            "borderBottomWidth": 1,
-            "borderColor": "#DBDBDB",
-            "borderStyle": "solid",
-          }
-        }
-      />
-      <TileAV />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`67. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5417,7 +5271,7 @@ exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5490,7 +5344,7 @@ exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`69. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5563,7 +5417,7 @@ exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5636,7 +5490,7 @@ exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`73. comment lead and cartoon - huge 1`] = `
+exports[`71. comment lead and cartoon - huge 1`] = `
 <View
   style={
     Object {
@@ -5699,7 +5553,7 @@ exports[`73. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`74. daily universal register - huge 1`] = `
+exports[`72. daily universal register - huge 1`] = `
 <View
   style={
     Object {
@@ -5818,7 +5672,7 @@ exports[`74. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead one and one - huge 1`] = `
+exports[`73. lead one and one - huge 1`] = `
 <View
   style={
     Object {
@@ -5880,7 +5734,7 @@ exports[`75. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`76. lead one and one - supplement - huge 1`] = `
+exports[`74. lead one and one - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -5942,7 +5796,7 @@ exports[`76. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`77. lead one full width - huge 1`] = `
+exports[`75. lead one full width - huge 1`] = `
 <View
   style={
     Object {
@@ -5967,7 +5821,7 @@ exports[`77. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`78. lead two no pic and two - huge 1`] = `
+exports[`76. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6058,7 +5912,7 @@ exports[`78. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`79. lead two no pic and two - huge 1`] = `
+exports[`77. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6140,7 +5994,7 @@ exports[`79. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`80. leaders slice - huge 1`] = `
+exports[`78. leaders slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6275,7 +6129,7 @@ exports[`80. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary one and four - huge 1`] = `
+exports[`79. secondary one and four - huge 1`] = `
 <View
   style={
     Object {
@@ -6453,7 +6307,7 @@ exports[`81. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one - huge 1`] = `
+exports[`80. secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6478,7 +6332,7 @@ exports[`82. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`83. supplement secondary one - huge 1`] = `
+exports[`81. supplement secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6503,7 +6357,7 @@ exports[`83. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`84. secondary four - huge 1`] = `
+exports[`82. secondary four - huge 1`] = `
 <View
   style={
     Object {
@@ -6604,7 +6458,7 @@ exports[`84. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`85. secondary four - consecutive - huge 1`] = `
+exports[`83. secondary four - consecutive - huge 1`] = `
 <View
   style={
     Object {
@@ -6705,7 +6559,7 @@ exports[`85. secondary four - consecutive - huge 1`] = `
 </View>
 `;
 
-exports[`86. secondary four - supplement - huge 1`] = `
+exports[`84. secondary four - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -6814,7 +6668,7 @@ exports[`86. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`87. secondary one and columnist - huge 1`] = `
+exports[`85. secondary one and columnist - huge 1`] = `
 <View
   style={
     Object {
@@ -6877,7 +6731,7 @@ exports[`87. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two and two - huge 1`] = `
+exports[`86. secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6977,7 +6831,7 @@ exports[`88. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. supplement secondary two and two - huge 1`] = `
+exports[`87. supplement secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -7077,7 +6931,7 @@ exports[`89. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`90. lead one and four slice - huge 1`] = `
+exports[`88. lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -7170,7 +7024,7 @@ exports[`90. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`91. supplement lead one and four slice - huge 1`] = `
+exports[`89. supplement lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -7286,7 +7140,7 @@ exports[`91. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`92. standard slice - huge 1`] = `
+exports[`90. standard slice - huge 1`] = `
 <View
   style={
     Object {
@@ -7363,7 +7217,7 @@ exports[`92. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`93. secondary two no pic and two - huge 1`] = `
+exports[`91. secondary two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -7464,7 +7318,7 @@ exports[`93. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`94. list two and six no pic - huge 1`] = `
+exports[`92. list two and six no pic - huge 1`] = `
 <View
   style={
     Object {
@@ -7674,7 +7528,7 @@ exports[`94. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`95. puzzle - huge 1`] = `
+exports[`93. puzzle - huge 1`] = `
 <View
   style={
     Object {
@@ -7736,7 +7590,7 @@ exports[`95. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead two - portrait - huge 1`] = `
+exports[`94. front lead two - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7823,7 +7677,7 @@ exports[`96. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`97. front lead two - landscape - huge 1`] = `
+exports[`95. front lead two - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7918,7 +7772,7 @@ exports[`97. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`98. front lead one and one - portrait - huge 1`] = `
+exports[`96. front lead one and one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -8007,7 +7861,7 @@ exports[`98. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`99. front lead one and one - landscape - huge 1`] = `
+exports[`97. front lead one and one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -8103,7 +7957,7 @@ exports[`99. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`100. front lead one - portrait - huge 1`] = `
+exports[`98. front lead one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -8161,7 +8015,7 @@ exports[`100. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`101. front lead one - landscape - huge 1`] = `
+exports[`99. front lead one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -8238,7 +8092,7 @@ exports[`101. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`100. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8321,7 +8175,7 @@ exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = 
 </View>
 `;
 
-exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`101. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8404,90 +8258,7 @@ exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 1180,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "flexDirection": "row",
-          "marginHorizontal": 20,
-          "paddingVertical": 5,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "width": "66.6%",
-          }
-        }
-      >
-        <TileAT />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "width": "33.3%",
-          }
-        }
-      >
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8570,7 +8341,7 @@ exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1
 </View>
 `;
 
-exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8653,7 +8424,7 @@ exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`104. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8736,7 +8507,7 @@ exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View
   style={
     Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices-with-style.test.js.snap
@@ -845,7 +845,98 @@ exports[`12. secondary four - medium 1`] = `
 </View>
 `;
 
-exports[`13. secondary four - supplement - medium 1`] = `
+exports[`13. secondary four - consecutive - medium 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row-reverse",
+        "marginHorizontal": 20,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 2,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 15,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 15,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <TileB />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileB />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`14. secondary four - supplement - medium 1`] = `
 <View
   style={
     Object {
@@ -944,7 +1035,7 @@ exports[`13. secondary four - supplement - medium 1`] = `
 </View>
 `;
 
-exports[`14. secondary one and columnist - medium 1`] = `
+exports[`15. secondary one and columnist - medium 1`] = `
 <View
   style={
     Object {
@@ -997,7 +1088,7 @@ exports[`14. secondary one and columnist - medium 1`] = `
 </View>
 `;
 
-exports[`15. secondary two and two - medium 1`] = `
+exports[`16. secondary two and two - medium 1`] = `
 <View
   style={
     Object {
@@ -1105,7 +1196,7 @@ exports[`15. secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`16. supplement secondary two and two - medium 1`] = `
+exports[`17. supplement secondary two and two - medium 1`] = `
 <View
   style={
     Object {
@@ -1213,7 +1304,7 @@ exports[`16. supplement secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`17. lead one and four slice - medium 1`] = `
+exports[`18. lead one and four slice - medium 1`] = `
 <View
   style={
     Object {
@@ -1296,7 +1387,7 @@ exports[`17. lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`18. supplement lead one and four slice - medium 1`] = `
+exports[`19. supplement lead one and four slice - medium 1`] = `
 <View
   style={
     Object {
@@ -1403,7 +1494,7 @@ exports[`18. supplement lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`19. standard slice - medium 1`] = `
+exports[`20. standard slice - medium 1`] = `
 <View
   style={
     Object {
@@ -1470,7 +1561,7 @@ exports[`19. standard slice - medium 1`] = `
 </View>
 `;
 
-exports[`20. secondary two no pic and two - medium 1`] = `
+exports[`21. secondary two no pic and two - medium 1`] = `
 <View
   style={
     Object {
@@ -1577,7 +1668,7 @@ exports[`20. secondary two no pic and two - medium 1`] = `
 </View>
 `;
 
-exports[`21. list two and six no pic - medium 1`] = `
+exports[`22. list two and six no pic - medium 1`] = `
 <View
   style={
     Object {
@@ -1777,7 +1868,7 @@ exports[`21. list two and six no pic - medium 1`] = `
 </View>
 `;
 
-exports[`22. puzzle - medium 1`] = `
+exports[`23. puzzle - medium 1`] = `
 <View
   style={
     Object {
@@ -1829,7 +1920,7 @@ exports[`22. puzzle - medium 1`] = `
 </View>
 `;
 
-exports[`23. front lead two - portrait - medium 1`] = `
+exports[`24. front lead two - portrait - medium 1`] = `
 <View
   style={
     Object {
@@ -1906,7 +1997,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`24. front lead two - landscape - medium 1`] = `
+exports[`25. front lead two - landscape - medium 1`] = `
 <View
   style={
     Object {
@@ -1964,7 +2055,7 @@ exports[`24. front lead two - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`25. front lead one and one - portrait - medium 1`] = `
+exports[`26. front lead one and one - portrait - medium 1`] = `
 <View
   style={
     Object {
@@ -2043,7 +2134,7 @@ exports[`25. front lead one and one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`26. front lead one and one - landscape - medium 1`] = `
+exports[`27. front lead one and one - landscape - medium 1`] = `
 <View
   style={
     Object {
@@ -2101,7 +2192,7 @@ exports[`26. front lead one and one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`27. front lead one - portrait - medium 1`] = `
+exports[`28. front lead one - portrait - medium 1`] = `
 <View
   style={
     Object {
@@ -2149,7 +2240,7 @@ exports[`27. front lead one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`28. front lead one - landscape - medium 1`] = `
+exports[`29. front lead one - landscape - medium 1`] = `
 <View
   style={
     Object {
@@ -2194,7 +2285,7 @@ exports[`28. front lead one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
+exports[`30. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2267,7 +2358,7 @@ exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] =
 </View>
 `;
 
-exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2340,7 +2431,80 @@ exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "marginHorizontal": 20,
+        "paddingVertical": 5,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "66.6%",
+        }
+      }
+    >
+      <TileAT />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "33.3%",
+        }
+      }
+    >
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2413,7 +2577,7 @@ exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2486,7 +2650,7 @@ exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2559,7 +2723,7 @@ exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View
   style={
     Object {
@@ -2632,7 +2796,7 @@ exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`35. comment lead and cartoon - wide 1`] = `
+exports[`37. comment lead and cartoon - wide 1`] = `
 <View
   style={
     Object {
@@ -2685,7 +2849,7 @@ exports[`35. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`36. daily universal register - wide 1`] = `
+exports[`38. daily universal register - wide 1`] = `
 <View
   style={
     Object {
@@ -2794,7 +2958,7 @@ exports[`36. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`37. lead one and one - wide 1`] = `
+exports[`39. lead one and one - wide 1`] = `
 <View
   style={
     Object {
@@ -2846,7 +3010,7 @@ exports[`37. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`38. lead one and one - supplement - wide 1`] = `
+exports[`40. lead one and one - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -2898,7 +3062,7 @@ exports[`38. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one full width - wide 1`] = `
+exports[`41. lead one full width - wide 1`] = `
 <View
   style={
     Object {
@@ -2913,7 +3077,7 @@ exports[`39. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -2994,7 +3158,7 @@ exports[`40. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead two no pic and two - wide 1`] = `
+exports[`43. lead two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3066,7 +3230,7 @@ exports[`41. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`42. leaders slice - wide 1`] = `
+exports[`44. leaders slice - wide 1`] = `
 <View
   style={
     Object {
@@ -3191,7 +3355,7 @@ exports[`42. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`43. secondary one and four - wide 1`] = `
+exports[`45. secondary one and four - wide 1`] = `
 <View
   style={
     Object {
@@ -3359,7 +3523,7 @@ exports[`43. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`44. secondary one - wide 1`] = `
+exports[`46. secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3374,7 +3538,7 @@ exports[`44. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`45. supplement secondary one - wide 1`] = `
+exports[`47. supplement secondary one - wide 1`] = `
 <View
   style={
     Object {
@@ -3389,7 +3553,7 @@ exports[`45. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary four - wide 1`] = `
+exports[`48. secondary four - wide 1`] = `
 <View
   style={
     Object {
@@ -3480,7 +3644,98 @@ exports[`46. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`47. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - consecutive - wide 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 30,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row-reverse",
+        "marginHorizontal": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 2,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 15,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <TileAR />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 15,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <TileB />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileB />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`50. secondary four - supplement - wide 1`] = `
 <View
   style={
     Object {
@@ -3579,7 +3834,7 @@ exports[`47. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary one and columnist - wide 1`] = `
+exports[`51. secondary one and columnist - wide 1`] = `
 <View
   style={
     Object {
@@ -3632,7 +3887,7 @@ exports[`48. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary two and two - wide 1`] = `
+exports[`52. secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3722,7 +3977,7 @@ exports[`49. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`50. supplement secondary two and two - wide 1`] = `
+exports[`53. supplement secondary two and two - wide 1`] = `
 <View
   style={
     Object {
@@ -3830,7 +4085,7 @@ exports[`50. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`51. lead one and four slice - wide 1`] = `
+exports[`54. lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -3913,7 +4168,7 @@ exports[`51. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`52. supplement lead one and four slice - wide 1`] = `
+exports[`55. supplement lead one and four slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4019,7 +4274,7 @@ exports[`52. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`53. standard slice - wide 1`] = `
+exports[`56. standard slice - wide 1`] = `
 <View
   style={
     Object {
@@ -4086,7 +4341,7 @@ exports[`53. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`54. secondary two no pic and two - wide 1`] = `
+exports[`57. secondary two no pic and two - wide 1`] = `
 <View
   style={
     Object {
@@ -4177,7 +4432,7 @@ exports[`54. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`55. list two and six no pic - wide 1`] = `
+exports[`58. list two and six no pic - wide 1`] = `
 <View
   style={
     Object {
@@ -4377,7 +4632,7 @@ exports[`55. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`56. puzzle - wide 1`] = `
+exports[`59. puzzle - wide 1`] = `
 <View
   style={
     Object {
@@ -4429,7 +4684,7 @@ exports[`56. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`57. front lead two - portrait - wide 1`] = `
+exports[`60. front lead two - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4506,7 +4761,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`58. front lead two - landscape - wide 1`] = `
+exports[`61. front lead two - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4591,7 +4846,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`59. front lead one and one - portrait - wide 1`] = `
+exports[`62. front lead one and one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4670,7 +4925,7 @@ exports[`59. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead one and one - landscape - wide 1`] = `
+exports[`63. front lead one and one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4756,7 +5011,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead one - portrait - wide 1`] = `
+exports[`64. front lead one - portrait - wide 1`] = `
 <View
   style={
     Object {
@@ -4804,7 +5059,7 @@ exports[`61. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one - landscape - wide 1`] = `
+exports[`65. front lead one - landscape - wide 1`] = `
 <View
   style={
     Object {
@@ -4870,7 +5125,7 @@ exports[`62. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -4943,7 +5198,7 @@ exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5016,7 +5271,80 @@ exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 30,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "marginHorizontal": 20,
+        "paddingVertical": 5,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "66.6%",
+        }
+      }
+    >
+      <TileAT />
+    </View>
+    <View
+      style={
+        Object {
+          "borderColor": "#DBDBDB",
+          "borderRightWidth": 1,
+          "borderStyle": "solid",
+          "marginVertical": 10,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "width": "33.3%",
+        }
+      }
+    >
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+            "borderColor": "#DBDBDB",
+            "borderStyle": "solid",
+          }
+        }
+      />
+      <TileAV />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5089,7 +5417,7 @@ exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5162,7 +5490,7 @@ exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5235,7 +5563,7 @@ exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View
   style={
     Object {
@@ -5308,7 +5636,7 @@ exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`69. comment lead and cartoon - huge 1`] = `
+exports[`73. comment lead and cartoon - huge 1`] = `
 <View
   style={
     Object {
@@ -5371,7 +5699,7 @@ exports[`69. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`70. daily universal register - huge 1`] = `
+exports[`74. daily universal register - huge 1`] = `
 <View
   style={
     Object {
@@ -5490,7 +5818,7 @@ exports[`70. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`71. lead one and one - huge 1`] = `
+exports[`75. lead one and one - huge 1`] = `
 <View
   style={
     Object {
@@ -5552,7 +5880,7 @@ exports[`71. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`72. lead one and one - supplement - huge 1`] = `
+exports[`76. lead one and one - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -5614,7 +5942,7 @@ exports[`72. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`73. lead one full width - huge 1`] = `
+exports[`77. lead one full width - huge 1`] = `
 <View
   style={
     Object {
@@ -5639,7 +5967,7 @@ exports[`73. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`74. lead two no pic and two - huge 1`] = `
+exports[`78. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -5730,7 +6058,7 @@ exports[`74. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead two no pic and two - huge 1`] = `
+exports[`79. lead two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -5812,7 +6140,7 @@ exports[`75. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`76. leaders slice - huge 1`] = `
+exports[`80. leaders slice - huge 1`] = `
 <View
   style={
     Object {
@@ -5947,7 +6275,7 @@ exports[`76. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`77. secondary one and four - huge 1`] = `
+exports[`81. secondary one and four - huge 1`] = `
 <View
   style={
     Object {
@@ -6125,7 +6453,7 @@ exports[`77. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`78. secondary one - huge 1`] = `
+exports[`82. secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6150,7 +6478,7 @@ exports[`78. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`79. supplement secondary one - huge 1`] = `
+exports[`83. supplement secondary one - huge 1`] = `
 <View
   style={
     Object {
@@ -6175,7 +6503,7 @@ exports[`79. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`80. secondary four - huge 1`] = `
+exports[`84. secondary four - huge 1`] = `
 <View
   style={
     Object {
@@ -6276,7 +6604,108 @@ exports[`80. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary four - supplement - huge 1`] = `
+exports[`85. secondary four - consecutive - huge 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row-reverse",
+          "marginHorizontal": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 2,
+            "flexDirection": "row",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <TileAR />
+        </View>
+        <View
+          style={
+            Object {
+              "borderColor": "#DBDBDB",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "marginVertical": 15,
+            }
+          }
+        />
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <TileAR />
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 15,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingVertical": 5,
+          }
+        }
+      >
+        <TileB />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileB />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`86. secondary four - supplement - huge 1`] = `
 <View
   style={
     Object {
@@ -6385,7 +6814,7 @@ exports[`81. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one and columnist - huge 1`] = `
+exports[`87. secondary one and columnist - huge 1`] = `
 <View
   style={
     Object {
@@ -6448,7 +6877,7 @@ exports[`82. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`83. secondary two and two - huge 1`] = `
+exports[`88. secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6548,7 +6977,7 @@ exports[`83. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`84. supplement secondary two and two - huge 1`] = `
+exports[`89. supplement secondary two and two - huge 1`] = `
 <View
   style={
     Object {
@@ -6648,7 +7077,7 @@ exports[`84. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`85. lead one and four slice - huge 1`] = `
+exports[`90. lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6741,7 +7170,7 @@ exports[`85. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`86. supplement lead one and four slice - huge 1`] = `
+exports[`91. supplement lead one and four slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6857,7 +7286,7 @@ exports[`86. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`87. standard slice - huge 1`] = `
+exports[`92. standard slice - huge 1`] = `
 <View
   style={
     Object {
@@ -6934,7 +7363,7 @@ exports[`87. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two no pic and two - huge 1`] = `
+exports[`93. secondary two no pic and two - huge 1`] = `
 <View
   style={
     Object {
@@ -7035,7 +7464,7 @@ exports[`88. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. list two and six no pic - huge 1`] = `
+exports[`94. list two and six no pic - huge 1`] = `
 <View
   style={
     Object {
@@ -7245,7 +7674,7 @@ exports[`89. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`90. puzzle - huge 1`] = `
+exports[`95. puzzle - huge 1`] = `
 <View
   style={
     Object {
@@ -7307,7 +7736,7 @@ exports[`90. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`91. front lead two - portrait - huge 1`] = `
+exports[`96. front lead two - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7394,7 +7823,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`92. front lead two - landscape - huge 1`] = `
+exports[`97. front lead two - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7489,7 +7918,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`93. front lead one and one - portrait - huge 1`] = `
+exports[`98. front lead one and one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7578,7 +8007,7 @@ exports[`93. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`94. front lead one and one - landscape - huge 1`] = `
+exports[`99. front lead one and one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7674,7 +8103,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`95. front lead one - portrait - huge 1`] = `
+exports[`100. front lead one - portrait - huge 1`] = `
 <View
   style={
     Object {
@@ -7732,7 +8161,7 @@ exports[`95. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead one - landscape - huge 1`] = `
+exports[`101. front lead one - landscape - huge 1`] = `
 <View
   style={
     Object {
@@ -7809,7 +8238,7 @@ exports[`96. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -7892,7 +8321,7 @@ exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -7975,90 +8404,7 @@ exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`99. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "maxWidth": "100%",
-      "paddingHorizontal": 10,
-      "width": 1366,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 1180,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "flexDirection": "row",
-          "marginHorizontal": 20,
-          "paddingVertical": 5,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "width": "66.6%",
-          }
-        }
-      >
-        <TileAU />
-      </View>
-      <View
-        style={
-          Object {
-            "borderColor": "#DBDBDB",
-            "borderRightWidth": 1,
-            "borderStyle": "solid",
-            "marginVertical": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "width": "33.3%",
-          }
-        }
-      >
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-        <View
-          style={
-            Object {
-              "borderBottomWidth": 1,
-              "borderColor": "#DBDBDB",
-              "borderStyle": "solid",
-            }
-          }
-        />
-        <TileAV />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8141,7 +8487,7 @@ exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View
   style={
     Object {
@@ -8224,7 +8570,173 @@ exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`102. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 20,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "width": "66.6%",
+          }
+        }
+      >
+        <TileAT />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "width": "33.3%",
+          }
+        }
+      >
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": "100%",
+      "paddingHorizontal": 10,
+      "width": 1366,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": 1,
+        "width": 1180,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "marginHorizontal": 20,
+          "paddingVertical": 5,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "width": "66.6%",
+          }
+        }
+      >
+        <TileAU />
+      </View>
+      <View
+        style={
+          Object {
+            "borderColor": "#DBDBDB",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "marginVertical": 10,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "width": "33.3%",
+          }
+        }
+      >
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+        <View
+          style={
+            Object {
+              "borderBottomWidth": 1,
+              "borderColor": "#DBDBDB",
+              "borderStyle": "solid",
+            }
+          }
+        />
+        <TileAV />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View
   style={
     Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -344,7 +344,41 @@ exports[`12. secondary four - medium 1`] = `
 </View>
 `;
 
-exports[`13. secondary four - supplement - medium 1`] = `
+exports[`13. secondary four - consecutive - medium 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAR
+          breakpoint="medium"
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAR
+          breakpoint="medium"
+          tileName="secondary2"
+        />
+      </View>
+    </View>
+    <View />
+    <View>
+      <TileB
+        breakpoint="medium"
+        tileName="secondary3"
+      />
+      <View />
+      <TileB
+        breakpoint="medium"
+        tileName="secondary4"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`14. secondary four - supplement - medium 1`] = `
 <View>
   <View>
     <View>
@@ -380,7 +414,7 @@ exports[`13. secondary four - supplement - medium 1`] = `
 </View>
 `;
 
-exports[`14. secondary one and columnist - medium 1`] = `
+exports[`15. secondary one and columnist - medium 1`] = `
 <View>
   <View>
     <View>
@@ -401,7 +435,7 @@ exports[`14. secondary one and columnist - medium 1`] = `
 </View>
 `;
 
-exports[`15. secondary two and two - medium 1`] = `
+exports[`16. secondary two and two - medium 1`] = `
 <View>
   <View>
     <View>
@@ -437,7 +471,7 @@ exports[`15. secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`16. supplement secondary two and two - medium 1`] = `
+exports[`17. supplement secondary two and two - medium 1`] = `
 <View>
   <View>
     <View>
@@ -475,7 +509,7 @@ exports[`16. supplement secondary two and two - medium 1`] = `
 </View>
 `;
 
-exports[`17. lead one and four slice - medium 1`] = `
+exports[`18. lead one and four slice - medium 1`] = `
 <View>
   <View>
     <View>
@@ -510,7 +544,7 @@ exports[`17. lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`18. supplement lead one and four slice - medium 1`] = `
+exports[`19. supplement lead one and four slice - medium 1`] = `
 <View>
   <View>
     <View>
@@ -552,7 +586,7 @@ exports[`18. supplement lead one and four slice - medium 1`] = `
 </View>
 `;
 
-exports[`19. standard slice - medium 1`] = `
+exports[`20. standard slice - medium 1`] = `
 <View>
   <View>
     <View>
@@ -585,7 +619,7 @@ exports[`19. standard slice - medium 1`] = `
 </View>
 `;
 
-exports[`20. secondary two no pic and two - medium 1`] = `
+exports[`21. secondary two no pic and two - medium 1`] = `
 <View>
   <View>
     <View>
@@ -623,7 +657,7 @@ exports[`20. secondary two no pic and two - medium 1`] = `
 </View>
 `;
 
-exports[`21. list two and six no pic - medium 1`] = `
+exports[`22. list two and six no pic - medium 1`] = `
 <View>
   <View>
     <View>
@@ -693,7 +727,7 @@ exports[`21. list two and six no pic - medium 1`] = `
 </View>
 `;
 
-exports[`22. puzzle - medium 1`] = `
+exports[`23. puzzle - medium 1`] = `
 <View>
   <View>
     <View>
@@ -766,7 +800,7 @@ exports[`22. puzzle - medium 1`] = `
 </View>
 `;
 
-exports[`23. front lead two - portrait - medium 1`] = `
+exports[`24. front lead two - portrait - medium 1`] = `
 <View>
   <View>
     <View>
@@ -793,7 +827,7 @@ exports[`23. front lead two - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`24. front lead two - landscape - medium 1`] = `
+exports[`25. front lead two - landscape - medium 1`] = `
 <View>
   <View>
     <View>
@@ -821,7 +855,7 @@ exports[`24. front lead two - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`25. front lead one and one - portrait - medium 1`] = `
+exports[`26. front lead one and one - portrait - medium 1`] = `
 <View>
   <View>
     <View>
@@ -849,7 +883,7 @@ exports[`25. front lead one and one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`26. front lead one and one - landscape - medium 1`] = `
+exports[`27. front lead one and one - landscape - medium 1`] = `
 <View>
   <View>
     <View>
@@ -878,7 +912,7 @@ exports[`26. front lead one and one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`27. front lead one - portrait - medium 1`] = `
+exports[`28. front lead one - portrait - medium 1`] = `
 <View>
   <View>
     <View>
@@ -896,7 +930,7 @@ exports[`27. front lead one - portrait - medium 1`] = `
 </View>
 `;
 
-exports[`28. front lead one - landscape - medium 1`] = `
+exports[`29. front lead one - landscape - medium 1`] = `
 <View>
   <View>
     <View>
@@ -917,7 +951,7 @@ exports[`28. front lead one - landscape - medium 1`] = `
 </View>
 `;
 
-exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
+exports[`30. top secondary landscape (from topsecondaryfourslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -947,7 +981,7 @@ exports[`29. top secondary landscape (from topsecondaryfourslice) - medium 1`] =
 </View>
 `;
 
-exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -977,7 +1011,37 @@ exports[`30. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
+<View>
+  <View>
+    <View>
+      <TileAT
+        breakpoint="medium"
+        tileName="lead"
+      />
+    </View>
+    <View />
+    <View>
+      <TileAV
+        breakpoint="medium"
+        tileName="support1"
+      />
+      <View />
+      <TileAV
+        breakpoint="medium"
+        tileName="support2"
+      />
+      <View />
+      <TileAV
+        breakpoint="medium"
+        tileName="support3"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1007,7 +1071,7 @@ exports[`31. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1037,7 +1101,7 @@ exports[`32. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1067,7 +1131,7 @@ exports[`33. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1097,7 +1161,7 @@ exports[`34. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`35. comment lead and cartoon - wide 1`] = `
+exports[`37. comment lead and cartoon - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1117,7 +1181,7 @@ exports[`35. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`36. daily universal register - wide 1`] = `
+exports[`38. daily universal register - wide 1`] = `
 <View>
   <View>
     <Image
@@ -1170,7 +1234,7 @@ exports[`36. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`37. lead one and one - wide 1`] = `
+exports[`39. lead one and one - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1190,7 +1254,7 @@ exports[`37. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`38. lead one and one - supplement - wide 1`] = `
+exports[`40. lead one and one - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1219,7 +1283,7 @@ exports[`38. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one full width - wide 1`] = `
+exports[`41. lead one full width - wide 1`] = `
 <View>
   <TileR
     breakpoint="wide"
@@ -1228,7 +1292,7 @@ exports[`39. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1260,7 +1324,7 @@ exports[`40. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead two no pic and two - wide 1`] = `
+exports[`43. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1290,7 +1354,7 @@ exports[`41. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`42. leaders slice - wide 1`] = `
+exports[`44. leaders slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1334,7 +1398,7 @@ exports[`42. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`43. secondary one and four - wide 1`] = `
+exports[`45. secondary one and four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1390,7 +1454,7 @@ exports[`43. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`44. secondary one - wide 1`] = `
+exports[`46. secondary one - wide 1`] = `
 <View>
   <TileW
     breakpoint="wide"
@@ -1399,7 +1463,7 @@ exports[`44. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`45. supplement secondary one - wide 1`] = `
+exports[`47. supplement secondary one - wide 1`] = `
 <View>
   <TileBF
     breakpoint="wide"
@@ -1408,7 +1472,7 @@ exports[`45. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary four - wide 1`] = `
+exports[`48. secondary four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1454,7 +1518,53 @@ exports[`46. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`47. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - consecutive - wide 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAR
+          breakpoint="wide"
+          tileName="secondary1"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAR
+          breakpoint="wide"
+          tileName="secondary2"
+        />
+      </View>
+    </View>
+    <View />
+    <View>
+      <TileB
+        additionalHeadlineStyles={
+          Object {
+            "fontSize": 20,
+            "lineHeight": 20,
+          }
+        }
+        breakpoint="wide"
+        tileName="secondary3"
+      />
+      <View />
+      <TileB
+        additionalHeadlineStyles={
+          Object {
+            "fontSize": 20,
+            "lineHeight": 20,
+          }
+        }
+        breakpoint="wide"
+        tileName="secondary4"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`50. secondary four - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1490,7 +1600,7 @@ exports[`47. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary one and columnist - wide 1`] = `
+exports[`51. secondary one and columnist - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1511,7 +1621,7 @@ exports[`48. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary two and two - wide 1`] = `
+exports[`52. secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1541,7 +1651,7 @@ exports[`49. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`50. supplement secondary two and two - wide 1`] = `
+exports[`53. supplement secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1579,7 +1689,7 @@ exports[`50. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`51. lead one and four slice - wide 1`] = `
+exports[`54. lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1614,7 +1724,7 @@ exports[`51. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`52. supplement lead one and four slice - wide 1`] = `
+exports[`55. supplement lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1656,7 +1766,7 @@ exports[`52. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`53. standard slice - wide 1`] = `
+exports[`56. standard slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1689,7 +1799,7 @@ exports[`53. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`54. secondary two no pic and two - wide 1`] = `
+exports[`57. secondary two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1723,7 +1833,7 @@ exports[`54. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`55. list two and six no pic - wide 1`] = `
+exports[`58. list two and six no pic - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1793,7 +1903,7 @@ exports[`55. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`56. puzzle - wide 1`] = `
+exports[`59. puzzle - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1866,7 +1976,7 @@ exports[`56. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`57. front lead two - portrait - wide 1`] = `
+exports[`60. front lead two - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1893,7 +2003,7 @@ exports[`57. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`58. front lead two - landscape - wide 1`] = `
+exports[`61. front lead two - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1921,7 +2031,7 @@ exports[`58. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`59. front lead one and one - portrait - wide 1`] = `
+exports[`62. front lead one and one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1949,7 +2059,7 @@ exports[`59. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead one and one - landscape - wide 1`] = `
+exports[`63. front lead one and one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1978,7 +2088,7 @@ exports[`60. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead one - portrait - wide 1`] = `
+exports[`64. front lead one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1996,7 +2106,7 @@ exports[`61. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one - landscape - wide 1`] = `
+exports[`65. front lead one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2017,7 +2127,7 @@ exports[`62. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2047,7 +2157,7 @@ exports[`63. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2077,7 +2187,37 @@ exports[`64. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+<View>
+  <View>
+    <View>
+      <TileAT
+        breakpoint="wide"
+        tileName="lead"
+      />
+    </View>
+    <View />
+    <View>
+      <TileAV
+        breakpoint="wide"
+        tileName="support1"
+      />
+      <View />
+      <TileAV
+        breakpoint="wide"
+        tileName="support2"
+      />
+      <View />
+      <TileAV
+        breakpoint="wide"
+        tileName="support3"
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2107,7 +2247,7 @@ exports[`65. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2137,7 +2277,7 @@ exports[`66. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2167,7 +2307,7 @@ exports[`67. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2197,7 +2337,7 @@ exports[`68. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`69. comment lead and cartoon - huge 1`] = `
+exports[`73. comment lead and cartoon - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2219,7 +2359,7 @@ exports[`69. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`70. daily universal register - huge 1`] = `
+exports[`74. daily universal register - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2274,7 +2414,7 @@ exports[`70. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`71. lead one and one - huge 1`] = `
+exports[`75. lead one and one - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2296,7 +2436,7 @@ exports[`71. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`72. lead one and one - supplement - huge 1`] = `
+exports[`76. lead one and one - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2327,7 +2467,7 @@ exports[`72. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`73. lead one full width - huge 1`] = `
+exports[`77. lead one full width - huge 1`] = `
 <View>
   <View>
     <TileR
@@ -2338,7 +2478,7 @@ exports[`73. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`74. lead two no pic and two - huge 1`] = `
+exports[`78. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2372,7 +2512,7 @@ exports[`74. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead two no pic and two - huge 1`] = `
+exports[`79. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2404,7 +2544,7 @@ exports[`75. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`76. leaders slice - huge 1`] = `
+exports[`80. leaders slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2450,7 +2590,7 @@ exports[`76. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`77. secondary one and four - huge 1`] = `
+exports[`81. secondary one and four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2508,7 +2648,7 @@ exports[`77. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`78. secondary one - huge 1`] = `
+exports[`82. secondary one - huge 1`] = `
 <View>
   <View>
     <TileW
@@ -2519,7 +2659,7 @@ exports[`78. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`79. supplement secondary one - huge 1`] = `
+exports[`83. supplement secondary one - huge 1`] = `
 <View>
   <View>
     <TileBF
@@ -2530,7 +2670,7 @@ exports[`79. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`80. secondary four - huge 1`] = `
+exports[`84. secondary four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2578,7 +2718,55 @@ exports[`80. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary four - supplement - huge 1`] = `
+exports[`85. secondary four - consecutive - huge 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <View>
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary1"
+          />
+        </View>
+        <View />
+        <View>
+          <TileAR
+            breakpoint="huge"
+            tileName="secondary2"
+          />
+        </View>
+      </View>
+      <View />
+      <View>
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary3"
+        />
+        <View />
+        <TileB
+          additionalHeadlineStyles={
+            Object {
+              "fontSize": 22,
+              "lineHeight": 22,
+            }
+          }
+          breakpoint="huge"
+          tileName="secondary4"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`86. secondary four - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2616,7 +2804,7 @@ exports[`81. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one and columnist - huge 1`] = `
+exports[`87. secondary one and columnist - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2639,7 +2827,7 @@ exports[`82. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`83. secondary two and two - huge 1`] = `
+exports[`88. secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2671,7 +2859,7 @@ exports[`83. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`84. supplement secondary two and two - huge 1`] = `
+exports[`89. supplement secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2705,7 +2893,7 @@ exports[`84. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`85. lead one and four slice - huge 1`] = `
+exports[`90. lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2742,7 +2930,7 @@ exports[`85. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`86. supplement lead one and four slice - huge 1`] = `
+exports[`91. supplement lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2786,7 +2974,7 @@ exports[`86. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`87. standard slice - huge 1`] = `
+exports[`92. standard slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2821,7 +3009,7 @@ exports[`87. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two no pic and two - huge 1`] = `
+exports[`93. secondary two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2857,7 +3045,7 @@ exports[`88. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. list two and six no pic - huge 1`] = `
+exports[`94. list two and six no pic - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2929,7 +3117,7 @@ exports[`89. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`90. puzzle - huge 1`] = `
+exports[`95. puzzle - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3004,7 +3192,7 @@ exports[`90. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`91. front lead two - portrait - huge 1`] = `
+exports[`96. front lead two - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3033,7 +3221,7 @@ exports[`91. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`92. front lead two - landscape - huge 1`] = `
+exports[`97. front lead two - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3063,7 +3251,7 @@ exports[`92. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`93. front lead one and one - portrait - huge 1`] = `
+exports[`98. front lead one and one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3093,7 +3281,7 @@ exports[`93. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`94. front lead one and one - landscape - huge 1`] = `
+exports[`99. front lead one and one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3124,7 +3312,7 @@ exports[`94. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`95. front lead one - portrait - huge 1`] = `
+exports[`100. front lead one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3144,7 +3332,7 @@ exports[`95. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead one - landscape - huge 1`] = `
+exports[`101. front lead one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3167,7 +3355,7 @@ exports[`96. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3199,7 +3387,7 @@ exports[`97. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3231,39 +3419,7 @@ exports[`98. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`99. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
-<View>
-  <View>
-    <View>
-      <View>
-        <TileAU
-          breakpoint="huge"
-          tileName="lead"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAV
-          breakpoint="huge"
-          tileName="support1"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support2"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support3"
-        />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3295,7 +3451,7 @@ exports[`100. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3327,7 +3483,71 @@ exports[`101. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`102. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAT
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAV
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support3"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+<View>
+  <View>
+    <View>
+      <View>
+        <TileAU
+          breakpoint="huge"
+          tileName="lead"
+        />
+      </View>
+      <View />
+      <View>
+        <TileAV
+          breakpoint="huge"
+          tileName="support1"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support2"
+        />
+        <View />
+        <TileAV
+          breakpoint="huge"
+          tileName="support3"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tablet-slices.test.js.snap
@@ -1011,37 +1011,7 @@ exports[`31. top secondary portrait (from topsecondaryfourslice) - medium 1`] = 
 </View>
 `;
 
-exports[`32. top secondary portrait (from topsecondaryfourslice) - medium 1`] = `
-<View>
-  <View>
-    <View>
-      <TileAT
-        breakpoint="medium"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAV
-        breakpoint="medium"
-        tileName="support1"
-      />
-      <View />
-      <TileAV
-        breakpoint="medium"
-        tileName="support2"
-      />
-      <View />
-      <TileAV
-        breakpoint="medium"
-        tileName="support3"
-      />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`32. top secondary landscape (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1071,7 +1041,7 @@ exports[`33. top secondary landscape (from topsecondarytwoandtwoslice) - medium 
 </View>
 `;
 
-exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
+exports[`33. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1101,7 +1071,7 @@ exports[`34. top secondary portrait (from topsecondarytwoandtwoslice) - medium 1
 </View>
 `;
 
-exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`34. top secondary landscape (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1131,7 +1101,7 @@ exports[`35. top secondary landscape (from topsecondarytwonopicandtwoslice) - me
 </View>
 `;
 
-exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
+exports[`35. top secondary portrait (from topsecondarytwonopicandtwoslice) - medium 1`] = `
 <View>
   <View>
     <View>
@@ -1161,7 +1131,7 @@ exports[`36. top secondary portrait (from topsecondarytwonopicandtwoslice) - med
 </View>
 `;
 
-exports[`37. comment lead and cartoon - wide 1`] = `
+exports[`36. comment lead and cartoon - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1181,7 +1151,7 @@ exports[`37. comment lead and cartoon - wide 1`] = `
 </View>
 `;
 
-exports[`38. daily universal register - wide 1`] = `
+exports[`37. daily universal register - wide 1`] = `
 <View>
   <View>
     <Image
@@ -1234,7 +1204,7 @@ exports[`38. daily universal register - wide 1`] = `
 </View>
 `;
 
-exports[`39. lead one and one - wide 1`] = `
+exports[`38. lead one and one - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1254,7 +1224,7 @@ exports[`39. lead one and one - wide 1`] = `
 </View>
 `;
 
-exports[`40. lead one and one - supplement - wide 1`] = `
+exports[`39. lead one and one - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1283,7 +1253,7 @@ exports[`40. lead one and one - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`41. lead one full width - wide 1`] = `
+exports[`40. lead one full width - wide 1`] = `
 <View>
   <TileR
     breakpoint="wide"
@@ -1292,7 +1262,7 @@ exports[`41. lead one full width - wide 1`] = `
 </View>
 `;
 
-exports[`42. lead two no pic and two - wide 1`] = `
+exports[`41. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1324,7 +1294,7 @@ exports[`42. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`43. lead two no pic and two - wide 1`] = `
+exports[`42. lead two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1354,7 +1324,7 @@ exports[`43. lead two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`44. leaders slice - wide 1`] = `
+exports[`43. leaders slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1398,7 +1368,7 @@ exports[`44. leaders slice - wide 1`] = `
 </View>
 `;
 
-exports[`45. secondary one and four - wide 1`] = `
+exports[`44. secondary one and four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1454,7 +1424,7 @@ exports[`45. secondary one and four - wide 1`] = `
 </View>
 `;
 
-exports[`46. secondary one - wide 1`] = `
+exports[`45. secondary one - wide 1`] = `
 <View>
   <TileW
     breakpoint="wide"
@@ -1463,7 +1433,7 @@ exports[`46. secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`47. supplement secondary one - wide 1`] = `
+exports[`46. supplement secondary one - wide 1`] = `
 <View>
   <TileBF
     breakpoint="wide"
@@ -1472,7 +1442,7 @@ exports[`47. supplement secondary one - wide 1`] = `
 </View>
 `;
 
-exports[`48. secondary four - wide 1`] = `
+exports[`47. secondary four - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1518,7 +1488,7 @@ exports[`48. secondary four - wide 1`] = `
 </View>
 `;
 
-exports[`49. secondary four - consecutive - wide 1`] = `
+exports[`48. secondary four - consecutive - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1564,7 +1534,7 @@ exports[`49. secondary four - consecutive - wide 1`] = `
 </View>
 `;
 
-exports[`50. secondary four - supplement - wide 1`] = `
+exports[`49. secondary four - supplement - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1600,7 +1570,7 @@ exports[`50. secondary four - supplement - wide 1`] = `
 </View>
 `;
 
-exports[`51. secondary one and columnist - wide 1`] = `
+exports[`50. secondary one and columnist - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1621,7 +1591,7 @@ exports[`51. secondary one and columnist - wide 1`] = `
 </View>
 `;
 
-exports[`52. secondary two and two - wide 1`] = `
+exports[`51. secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1651,7 +1621,7 @@ exports[`52. secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`53. supplement secondary two and two - wide 1`] = `
+exports[`52. supplement secondary two and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1689,7 +1659,7 @@ exports[`53. supplement secondary two and two - wide 1`] = `
 </View>
 `;
 
-exports[`54. lead one and four slice - wide 1`] = `
+exports[`53. lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1724,7 +1694,7 @@ exports[`54. lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`55. supplement lead one and four slice - wide 1`] = `
+exports[`54. supplement lead one and four slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1766,7 +1736,7 @@ exports[`55. supplement lead one and four slice - wide 1`] = `
 </View>
 `;
 
-exports[`56. standard slice - wide 1`] = `
+exports[`55. standard slice - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1799,7 +1769,7 @@ exports[`56. standard slice - wide 1`] = `
 </View>
 `;
 
-exports[`57. secondary two no pic and two - wide 1`] = `
+exports[`56. secondary two no pic and two - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1833,7 +1803,7 @@ exports[`57. secondary two no pic and two - wide 1`] = `
 </View>
 `;
 
-exports[`58. list two and six no pic - wide 1`] = `
+exports[`57. list two and six no pic - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1903,7 +1873,7 @@ exports[`58. list two and six no pic - wide 1`] = `
 </View>
 `;
 
-exports[`59. puzzle - wide 1`] = `
+exports[`58. puzzle - wide 1`] = `
 <View>
   <View>
     <View>
@@ -1976,7 +1946,7 @@ exports[`59. puzzle - wide 1`] = `
 </View>
 `;
 
-exports[`60. front lead two - portrait - wide 1`] = `
+exports[`59. front lead two - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2003,7 +1973,7 @@ exports[`60. front lead two - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`61. front lead two - landscape - wide 1`] = `
+exports[`60. front lead two - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2031,7 +2001,7 @@ exports[`61. front lead two - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`62. front lead one and one - portrait - wide 1`] = `
+exports[`61. front lead one and one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2059,7 +2029,7 @@ exports[`62. front lead one and one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`63. front lead one and one - landscape - wide 1`] = `
+exports[`62. front lead one and one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2088,7 +2058,7 @@ exports[`63. front lead one and one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`64. front lead one - portrait - wide 1`] = `
+exports[`63. front lead one - portrait - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2106,7 +2076,7 @@ exports[`64. front lead one - portrait - wide 1`] = `
 </View>
 `;
 
-exports[`65. front lead one - landscape - wide 1`] = `
+exports[`64. front lead one - landscape - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2127,7 +2097,7 @@ exports[`65. front lead one - landscape - wide 1`] = `
 </View>
 `;
 
-exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
+exports[`65. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2157,7 +2127,7 @@ exports[`66. top secondary landscape (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
+exports[`66. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2187,37 +2157,7 @@ exports[`67. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
 </View>
 `;
 
-exports[`68. top secondary portrait (from topsecondaryfourslice) - wide 1`] = `
-<View>
-  <View>
-    <View>
-      <TileAT
-        breakpoint="wide"
-        tileName="lead"
-      />
-    </View>
-    <View />
-    <View>
-      <TileAV
-        breakpoint="wide"
-        tileName="support1"
-      />
-      <View />
-      <TileAV
-        breakpoint="wide"
-        tileName="support2"
-      />
-      <View />
-      <TileAV
-        breakpoint="wide"
-        tileName="support3"
-      />
-    </View>
-  </View>
-</View>
-`;
-
-exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`67. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2247,7 +2187,7 @@ exports[`69. top secondary landscape (from topsecondarytwoandtwoslice) - wide 1`
 </View>
 `;
 
-exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
+exports[`68. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2277,7 +2217,7 @@ exports[`70. top secondary portrait (from topsecondarytwoandtwoslice) - wide 1`]
 </View>
 `;
 
-exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`69. top secondary landscape (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2307,7 +2247,7 @@ exports[`71. top secondary landscape (from topsecondarytwonopicandtwoslice) - wi
 </View>
 `;
 
-exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
+exports[`70. top secondary portrait (from topsecondarytwonopicandtwoslice) - wide 1`] = `
 <View>
   <View>
     <View>
@@ -2337,7 +2277,7 @@ exports[`72. top secondary portrait (from topsecondarytwonopicandtwoslice) - wid
 </View>
 `;
 
-exports[`73. comment lead and cartoon - huge 1`] = `
+exports[`71. comment lead and cartoon - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2359,7 +2299,7 @@ exports[`73. comment lead and cartoon - huge 1`] = `
 </View>
 `;
 
-exports[`74. daily universal register - huge 1`] = `
+exports[`72. daily universal register - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2414,7 +2354,7 @@ exports[`74. daily universal register - huge 1`] = `
 </View>
 `;
 
-exports[`75. lead one and one - huge 1`] = `
+exports[`73. lead one and one - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2436,7 +2376,7 @@ exports[`75. lead one and one - huge 1`] = `
 </View>
 `;
 
-exports[`76. lead one and one - supplement - huge 1`] = `
+exports[`74. lead one and one - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2467,7 +2407,7 @@ exports[`76. lead one and one - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`77. lead one full width - huge 1`] = `
+exports[`75. lead one full width - huge 1`] = `
 <View>
   <View>
     <TileR
@@ -2478,7 +2418,7 @@ exports[`77. lead one full width - huge 1`] = `
 </View>
 `;
 
-exports[`78. lead two no pic and two - huge 1`] = `
+exports[`76. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2512,7 +2452,7 @@ exports[`78. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`79. lead two no pic and two - huge 1`] = `
+exports[`77. lead two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2544,7 +2484,7 @@ exports[`79. lead two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`80. leaders slice - huge 1`] = `
+exports[`78. leaders slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2590,7 +2530,7 @@ exports[`80. leaders slice - huge 1`] = `
 </View>
 `;
 
-exports[`81. secondary one and four - huge 1`] = `
+exports[`79. secondary one and four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2648,7 +2588,7 @@ exports[`81. secondary one and four - huge 1`] = `
 </View>
 `;
 
-exports[`82. secondary one - huge 1`] = `
+exports[`80. secondary one - huge 1`] = `
 <View>
   <View>
     <TileW
@@ -2659,7 +2599,7 @@ exports[`82. secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`83. supplement secondary one - huge 1`] = `
+exports[`81. supplement secondary one - huge 1`] = `
 <View>
   <View>
     <TileBF
@@ -2670,7 +2610,7 @@ exports[`83. supplement secondary one - huge 1`] = `
 </View>
 `;
 
-exports[`84. secondary four - huge 1`] = `
+exports[`82. secondary four - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2718,7 +2658,7 @@ exports[`84. secondary four - huge 1`] = `
 </View>
 `;
 
-exports[`85. secondary four - consecutive - huge 1`] = `
+exports[`83. secondary four - consecutive - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2766,7 +2706,7 @@ exports[`85. secondary four - consecutive - huge 1`] = `
 </View>
 `;
 
-exports[`86. secondary four - supplement - huge 1`] = `
+exports[`84. secondary four - supplement - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2804,7 +2744,7 @@ exports[`86. secondary four - supplement - huge 1`] = `
 </View>
 `;
 
-exports[`87. secondary one and columnist - huge 1`] = `
+exports[`85. secondary one and columnist - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2827,7 +2767,7 @@ exports[`87. secondary one and columnist - huge 1`] = `
 </View>
 `;
 
-exports[`88. secondary two and two - huge 1`] = `
+exports[`86. secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2859,7 +2799,7 @@ exports[`88. secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`89. supplement secondary two and two - huge 1`] = `
+exports[`87. supplement secondary two and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2893,7 +2833,7 @@ exports[`89. supplement secondary two and two - huge 1`] = `
 </View>
 `;
 
-exports[`90. lead one and four slice - huge 1`] = `
+exports[`88. lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2930,7 +2870,7 @@ exports[`90. lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`91. supplement lead one and four slice - huge 1`] = `
+exports[`89. supplement lead one and four slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -2974,7 +2914,7 @@ exports[`91. supplement lead one and four slice - huge 1`] = `
 </View>
 `;
 
-exports[`92. standard slice - huge 1`] = `
+exports[`90. standard slice - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3009,7 +2949,7 @@ exports[`92. standard slice - huge 1`] = `
 </View>
 `;
 
-exports[`93. secondary two no pic and two - huge 1`] = `
+exports[`91. secondary two no pic and two - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3045,7 +2985,7 @@ exports[`93. secondary two no pic and two - huge 1`] = `
 </View>
 `;
 
-exports[`94. list two and six no pic - huge 1`] = `
+exports[`92. list two and six no pic - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3117,7 +3057,7 @@ exports[`94. list two and six no pic - huge 1`] = `
 </View>
 `;
 
-exports[`95. puzzle - huge 1`] = `
+exports[`93. puzzle - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3192,7 +3132,7 @@ exports[`95. puzzle - huge 1`] = `
 </View>
 `;
 
-exports[`96. front lead two - portrait - huge 1`] = `
+exports[`94. front lead two - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3221,7 +3161,7 @@ exports[`96. front lead two - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`97. front lead two - landscape - huge 1`] = `
+exports[`95. front lead two - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3251,7 +3191,7 @@ exports[`97. front lead two - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`98. front lead one and one - portrait - huge 1`] = `
+exports[`96. front lead one and one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3281,7 +3221,7 @@ exports[`98. front lead one and one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`99. front lead one and one - landscape - huge 1`] = `
+exports[`97. front lead one and one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3312,7 +3252,7 @@ exports[`99. front lead one and one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`100. front lead one - portrait - huge 1`] = `
+exports[`98. front lead one - portrait - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3332,7 +3272,7 @@ exports[`100. front lead one - portrait - huge 1`] = `
 </View>
 `;
 
-exports[`101. front lead one - landscape - huge 1`] = `
+exports[`99. front lead one - landscape - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3355,7 +3295,7 @@ exports[`101. front lead one - landscape - huge 1`] = `
 </View>
 `;
 
-exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
+exports[`100. top secondary landscape (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3387,7 +3327,7 @@ exports[`102. top secondary landscape (from topsecondaryfourslice) - huge 1`] = 
 </View>
 `;
 
-exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
+exports[`101. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3419,39 +3359,7 @@ exports[`103. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
 </View>
 `;
 
-exports[`104. top secondary portrait (from topsecondaryfourslice) - huge 1`] = `
-<View>
-  <View>
-    <View>
-      <View>
-        <TileAT
-          breakpoint="huge"
-          tileName="lead"
-        />
-      </View>
-      <View />
-      <View>
-        <TileAV
-          breakpoint="huge"
-          tileName="support1"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support2"
-        />
-        <View />
-        <TileAV
-          breakpoint="huge"
-          tileName="support3"
-        />
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`102. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3483,7 +3391,7 @@ exports[`105. top secondary landscape (from topsecondarytwoandtwoslice) - huge 1
 </View>
 `;
 
-exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
+exports[`103. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3515,7 +3423,7 @@ exports[`106. top secondary portrait (from topsecondarytwoandtwoslice) - huge 1`
 </View>
 `;
 
-exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`104. top secondary landscape (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>
@@ -3547,7 +3455,7 @@ exports[`107. top secondary landscape (from topsecondarytwonopicandtwoslice) - h
 </View>
 `;
 
-exports[`108. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
+exports[`105. top secondary portrait (from topsecondarytwonopicandtwoslice) - huge 1`] = `
 <View>
   <View>
     <View>

--- a/packages/edition-slices/__tests__/shared-tablet-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-tablet-slices.base.js
@@ -119,6 +119,11 @@ const slices = [
     Slice: SecondaryFourSlice,
   },
   {
+    mock: mockSecondaryFourSlice({ isConsecutive: true }),
+    name: "secondary four - consecutive",
+    Slice: SecondaryFourSlice,
+  },
+  {
     mock: mockSecondaryFourSlice(),
     name: "secondary four - supplement",
     Slice: SupplementSecondaryFourSlice,
@@ -227,6 +232,12 @@ const slices = [
     name: "top secondary landscape (from TopSecondaryFourSlice)",
     Slice: TopSecondarySlice,
     orientation: "landscape",
+  },
+  {
+    mock: mockSecondaryFourSlice(),
+    name: "top secondary portrait (from TopSecondaryFourSlice)",
+    Slice: TopSecondarySlice,
+    orientation: "portrait",
   },
   {
     mock: mockSecondaryFourSlice(),

--- a/packages/edition-slices/__tests__/shared-tablet-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-tablet-slices.base.js
@@ -240,12 +240,6 @@ const slices = [
     orientation: "portrait",
   },
   {
-    mock: mockSecondaryFourSlice(),
-    name: "top secondary portrait (from TopSecondaryFourSlice)",
-    Slice: TopSecondarySlice,
-    orientation: "portrait",
-  },
-  {
     mock: mockSecondaryTwoAndTwoSlice(),
     name: "top secondary landscape (from TopSecondaryTwoAndTwoSlice)",
     Slice: TopSecondarySlice,

--- a/packages/edition-slices/src/slices/secondaryfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryfour/index.js
@@ -43,6 +43,10 @@ class SecondaryFour extends Component {
       slice: { isConsecutive, secondary1, secondary2, secondary3, secondary4 },
     } = this.props;
 
+    const tiles = isConsecutive
+      ? [secondary3, secondary4, secondary1, secondary2]
+      : [secondary1, secondary2, secondary3, secondary4];
+
     return (
       <SecondaryFourSlice
         breakpoint={breakpoint}
@@ -51,7 +55,7 @@ class SecondaryFour extends Component {
           <TileAR
             breakpoint={breakpoint}
             onPress={onPress}
-            tile={secondary1}
+            tile={tiles[0]}
             tileName="secondary1"
           />
         }
@@ -59,7 +63,7 @@ class SecondaryFour extends Component {
           <TileAR
             breakpoint={breakpoint}
             onPress={onPress}
-            tile={secondary2}
+            tile={tiles[1]}
             tileName="secondary2"
           />
         }
@@ -67,7 +71,7 @@ class SecondaryFour extends Component {
           <TileB
             breakpoint={breakpoint}
             onPress={onPress}
-            tile={secondary3}
+            tile={tiles[2]}
             tileName="secondary3"
             additionalHeadlineStyles={stylesFactory(breakpoint)}
           />
@@ -76,7 +80,7 @@ class SecondaryFour extends Component {
           <TileB
             breakpoint={breakpoint}
             onPress={onPress}
-            tile={secondary4}
+            tile={tiles[3]}
             tileName="secondary4"
             additionalHeadlineStyles={stylesFactory(breakpoint)}
           />

--- a/packages/fixture-generator/src/mock-slice.ts
+++ b/packages/fixture-generator/src/mock-slice.ts
@@ -73,6 +73,7 @@ interface SecondaryOneAndFourSliceWithName extends SecondaryOneAndFourSlice {
 
 interface SecondaryFourSliceWithName extends SecondaryFourSlice {
   name: string;
+  isConsecutive: boolean;
 }
 
 interface SecondaryTwoAndTwoSliceWithName extends SecondaryTwoAndTwoSlice {
@@ -326,7 +327,11 @@ function mockSecondaryOneAndFourSlice(): SecondaryOneAndFourSliceWithName {
   };
 }
 
-function mockSecondaryFourSlice(): SecondaryFourSliceWithName {
+function mockSecondaryFourSlice(
+  { isConsecutive } = {
+    isConsecutive: false,
+  },
+): SecondaryFourSliceWithName {
   const tiles = getTiles(4);
   return <SecondaryFourSliceWithName>{
     name: "SecondaryFourSlice",
@@ -335,6 +340,7 @@ function mockSecondaryFourSlice(): SecondaryFourSliceWithName {
     secondary3: tiles[2],
     secondary4: tiles[3],
     items: tiles,
+    isConsecutive,
   };
 }
 

--- a/packages/section/__tests__/unit/__snapshots__/prepareSlicesForRender.test.ts.snap
+++ b/packages/section/__tests__/unit/__snapshots__/prepareSlicesForRender.test.ts.snap
@@ -69,7 +69,6 @@ Array [
     "elementId": "k.10",
     "id": "k",
     "ignoreSeparator": true,
-    "isConsecutive": true,
     "name": "OtherSlice",
   },
   Object {

--- a/packages/section/__tests__/unit/consecutiveItemsFlagger.test.ts
+++ b/packages/section/__tests__/unit/consecutiveItemsFlagger.test.ts
@@ -58,6 +58,61 @@ describe("consecutiveItemsFlagger", () => {
     expect(newData).toEqual(flaggedData);
   });
 
+  it("should add isConsecutive property to alternating slices", () => {
+    const originalData = [
+      { id: "a", name: "LeadersSlice" },
+      { id: "b", name: "SecondaryFourSlice" },
+      { id: "c", name: "SecondaryFourSlice" },
+      { id: "d", name: "SecondaryFourSlice" },
+      { id: "e", name: "SecondaryFourSlice" },
+    ];
+
+    const flaggedData = [
+      { id: "a", name: "LeadersSlice" },
+      { id: "b", name: "SecondaryFourSlice" },
+      { id: "c", name: "SecondaryFourSlice", isConsecutive: true },
+      { id: "d", name: "SecondaryFourSlice" },
+      { id: "e", name: "SecondaryFourSlice", isConsecutive: true },
+    ];
+
+    const newData = consecutiveItemsFlagger(originalData);
+    expect(newData).toEqual(flaggedData);
+  });
+
+  it("should add isConsecutive property on a SecondaryFourSlice that follows a TopSecondaryFourSlice", () => {
+    const originalData = [
+      { id: "a", name: "TopSecondaryFourSlice" },
+      { id: "b", name: "SecondaryFourSlice" },
+      { id: "c", name: "OtherSlice" },
+    ];
+
+    const flaggedData = [
+      { id: "a", name: "TopSecondaryFourSlice" },
+      { id: "b", name: "SecondaryFourSlice", isConsecutive: true },
+      { id: "c", name: "OtherSlice" },
+    ];
+
+    const newData = consecutiveItemsFlagger(originalData);
+    expect(newData).toEqual(flaggedData);
+  });
+
+  it("should add isConsecutive property on a SecondaryFourSlice that follows a LeadOneAndOneSlice", () => {
+    const originalData = [
+      { id: "a", name: "LeadOneAndOneSlice" },
+      { id: "b", name: "SecondaryFourSlice" },
+      { id: "c", name: "OtherSlice" },
+    ];
+
+    const flaggedData = [
+      { id: "a", name: "LeadOneAndOneSlice" },
+      { id: "b", name: "SecondaryFourSlice", isConsecutive: true },
+      { id: "c", name: "OtherSlice" },
+    ];
+
+    const newData = consecutiveItemsFlagger(originalData);
+    expect(newData).toEqual(flaggedData);
+  });
+
   it("should not mutate passed data", () => {
     const originalData = [
       { id: "a", name: "LeadersSlice" },

--- a/packages/section/src/utils/consecutiveItemsFlagger.ts
+++ b/packages/section/src/utils/consecutiveItemsFlagger.ts
@@ -2,7 +2,6 @@ import memoizeOne from "memoize-one";
 
 const withIsConsecutive = (slice: any) => ({ ...slice, isConsecutive: true });
 
-// in order to
 const consecutivePairs = [
   ["TopSecondaryFourSlice", "SecondaryFourSlice"],
   ["LeadOneAndOneSlice", "SecondaryFourSlice"],

--- a/packages/section/src/utils/consecutiveItemsFlagger.ts
+++ b/packages/section/src/utils/consecutiveItemsFlagger.ts
@@ -1,8 +1,11 @@
 import memoizeOne from "memoize-one";
+import { SliceName } from "@times-components-native/types";
 
 const withIsConsecutive = (slice: any) => ({ ...slice, isConsecutive: true });
 
-const consecutivePairs = [
+type Pair = [SliceName, SliceName];
+
+const consecutivePairs: Pair[] = [
   ["TopSecondaryFourSlice", "SecondaryFourSlice"],
   ["LeadOneAndOneSlice", "SecondaryFourSlice"],
 ];

--- a/packages/section/src/utils/consecutiveItemsFlagger.ts
+++ b/packages/section/src/utils/consecutiveItemsFlagger.ts
@@ -2,15 +2,30 @@ import memoizeOne from "memoize-one";
 
 const withIsConsecutive = (slice: any) => ({ ...slice, isConsecutive: true });
 
+// in order to
+const consecutivePairs = [
+  ["TopSecondaryFourSlice", "SecondaryFourSlice"],
+  ["LeadOneAndOneSlice", "SecondaryFourSlice"],
+];
+
+const isConsecutivePair = (
+  currentName: string,
+  previousName: string,
+): boolean =>
+  consecutivePairs.some(([a, b]) => previousName == a && currentName == b);
+
 export const consecutiveItemsFlagger = memoizeOne((slices: any[]) =>
-  slices.reduce(
-    (acc, curr, i) =>
-      acc.length > 0 &&
-      curr.name &&
-      acc[i - 1].name &&
-      curr.name === acc[i - 1].name
-        ? [...acc, withIsConsecutive(curr)]
-        : [...acc, curr],
-    [],
-  ),
+  slices.reduce((acc, curr, i) => {
+    const currentName = curr.name;
+    const previousName = acc[i - 1]?.name;
+    const previousIsConsecutive = acc[i - 1]?.isConsecutive;
+
+    const isConsecutiveSlices =
+      currentName === previousName ||
+      isConsecutivePair(currentName, previousName);
+
+    return !previousIsConsecutive && isConsecutiveSlices
+      ? [...acc, withIsConsecutive(curr)]
+      : [...acc, curr];
+  }, []),
 );

--- a/packages/types/domain-types.ts
+++ b/packages/types/domain-types.ts
@@ -90,3 +90,28 @@ export type ArticleContent =
   | InteractiveContent
   | ImageContent
   | AdContent;
+
+export type SliceName =
+  | "LeadOneAndOneSlice"
+  | "LeadOneAndFourSlice"
+  | "TopSecondaryFourSlice"
+  | "SecondaryFourSlice"
+  | "CommentLeadAndCartoonSlice"
+  | "DailyUniversalRegister"
+  | "LeadersSlice"
+  | "LeadOneFullWidthSlice"
+  | "LeadTwoNoPicAndTwoSlice"
+  | "Puzzle"
+  | "SecondaryOneAndColumnistSlice"
+  | "SecondaryOneAndFourSlice"
+  | "SecondaryOneSlice"
+  | "SecondaryTwoAndTwoSlice"
+  | "SecondaryTwoNoPicAndTwoSlice"
+  | "StandardSlice"
+  | "TwoPicAndSixNoPicSlice"
+  | "LeadTwoFrontSlice"
+  | "LeadOneAndOneFrontSlice"
+  | "LeadOneFullWidthFrontSlice"
+  | "TopSecondaryTwoAndTwoSlice"
+  | "TopSecondaryTwoNoPicAndTwoSlice"
+  | "SectionAd";


### PR DESCRIPTION
This PR ensures that a secondary-four slice displays right-aligned images after they follow a slice with left-aligned images.

There were a few issues with the previous implementation which are now fixed: 
1. We weren't alternating the image alignment from left-right-left and so on. We were only doing left-right-right-etc
2. When we were flipping a secondary-four slice to be right-aligned, the articles were also being flipped, which isn't correct. The articles need to appear in the same order in the slice from left-to-right but have a different display.

# TopSecondarySlice / Secondary Four
https://nidigitalsolutions.jira.com/browse/TNLT-6336

## Before
![image](https://user-images.githubusercontent.com/6280629/105510700-e0d0ea80-5cc6-11eb-9873-f6206d1cf7db.png)
## After
![simulator_screenshot_A3085C48-2BD1-4A15-A2E8-7DEA9234A8A2](https://user-images.githubusercontent.com/6280629/105510730-eaf2e900-5cc6-11eb-9467-95d0d135fccb.png)

# LeadOneAndOne / Secondary Four
https://nidigitalsolutions.jira.com/browse/TNLT-6352

## Before
![image](https://user-images.githubusercontent.com/6280629/105510599-bed76800-5cc6-11eb-8324-46cb93e5dc64.png)

## After
![simulator_screenshot_ADD1C73B-C607-43DA-9C9B-8DC596E09CF0](https://user-images.githubusercontent.com/6280629/105510528-a6ffe400-5cc6-11eb-8043-f343db424f84.png)
