### PR TITLE
chore: release 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- feat: (TNLT-6336/TNLT-6352) secondary-four right-aligned variants (tablet only)
- fix: (TNLT-994) play icon showing below image
- fix: (TNLT-6347): changes front lead2 portrait grid
