### PR TITLE
fix: (TNLT-6352) orientation aware consecutive slices

### DIFF
--- a/packages/section/__tests__/unit/consecutiveItemsFlagger.test.ts
+++ b/packages/section/__tests__/unit/consecutiveItemsFlagger.test.ts
@@ -2,7 +2,7 @@ import { consecutiveItemsFlagger } from "../../src/utils/consecutiveItemsFlagger
 import { Orientation } from "@times-components-native/responsive/src/context";
 
 describe("consecutiveItemsFlagger", () => {
-  const orientation = Orientation.LANDSCAPE;
+  const landscape = Orientation.LANDSCAPE;
   it("should not add any properties if there aren't any consecutive slices", () => {
     const originalData = [
       { id: "a", name: "LeadersSlice" },
@@ -19,7 +19,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "l", name: "SecondaryFourSlice" },
     ];
 
-    const newData = consecutiveItemsFlagger(orientation)(originalData);
+    const newData = consecutiveItemsFlagger(landscape)(originalData);
 
     expect(newData).toEqual(originalData);
   });
@@ -55,7 +55,7 @@ describe("consecutiveItemsFlagger", () => {
       { isConsecutive: true, id: "l", name: "DailyUniversalRegister" },
     ];
 
-    const newData = consecutiveItemsFlagger(orientation)(originalData);
+    const newData = consecutiveItemsFlagger(landscape)(originalData);
     expect(newData).toMatchSnapshot();
     expect(newData).toEqual(flaggedData);
   });
@@ -77,7 +77,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "e", name: "SecondaryFourSlice", isConsecutive: true },
     ];
 
-    const newData = consecutiveItemsFlagger(orientation)(originalData);
+    const newData = consecutiveItemsFlagger(landscape)(originalData);
     expect(newData).toEqual(flaggedData);
   });
 
@@ -94,7 +94,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "c", name: "OtherSlice" },
     ];
 
-    const newData = consecutiveItemsFlagger(orientation)(originalData);
+    const newData = consecutiveItemsFlagger(landscape)(originalData);
     expect(newData).toEqual(flaggedData);
   });
 
@@ -150,7 +150,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "l", name: "SecondaryFourSlice" },
     ];
     const json = JSON.stringify(originalData);
-    consecutiveItemsFlagger(orientation)(originalData);
+    consecutiveItemsFlagger(landscape)(originalData);
     expect(JSON.stringify(originalData)).toEqual(json);
   });
 });

--- a/packages/section/__tests__/unit/consecutiveItemsFlagger.test.ts
+++ b/packages/section/__tests__/unit/consecutiveItemsFlagger.test.ts
@@ -1,6 +1,8 @@
 import { consecutiveItemsFlagger } from "../../src/utils/consecutiveItemsFlagger";
+import { Orientation } from "@times-components-native/responsive/src/context";
 
 describe("consecutiveItemsFlagger", () => {
+  const orientation = Orientation.LANDSCAPE;
   it("should not add any properties if there aren't any consecutive slices", () => {
     const originalData = [
       { id: "a", name: "LeadersSlice" },
@@ -17,7 +19,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "l", name: "SecondaryFourSlice" },
     ];
 
-    const newData = consecutiveItemsFlagger(originalData);
+    const newData = consecutiveItemsFlagger(orientation)(originalData);
 
     expect(newData).toEqual(originalData);
   });
@@ -53,7 +55,7 @@ describe("consecutiveItemsFlagger", () => {
       { isConsecutive: true, id: "l", name: "DailyUniversalRegister" },
     ];
 
-    const newData = consecutiveItemsFlagger(originalData);
+    const newData = consecutiveItemsFlagger(orientation)(originalData);
     expect(newData).toMatchSnapshot();
     expect(newData).toEqual(flaggedData);
   });
@@ -75,7 +77,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "e", name: "SecondaryFourSlice", isConsecutive: true },
     ];
 
-    const newData = consecutiveItemsFlagger(originalData);
+    const newData = consecutiveItemsFlagger(orientation)(originalData);
     expect(newData).toEqual(flaggedData);
   });
 
@@ -92,11 +94,11 @@ describe("consecutiveItemsFlagger", () => {
       { id: "c", name: "OtherSlice" },
     ];
 
-    const newData = consecutiveItemsFlagger(originalData);
+    const newData = consecutiveItemsFlagger(orientation)(originalData);
     expect(newData).toEqual(flaggedData);
   });
 
-  it("should add isConsecutive property on a SecondaryFourSlice that follows a LeadOneAndOneSlice", () => {
+  it("should add isConsecutive property on a SecondaryFourSlice that follows a LeadOneAndOneSlice on portrait", () => {
     const originalData = [
       { id: "a", name: "LeadOneAndOneSlice" },
       { id: "b", name: "SecondaryFourSlice" },
@@ -109,7 +111,26 @@ describe("consecutiveItemsFlagger", () => {
       { id: "c", name: "OtherSlice" },
     ];
 
-    const newData = consecutiveItemsFlagger(originalData);
+    const newData = consecutiveItemsFlagger(Orientation.PORTRAIT)(originalData);
+    expect(newData).toEqual(flaggedData);
+  });
+
+  it("should not add isConsecutive property on a SecondaryFourSlice that follows a LeadOneAndOneSlice on landscape", () => {
+    const originalData = [
+      { id: "a", name: "LeadOneAndOneSlice" },
+      { id: "b", name: "SecondaryFourSlice" },
+      { id: "c", name: "OtherSlice" },
+    ];
+
+    const flaggedData = [
+      { id: "a", name: "LeadOneAndOneSlice" },
+      { id: "b", name: "SecondaryFourSlice" },
+      { id: "c", name: "OtherSlice" },
+    ];
+
+    const newData = consecutiveItemsFlagger(Orientation.LANDSCAPE)(
+      originalData,
+    );
     expect(newData).toEqual(flaggedData);
   });
 
@@ -129,7 +150,7 @@ describe("consecutiveItemsFlagger", () => {
       { id: "l", name: "SecondaryFourSlice" },
     ];
     const json = JSON.stringify(originalData);
-    consecutiveItemsFlagger(originalData);
+    consecutiveItemsFlagger(orientation)(originalData);
     expect(JSON.stringify(originalData)).toEqual(json);
   });
 });

--- a/packages/section/__tests__/unit/prepareSlicesForRender.test.ts
+++ b/packages/section/__tests__/unit/prepareSlicesForRender.test.ts
@@ -1,4 +1,5 @@
 import { prepareSlicesForRender } from "../../src/utils/prepareSlicesForRender";
+import { Orientation } from "@times-components-native/responsive/src/context";
 
 describe("prepareSlicesForRender", () => {
   it("should transform data", () => {
@@ -17,7 +18,11 @@ describe("prepareSlicesForRender", () => {
       { id: "l", name: "DailyUniversalRegister" },
     ];
 
-    const prepararedData = prepareSlicesForRender(true, "News")(originalData);
+    const prepararedData = prepareSlicesForRender(
+      true,
+      "News",
+      Orientation.LANDSCAPE,
+    )(originalData);
     expect(prepararedData).toMatchSnapshot();
   });
 });

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -149,7 +149,7 @@ const Section: React.FC<Props> = ({
 
   const data = isPuzzle
     ? createPuzzleData(isTablet, sectionTitle)(slices, editionBreakpoint)
-    : prepareSlicesForRender(isTablet, sectionTitle)(slices);
+    : prepareSlicesForRender(isTablet, sectionTitle, orientation)(slices);
 
   if (slices) receiveChildList(data);
 

--- a/packages/section/src/utils/consecutiveItemsFlagger.ts
+++ b/packages/section/src/utils/consecutiveItemsFlagger.ts
@@ -1,33 +1,47 @@
 import memoizeOne from "memoize-one";
 import { SliceName } from "@times-components-native/types";
+import { Orientation } from "@times-components-native/responsive/src/context";
 
 const withIsConsecutive = (slice: any) => ({ ...slice, isConsecutive: true });
 
 type Pair = [SliceName, SliceName];
 
-const consecutivePairs: Pair[] = [
-  ["TopSecondaryFourSlice", "SecondaryFourSlice"],
+const consecutivePairsOnPortrait: Pair[] = [
   ["LeadOneAndOneSlice", "SecondaryFourSlice"],
 ];
+
+const consecutivePairs: Pair[] = [
+  ["TopSecondaryFourSlice", "SecondaryFourSlice"],
+];
+
+const doesListIncludePair = (
+  pairs: Pair[],
+  previousName: string,
+  currentName: string,
+) => consecutivePairs.some(([a, b]) => previousName == a && currentName == b);
 
 const isConsecutivePair = (
   currentName: string,
   previousName: string,
+  orientation: string,
 ): boolean =>
-  consecutivePairs.some(([a, b]) => previousName == a && currentName == b);
+  doesListIncludePair(consecutivePairs, previousName, currentName) ||
+  (orientation === Orientation.PORTRAIT &&
+    doesListIncludePair(consecutivePairsOnPortrait, previousName, currentName));
 
-export const consecutiveItemsFlagger = memoizeOne((slices: any[]) =>
-  slices.reduce((acc, curr, i) => {
-    const currentName = curr.name;
-    const previousName = acc[i - 1]?.name;
-    const previousIsConsecutive = acc[i - 1]?.isConsecutive;
+export const consecutiveItemsFlagger = memoizeOne(
+  (orientation: string) => (slices: any[]) =>
+    slices.reduce((acc, curr, i) => {
+      const currentName = curr.name;
+      const previousName = acc[i - 1]?.name;
+      const previousIsConsecutive = acc[i - 1]?.isConsecutive;
 
-    const isConsecutiveSlices =
-      currentName === previousName ||
-      isConsecutivePair(currentName, previousName);
+      const isConsecutiveSlices =
+        currentName === previousName ||
+        isConsecutivePair(currentName, previousName, orientation);
 
-    return !previousIsConsecutive && isConsecutiveSlices
-      ? [...acc, withIsConsecutive(curr)]
-      : [...acc, curr];
-  }, []),
+      return !previousIsConsecutive && isConsecutiveSlices
+        ? [...acc, withIsConsecutive(curr)]
+        : [...acc, curr];
+    }, []),
 );

--- a/packages/section/src/utils/consecutiveItemsFlagger.ts
+++ b/packages/section/src/utils/consecutiveItemsFlagger.ts
@@ -18,7 +18,7 @@ const doesListIncludePair = (
   pairs: Pair[],
   previousName: string,
   currentName: string,
-) => consecutivePairs.some(([a, b]) => previousName == a && currentName == b);
+) => pairs.some(([a, b]) => previousName == a && currentName == b);
 
 const isConsecutivePair = (
   currentName: string,

--- a/packages/section/src/utils/prepareSlicesForRender.ts
+++ b/packages/section/src/utils/prepareSlicesForRender.ts
@@ -6,9 +6,10 @@ import { consecutiveItemsFlagger } from "./consecutiveItemsFlagger";
 export const prepareSlicesForRender = (
   isTablet: boolean,
   sectionTitle: string,
+  orientation: string,
 ) =>
   pipe(
     buildSliceData(isTablet, sectionTitle),
-    consecutiveItemsFlagger,
+    consecutiveItemsFlagger(orientation),
     insertSectionAd(isTablet),
   );


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-6352

## Problem with the current implementation
When a secondary-4 follows a lead-one-and-one, the images are now being flipped on the secondary-4 to right-align the images. As the lead-one-and-one has right-aligned images on landscape, we only want to flip the secondary-4 on portrait.

### Before
![simulator_screenshot_77D5A9AD-8209-4F10-AA0E-BE940FD7D829](https://user-images.githubusercontent.com/6280629/106888736-e4a93780-66de-11eb-9668-46549016dc70.png)
![simulator_screenshot_CA5F2A47-AA1F-4CEE-973C-587C30DE9D28](https://user-images.githubusercontent.com/6280629/106888805-fb4f8e80-66de-11eb-914f-a55e4184768e.png)


### After
![simulator_screenshot_77D5A9AD-8209-4F10-AA0E-BE940FD7D829](https://user-images.githubusercontent.com/6280629/106888736-e4a93780-66de-11eb-9668-46549016dc70.png)
![simulator_screenshot_38DB8879-95F1-4538-92F6-D95069A76753](https://user-images.githubusercontent.com/6280629/106888380-62b90e80-66de-11eb-9942-b7b637a2ac50.png)

