### PR TITLE
chore: fixes some unit test warnings

### DIFF
--- a/packages/article-summary/src/article-summary-content.js
+++ b/packages/article-summary/src/article-summary-content.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
 import PropTypes from "prop-types";
-import { propTypes as treePropType } from "@times-components-native/markup-forest";
 import { renderAst as defaultRenderAst } from "./article-summary";
 import styles from "./styles";
 
@@ -35,7 +34,7 @@ const ArticleSummaryContent = ({
 };
 
 ArticleSummaryContent.propTypes = {
-  ast: PropTypes.arrayOf(treePropType),
+  ast: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   className: PropTypes.string,
   style: PropTypes.shape({}),
 };

--- a/packages/edition-slices/__tests__/shared-components.base.js
+++ b/packages/edition-slices/__tests__/shared-components.base.js
@@ -1,7 +1,5 @@
 import React from "react";
-import { Animated, Text } from "react-native";
-import { delay } from "@times-components-native/test-utils";
-import { shallow } from "enzyme";
+import { Text } from "react-native";
 import TestRenderer from "react-test-renderer";
 import Image from "@times-components-native/image";
 import { SectionContext } from "@times-components-native/context";

--- a/packages/edition-slices/__tests__/shared-components.base.js
+++ b/packages/edition-slices/__tests__/shared-components.base.js
@@ -32,6 +32,8 @@ export default () => {
       name:
         "Tile summary falls back to article strapline if strapline is unavailable",
       test: () => {
+        jest.useFakeTimers();
+
         const tileWithoutStrapline = {
           ...tile,
           article: {
@@ -54,6 +56,8 @@ export default () => {
       name:
         "Tile summary falls back to shortHeadline if tileHeadline is unavailable",
       test: () => {
+        jest.useFakeTimers();
+
         const tileWithoutShortHeadline = {
           ...tile,
           article: {
@@ -76,6 +80,8 @@ export default () => {
       name:
         "Tile summary falls back to headline if shortHeadline and tileHeadline is unavailable",
       test: () => {
+        jest.useFakeTimers();
+
         const tileWithoutShortHeadlineAndTileHeadline = {
           ...tile,
           article: {
@@ -97,6 +103,8 @@ export default () => {
     {
       name: "Tile summary hides the label correctly",
       test: () => {
+        jest.useFakeTimers();
+
         const output = TestRenderer.create(
           <TileSummary tile={tile} hideLabel={true} />,
         );
@@ -109,6 +117,8 @@ export default () => {
       name:
         "Tile summary displays the tile summary override if it is available",
       test: () => {
+        jest.useFakeTimers();
+
         const tileWithTeaserOverride = {
           article: {
             ...tile.article,
@@ -143,6 +153,8 @@ export default () => {
     {
       name: "Tile summary displays tile leadAsset override if it is available",
       test: () => {
+        jest.useFakeTimers();
+
         const tileWithLeadAssetOverride = {
           article: {
             ...tile.article,
@@ -179,6 +191,8 @@ export default () => {
       name:
         "Tile summary displays tile listingAsset override if no tile override is available",
       test: () => {
+        jest.useFakeTimers();
+
         const tileWithListingAssetOverride = {
           ...tile,
           article: {

--- a/packages/edition-slices/__tests__/shared-tile-utils.js
+++ b/packages/edition-slices/__tests__/shared-tile-utils.js
@@ -16,6 +16,8 @@ export const testTile = (
   mockTile = tile,
   otherProps = {},
 ) => {
+  // our Tile have dependencies on React Native's Animated which is difficult to mock, and results in tests not stopping gracefully. This fixes this issue (https://github.com/facebook/jest/issues/6434)
+  jest.useFakeTimers();
   const output = TestRenderer.create(
     <Tile
       onPress={() => null}

--- a/packages/edition-slices/__tests__/shared-tile-utils.js
+++ b/packages/edition-slices/__tests__/shared-tile-utils.js
@@ -16,7 +16,7 @@ export const testTile = (
   mockTile = tile,
   otherProps = {},
 ) => {
-  // our Tile have dependencies on React Native's Animated which is difficult to mock, and results in tests not stopping gracefully. This fixes this issue (https://github.com/facebook/jest/issues/6434)
+  // Tile component has dependencies on React Native's Animated which is difficult to mock, and results in tests not stopping gracefully. This fixes this issue (https://github.com/facebook/jest/issues/6434)
   jest.useFakeTimers();
   const output = TestRenderer.create(
     <Tile

--- a/packages/edition-slices/src/tiles/shared/tile-link.tsx
+++ b/packages/edition-slices/src/tiles/shared/tile-link.tsx
@@ -5,7 +5,7 @@ import { ConfiguredTile, OnArticlePress } from "@times-components-native/types";
 
 interface Props {
   onPress: OnArticlePress;
-  style: TextStyle;
+  style?: TextStyle;
   tile: ConfiguredTile;
 }
 const TileLink: FC<Props> = ({

--- a/test-setup/setup-jest.js
+++ b/test-setup/setup-jest.js
@@ -25,3 +25,5 @@ jest.mock("@react-native-community/netinfo", () => {
     subscribe: () => () => null,
   };
 });
+
+jest.mock("react-native/Libraries/Animated/src/NativeAnimatedHelper");


### PR DESCRIPTION
This PR fixes a few issues showing in the unit test output.

To fix this particular issue (found solution here https://github.com/facebook/jest/issues/6434) - I've had to have all tile tests use `jest.useFakeTimers()` - as the RN Animated logic was causing tests to not stop gracefully.

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

      94 |       {labelProps ? <ArticleSummaryLabel {...labelProps} /> : null}
      95 |       {isOpinionByline && byline}
    > 96 |       {headline}
         |        ^
      97 |       {strapline}
      98 |       {flags}
      99 |       {content}

      at easeInOut (node_modules/react-native/Libraries/Animated/src/animations/TimingAnimation.js:36:18)
      at new TimingAnimation (node_modules/react-native/Libraries/Animated/src/animations/TimingAnimation.js:57:81)
      at start (node_modules/react-native/Libraries/Animated/src/AnimatedImplementation.js:156:27)
      at Object.start (node_modules/react-native/Libraries/Animated/src/AnimatedImplementation.js:162:7)
      at packages/article-summary/src/article-summary.js:96:8
  console.error node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10141
    The above error occurred in the <ArticleSummaryLabel> component:
        in ArticleSummaryLabel (created by ArticleSummary)
        in View (created by View)
        in View (created by ArticleSummary)
        in ArticleSummary (created by Context.Consumer)
        in TileSummary (created by TileA)
        in Link (created by TileLink)
        in TileLink (created by TileA)
        in TileA (created by WithTrackEvents(TileA))
        in WithTrackEvents(TileA)
    
    Consider adding an error boundary to your tree to customize error handling behavior.
    Visit https://fb.me/react-error-boundaries to learn more about error boundaries.

  console.error node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10141
    The above error occurred in the <TileSummary> component:
        in TileSummary (created by TileA)
        in Link (created by TileLink)
        in TileLink (created by TileA)
        in TileA (created by WithTrackEvents(TileA))
        in WithTrackEvents(TileA)
    
    Consider adding an error boundary to your tree to customize error handling behavior.
    Visit https://fb.me/react-error-boundaries to learn more about error boundaries.

/Users/chrisjordan/Work/TNL/times-components-native/node_modules/scheduler/cjs/scheduler.development.js:47
        throw e;
        ^

TypeError: Easing.inOut is not a function

```