### PR TITLE
fix: Fixed sections slices to respect dimension changes on orientation change

### DIFF
--- a/packages/edition-slices/src/edition-slices.js
+++ b/packages/edition-slices/src/edition-slices.js
@@ -1,6 +1,3 @@
-import { getDimensions } from "@times-components-native/utils";
-import { tabletWidth } from "@times-components-native/styleguide";
-import { NativeModules } from "react-native";
 import {
   CommentLeadAndCartoonSlice,
   DailyRegisterLeadFourSlice,
@@ -32,16 +29,9 @@ import {
 } from "./slices";
 import { sectionConfigs } from "@times-components-native/section/src/utils";
 
-const config = (NativeModules || {}).ReactConfig;
-
-const { width } = getDimensions();
-const isTablet =
-  (config && config.breakpoint && config.breakpoint !== "small") ||
-  width > tabletWidth;
-
 const { sectionTitles } = sectionConfigs;
 
-const sliceMap = (isInSupplement, sectionTitle, orientation) => {
+const sliceMap = (isInSupplement, sectionTitle, orientation, isTablet) => {
   const isInTabletSupplement = isInSupplement && isTablet;
   return {
     CommentLeadAndCartoonSlice,
@@ -91,7 +81,8 @@ export const getSlice = (
   sliceName,
   sectionTitle,
   orientation,
-) => sliceMap(isInSupplement, sectionTitle, orientation)[sliceName];
+  isTablet,
+) => sliceMap(isInSupplement, sectionTitle, orientation, isTablet)[sliceName];
 
 const renderLeadTwoNoPicAndTwoSlice = (isTablet, sectionTitle, orientation) =>
   isTablet && sectionTitle === sectionTitles.sport && orientation === "portrait"

--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -348,7 +348,7 @@ exports[`should render Secondary 2 No Pic and 2 instead of Secondary 2 and 2 for
 <RCTScrollView>
   <View>
     <View>
-      <SecondaryTwoAndTwoSlice />
+      <SecondaryTwoNoPicAndTwoSlice />
       <View>
         <View
           style={

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -348,7 +348,7 @@ exports[`should render Secondary 2 No Pic and 2 instead of Secondary 2 and 2 for
 <RCTScrollView>
   <View>
     <View>
-      <SecondaryTwoAndTwoSlice />
+      <SecondaryTwoNoPicAndTwoSlice />
       <View>
         <View
           style={

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -106,6 +106,7 @@ const Section: React.FC<Props> = ({
       adConfig={adConfig}
       sectionTitle={sectionTitle}
       orientation={orientation}
+      isTablet={isTablet}
     />
   );
 

--- a/packages/section/src/slice.js
+++ b/packages/section/src/slice.js
@@ -1,6 +1,6 @@
+import { getSlice } from "@times-components-native/edition-slices";
 import React from "react";
 import PropTypes from "prop-types";
-import { getSlice } from "@times-components-native/edition-slices";
 import withSliceTrackingContext from "./slice-tracking-context";
 
 const Slice = ({
@@ -12,12 +12,14 @@ const Slice = ({
   adConfig,
   sectionTitle,
   orientation,
+  isTablet,
 }) => {
   const Component = getSlice(
     isInSupplement,
     slice.name,
     sectionTitle,
     orientation,
+    isTablet,
   );
   return Component ? (
     <Component


### PR DESCRIPTION
Basically we were previously just using `getDimensions` directly which doesn't update on orientation change so `isTablet` was only calculated once on first render. Now it updates correctly.