### PR TITLE
feat: (TNLT-6350) add 2 by 3 image fragment to support2 on leadtwonopicandtwo fragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -486,7 +486,7 @@ fragment commonSlicesSection on StandardSectionSlice {
       }
       teaser125: teaser(maxCharCount: 125)
       teaser300: teaser(maxCharCount: 300)
-      teaser1000: summary(maxCharCount: 1000)
+      teaser1000: teaser(maxCharCount: 1000)
     }
     support1 {
       headline

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -482,9 +482,11 @@ fragment commonSlicesSection on StandardSectionSlice {
         ...baseArticleProps
         summary125: summary(maxCharCount: 125)
         summary300: summary(maxCharCount: 300)
+        summary1000: summary(maxCharCount: 1000)
       }
       teaser125: teaser(maxCharCount: 125)
       teaser300: teaser(maxCharCount: 300)
+      teaser1000: summary(maxCharCount: 1000)
     }
     support1 {
       headline

--- a/packages/provider-queries/src/section_fragment.graphql
+++ b/packages/provider-queries/src/section_fragment.graphql
@@ -509,14 +509,17 @@ fragment commonSlicesSection on StandardSectionSlice {
       headline
       leadAsset {
         ...leadAsset32and45
+        ...leadAsset23
       }
       article {
         ...baseArticleProps
         leadAsset {
           ...leadAsset32and45
+          ...leadAsset23
         }
         listingAsset {
           ...leadAsset32and45
+          ...leadAsset23
         }
         summary125: summary(maxCharCount: 125)
         summary800: summary(maxCharCount: 800)
@@ -1012,7 +1015,7 @@ fragment frontSlicesSection on FrontPageSectionSlice {
           ... on ArticleLink {
             articleId
           }
-           ... on Link {
+          ... on Link {
             url
           }
         }


### PR DESCRIPTION
Copy of https://github.com/newsuk/times-components-native/pull/299

Updated the leadtwonopicandtwo query to incorporate a 2:3 image ratio format from TPA for the support 2 section of the slice. This is needed as the new sports variant of this leadtwonopicandtwo requires 2:3 image format on portrait and 4:5 image for landscape.

