### PR TITLE
chore: (TNLT-6506/TNLT-6563) New Ad logic

### DIFF
--- a/packages/ad/src/utils/generate-config.js
+++ b/packages/ad/src/utils/generate-config.js
@@ -40,6 +40,7 @@ export const sizeMap = {
   header: sizes.header,
   mpu: sizes.mpu,
   "native-inline-ad": sizes.native,
+  "native-leaderboard": sizes.leaderboard,
   "native-single-mpu": sizes.singleMPU,
   "native-double-mpu": sizes.doubleMPU,
   "native-section-ad": sizes.section,

--- a/packages/ad/src/utils/sizes.js
+++ b/packages/ad/src/utils/sizes.js
@@ -93,14 +93,6 @@ const sizes = {
       width: 970,
     },
   ],
-  leaderboard: [
-    {
-      orientation: ["landscape", "portrait"],
-      height: 90,
-      sizes: [leaderboard],
-      width: 728,
-    },
-  ],
   singleMPU: [
     {
       orientation: ["landscape", "portrait"],

--- a/packages/ad/src/utils/sizes.js
+++ b/packages/ad/src/utils/sizes.js
@@ -93,6 +93,14 @@ const sizes = {
       width: 970,
     },
   ],
+  leaderboard: [
+    {
+      orientation: ["landscape", "portrait"],
+      height: 90,
+      sizes: [leaderboard],
+      width: 728,
+    },
+  ],
   singleMPU: [
     {
       orientation: ["landscape", "portrait"],

--- a/packages/article-skeleton/__tests__/body-utils/setup-ad.js
+++ b/packages/article-skeleton/__tests__/body-utils/setup-ad.js
@@ -51,7 +51,7 @@ export default () => {
       ).toEqual(contentWithoutAd);
     });
 
-    it("should remove ad if tablet and template is not mainstandard", () => {
+    it("should remove ad if tablet and template is not supported template", () => {
       const contentWithoutAd = content.filter((item) => item.name !== "ad");
       expect(
         setupAd({
@@ -73,23 +73,40 @@ export default () => {
   });
 
   describe("setupArticleMpuAd", () => {
-    it("should return content with an inline double mpu ad present and attributes overriden when no non-paragraph content within threshold", () => {
-      const longContent = [
+    it("should return content with ad removed if less than 6 paragraphs", () => {
+      const shortContent = [
         createParagraph("a"),
         createParagraph("b"),
         createParagraph("c"),
         createParagraph("d"),
         createParagraph("e"),
         { name: "ad", children: [] },
+      ];
+
+      const newSkeletonProps = {
+        ...skeletonProps,
+        data: { ...skeletonProps.data, content: shortContent },
+      };
+
+      expect(setupAd(newSkeletonProps)).toEqual([
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        createParagraph("e"),
+      ]);
+    });
+
+    it("should return content with the inline single mpu ad present when between 6 and 7 paragraphs", () => {
+      const longContent = [
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        { name: "ad", children: [] },
+        createParagraph("e"),
         createParagraph("f"),
         createParagraph("g"),
-        createParagraph("h"),
-        createParagraph("i"),
-        createParagraph("j"),
-        createParagraph("k"),
-        createParagraph("l"),
-        { name: "image", children: [] },
-        createParagraph("m"),
       ];
 
       const newSkeletonProps = {
@@ -106,29 +123,22 @@ export default () => {
           name: "inlineContent",
           attributes: {
             width: 300,
-            height: 600,
-            slotName: "native-double-mpu",
+            height: 250,
+            slotName: "native-single-mpu",
             inlineContent: [
               createParagraph("e"),
               createParagraph("f"),
               createParagraph("g"),
-              createParagraph("h"),
-              createParagraph("i"),
-              createParagraph("j"),
-              createParagraph("k"),
             ],
             originalName: "ad",
             skeletonProps: newSkeletonProps,
           },
           children: [],
         },
-        createParagraph("l"),
-        { name: "image", children: [] },
-        createParagraph("m"),
       ]);
     });
 
-    it("should return content with the inline single mpu ad present when non-paragraph content within threshold", () => {
+    it("should return content with the inline single mpu ad present when 8 or more paragraphs and non-paragraph content within threshold", () => {
       const longContent = [
         createParagraph("a"),
         createParagraph("b"),
@@ -179,6 +189,61 @@ export default () => {
           children: [],
         },
         createParagraph("l"),
+        createParagraph("m"),
+      ]);
+    });
+
+    it("should return content with an inline double mpu ad present and attributes overriden when more than 8 and no non-paragraph content within threshold", () => {
+      const longContent = [
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        createParagraph("e"),
+        { name: "ad", children: [] },
+        createParagraph("f"),
+        createParagraph("g"),
+        createParagraph("h"),
+        createParagraph("i"),
+        createParagraph("j"),
+        createParagraph("k"),
+        createParagraph("l"),
+        { name: "image", children: [] },
+        createParagraph("m"),
+      ];
+
+      const newSkeletonProps = {
+        ...skeletonProps,
+        data: { ...skeletonProps.data, content: longContent },
+      };
+
+      expect(setupAd(newSkeletonProps)).toEqual([
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        {
+          name: "inlineContent",
+          attributes: {
+            width: 300,
+            height: 600,
+            slotName: "native-double-mpu",
+            inlineContent: [
+              createParagraph("e"),
+              createParagraph("f"),
+              createParagraph("g"),
+              createParagraph("h"),
+              createParagraph("i"),
+              createParagraph("j"),
+              createParagraph("k"),
+            ],
+            originalName: "ad",
+            skeletonProps: newSkeletonProps,
+          },
+          children: [],
+        },
+        createParagraph("l"),
+        { name: "image", children: [] },
         createParagraph("m"),
       ]);
     });

--- a/packages/article-skeleton/__tests__/body-utils/setup-ad.js
+++ b/packages/article-skeleton/__tests__/body-utils/setup-ad.js
@@ -97,7 +97,7 @@ export default () => {
       ]);
     });
 
-    it("should return content with a leaderboard/billboard if non paragraph precedes and follows 5th paragraph", () => {
+    it("should return content with a leaderboard if non paragraph precedes and follows 5th paragraph", () => {
       const crowdedContent = [
         createParagraph("a"),
         createParagraph("b"),
@@ -119,7 +119,25 @@ export default () => {
         data: { ...skeletonProps.data, content: crowdedContent },
       };
 
-      expect(setupAd(newSkeletonProps)).toEqual(crowdedContent);
+      expect(setupAd(newSkeletonProps)).toEqual([
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        { name: "image", children: [] },
+        createParagraph("e"),
+        {
+          name: "ad",
+          attributes: { slotName: "native-leaderboard" },
+          children: [],
+        },
+        { name: "image", children: [] },
+        createParagraph("f"),
+        createParagraph("g"),
+        createParagraph("h"),
+        createParagraph("i"),
+        createParagraph("j"),
+      ]);
     });
 
     it("should return content with the inline single mpu ad present when between 6 and 7 paragraphs", () => {

--- a/packages/article-skeleton/__tests__/body-utils/setup-ad.js
+++ b/packages/article-skeleton/__tests__/body-utils/setup-ad.js
@@ -97,6 +97,31 @@ export default () => {
       ]);
     });
 
+    it("should return content with a leaderboard/billboard if non paragraph precedes and follows 5th paragraph", () => {
+      const crowdedContent = [
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        { name: "image", children: [] },
+        createParagraph("e"),
+        { name: "ad", children: [] },
+        { name: "image", children: [] },
+        createParagraph("f"),
+        createParagraph("g"),
+        createParagraph("h"),
+        createParagraph("i"),
+        createParagraph("j"),
+      ];
+
+      const newSkeletonProps = {
+        ...skeletonProps,
+        data: { ...skeletonProps.data, content: crowdedContent },
+      };
+
+      expect(setupAd(newSkeletonProps)).toEqual(crowdedContent);
+    });
+
     it("should return content with the inline single mpu ad present when between 6 and 7 paragraphs", () => {
       const longContent = [
         createParagraph("a"),

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -175,7 +175,6 @@ export default ({
       );
     },
     ad(key, attributes) {
-      console.log("DASDASDASDASDASDASASADASAAAAAAAAAA", attributes);
       return (
         <Ad
           key={key}

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -175,6 +175,7 @@ export default ({
       );
     },
     ad(key, attributes) {
+      console.log("DASDASDASDASDASDASASADASAAAAAAAAAA", attributes);
       return (
         <Ad
           key={key}

--- a/packages/article-skeleton/src/body-utils/setupAd.js
+++ b/packages/article-skeleton/src/body-utils/setupAd.js
@@ -44,6 +44,9 @@ const setupArticleMpuAd = (
       ...contentWithoutAdSlot.slice(0, adSlotIndex + 1),
       {
         name: "ad",
+        attributes: {
+          slotName: "native-leaderboard",
+        },
         children: [],
       },
       ...contentWithoutAdSlot.slice(adSlotIndex + 1),

--- a/packages/article-skeleton/src/body-utils/setupAd.js
+++ b/packages/article-skeleton/src/body-utils/setupAd.js
@@ -14,6 +14,7 @@ const setupArticleMpuAd = (
   let nthParagraphIndex = currentAdSlotIndex;
 
   let hasNonParagraphContentBeforeThreshold = false;
+  let lastParagraphIndex;
 
   const numberOfParagraphs = contentWithoutAdSlot.reduce(
     (count, item, index) => {
@@ -23,8 +24,9 @@ const setupArticleMpuAd = (
         return count;
       }
       if (count === adPosition) {
-        nthParagraphIndex = index - 1;
+        nthParagraphIndex = lastParagraphIndex;
       }
+      lastParagraphIndex = index;
       return count + 1;
     },
     0,
@@ -34,22 +36,25 @@ const setupArticleMpuAd = (
 
   const adSlotIndex = nthParagraphIndex;
 
-  let showLeaderboard = false;
-
   if (
     contentWithoutAdSlot[nthParagraphIndex - 1]?.name !== "paragraph" &&
     contentWithoutAdSlot[nthParagraphIndex + 1]?.name !== "paragraph"
   ) {
-    showLeaderboard = true;
-    return contentWithoutAdSlot;
+    return [
+      ...contentWithoutAdSlot.slice(0, adSlotIndex + 1),
+      {
+        name: "ad",
+        children: [],
+      },
+      ...contentWithoutAdSlot.slice(adSlotIndex + 1),
+    ];
   }
 
-  const slotName = showLeaderboard
-    ? "native-inline-ad"
-    : numberOfParagraphs < singleMPUThreshold ||
-      hasNonParagraphContentBeforeThreshold
-    ? "native-single-mpu"
-    : "native-double-mpu";
+  const slotName =
+    numberOfParagraphs < singleMPUThreshold ||
+    hasNonParagraphContentBeforeThreshold
+      ? "native-single-mpu"
+      : "native-double-mpu";
 
   const { height, width } = sizeMap[slotName][0];
 
@@ -121,8 +126,6 @@ export const setupAd = (skeletonProps) => {
   });
 
   if (!currentAdSlotIndex) return cleanedContent;
-
-  console.log("TTTTTTTTfjdskjsdklfjdslkfjsdkjfdslk234!!567899", template);
 
   // If tablet, only show on mainstandard template
   if (isTablet && !templatesWithAds.includes(template))

--- a/packages/article-skeleton/src/body-utils/setupAd.js
+++ b/packages/article-skeleton/src/body-utils/setupAd.js
@@ -127,7 +127,7 @@ export const setupAd = (skeletonProps) => {
 
   if (!currentAdSlotIndex) return cleanedContent;
 
-  // If tablet, only show on mainstandard template
+  // If tablet, only show on mainstandard/indepth/magazinestandard template
   if (isTablet && !templatesWithAds.includes(template))
     return contentWithoutAdSlot;
 


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-6506
https://nidigitalsolutions.jira.com/browse/TNLT-6563

* Enables adverts on In Depth and Magazine Standard templates.
* Implements the following rules/logic to determine when and what type of advert to display:
  * If an article has less than 6 paragraphs of text then do not show any advert
  * If an article has 6 or 7 paragraphs of text then show a single mpu ad aligned the start of the 5th paragraph
  * If an article has 8 or more paragraphs of text, but also includes inline images/interactives in the first 10 items then show a single mpu
  * If an article has 8 or more paragraphs of text but does not include any inline images/interactives in the first 10 items then show a double mpu
  * If an article has an image/interactive directly above and below the 5th paragraph (i.e. top ten countries to visit) then show a leaderboard directly below the 5th paragraph
* Updated/added tests to cover the additional cases

## Screenshots

### Enables adverts on In Depth template
![6 - Ads enabled on indepth template](https://user-images.githubusercontent.com/5103512/106917550-462dce00-6700-11eb-8344-135d4e8863fe.png)

### Enables adverts on Magazine Standard template
![5 - Ads enabled on magazinestandard template](https://user-images.githubusercontent.com/5103512/106917633-5c3b8e80-6700-11eb-8405-f65c5265c816.png)

### If an article has less than 6 paragraphs of text then do not show any advert
![1 - No ads if less than 6](https://user-images.githubusercontent.com/5103512/106917129-e0d9dd00-66ff-11eb-82fd-6db292397468.png)

### If an article has 6 or 7 paragraphs of text then show a single mpu ad aligned the start of the 5th paragraph
![2 - Single MPU if less than 8](https://user-images.githubusercontent.com/5103512/106917214-f2bb8000-66ff-11eb-95c0-fe9f8b6e80c7.png)

### If an article has 8 or more paragraphs of text, but also includes inline images/interactives in the first 10 items then show a single mpu
![3 - Single MPU if 8 or more and has non paragraph](https://user-images.githubusercontent.com/5103512/106917292-07981380-6700-11eb-8753-95ec570d47a1.png)

### If an article has 8 or more paragraphs of text but does not include any inline images/interactives in the first 10 items then show a double mpu
![4 - Double MPU if 8 or more and no non paragraph](https://user-images.githubusercontent.com/5103512/106917367-1bdc1080-6700-11eb-9dd7-bf7999751f26.png)

### If an article has an image/interactive directly above and below the 5th paragraph (i.e. top ten countries to visit) then show a leaderboard directly below the 5th paragraph
#### Portrait
##### Before
![7 - Before - Portrait - Leaderboard when 5th para preceded and followed by non para](https://user-images.githubusercontent.com/5103512/106918140-d835d680-6700-11eb-82d1-384174e1c898.png)

##### After
![7 - After - Portrait - Leaderboard when 5th para preceded and followed by non para](https://user-images.githubusercontent.com/5103512/106918189-e3890200-6700-11eb-8808-91f15d3ce3b2.png)

#### Landscape
##### Before
![8 - Before - Landscape - Billboard when 5th para preceded and followed by non para](https://user-images.githubusercontent.com/5103512/106918287-f56aa500-6700-11eb-81a2-e2625c57a105.png)

##### After
![8 - After - Landscape - when 5th para preceded and followed by non para](https://user-images.githubusercontent.com/5103512/106923002-8b083380-6705-11eb-8032-1c977b67e743.png)
