### PR TITLE
feat: improve section performance

### DIFF
--- a/packages/edition-slices/src/slices/commentleadandcartoon/index.js
+++ b/packages/edition-slices/src/slices/commentleadandcartoon/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { CommentLeadAndCartoon } from "@times-components-native/slice-layout";
 import PropTypes from "prop-types";
 import { TileP, TileQ, TileAH, TileAI } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class CommentLeadAndCartoonSlice extends Component {
+class CommentLeadAndCartoonSlice extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
+++ b/packages/edition-slices/src/slices/dailyregisterleadfour/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { View, Text } from "react-native";
 import PropTypes from "prop-types";
 import {
@@ -10,7 +10,7 @@ import { TileS } from "../../tiles";
 import styleFactory from "./styles";
 import Logo from "./logo";
 
-class DailyRegisterLeadFour extends Component {
+class DailyRegisterLeadFour extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/leaders/index.js
+++ b/packages/edition-slices/src/slices/leaders/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { View, Text } from "react-native";
 import { SectionContext } from "@times-components-native/context";
 import { Leaders } from "@times-components-native/slice-layout";
@@ -21,7 +21,7 @@ const renderHead = (styles, breakpoint) => (
   </SectionContext.Consumer>
 );
 
-class LeadersSlice extends Component {
+class LeadersSlice extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSlice = this.renderSlice.bind(this);

--- a/packages/edition-slices/src/slices/leadoneandfour/index.js
+++ b/packages/edition-slices/src/slices/leadoneandfour/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { LeadOneAndFourSlice } from "@times-components-native/slice-layout";
 import { TileAC, TileAD, TileI, TileJ } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class LeadOneAndFour extends Component {
+class LeadOneAndFour extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -3,9 +3,7 @@ import PropTypes from "prop-types";
 import { LeadOneAndOneSlice } from "@times-components-native/slice-layout";
 import { TileA, TileB, TileZ, TileColStandard } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
-import { LogBox } from "react-native";
 
-LogBox.ignoreAllLogs();
 class LeadOneAndOne extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -1,10 +1,12 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { LeadOneAndOneSlice } from "@times-components-native/slice-layout";
 import { TileA, TileB, TileZ, TileColStandard } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
+import { LogBox } from "react-native";
 
-class LeadOneAndOne extends Component {
+LogBox.ignoreAllLogs();
+class LeadOneAndOne extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/leadonefullwidth/index.js
+++ b/packages/edition-slices/src/slices/leadonefullwidth/index.js
@@ -1,9 +1,9 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { TileA, TileR } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class LeadOneFullWidthSlice extends Component {
+class LeadOneFullWidthSlice extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { LeadTwoNoPicAndTwoSlice } from "@times-components-native/slice-layout";
 import { TileB, TileD, TileE, TileF, TileX, TileY, TileAL } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class LeadTwoNoPicAndTwo extends Component {
+class LeadTwoNoPicAndTwo extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/leadtwonopicandtwovariant2/index.js
+++ b/packages/edition-slices/src/slices/leadtwonopicandtwovariant2/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { LeadTwoNoPicAndTwoVariant2Slice } from "@times-components-native/slice-layout";
 import { ResponsiveSlice } from "../shared";
 import { TileColStandard, TileColImageBottom } from "../../tiles";
 
-class LeadTwoNoPicAndTwoVariant2 extends Component {
+class LeadTwoNoPicAndTwoVariant2 extends PureComponent {
   constructor(props) {
     super(props);
     this.renderMedium = this.renderMedium.bind(this);

--- a/packages/edition-slices/src/slices/listtwoandsixnopic/index.js
+++ b/packages/edition-slices/src/slices/listtwoandsixnopic/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { ListTwoAndSixNoPic } from "@times-components-native/slice-layout";
 import { ResponsiveSlice } from "../shared";
 import { TileL, TileC, TileAS } from "../../tiles";
 
-class ListTwoAndSixNoPicSlice extends Component {
+class ListTwoAndSixNoPicSlice extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSlice = this.renderSlice.bind(this);

--- a/packages/edition-slices/src/slices/puzzle/index.js
+++ b/packages/edition-slices/src/slices/puzzle/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { View } from "react-native";
 import { editionBreakpoints } from "@times-components-native/styleguide";
 import propTypes from "./proptypes";
@@ -6,7 +6,7 @@ import stylesFactory from "./styles";
 import { ResponsiveSlice } from "../shared";
 import { TileAJ, TileAK } from "../../tiles";
 
-class Puzzle extends Component {
+class Puzzle extends PureComponent {
   constructor(props) {
     super(props);
     this.renderPuzzles = this.renderPuzzles.bind(this);

--- a/packages/edition-slices/src/slices/secondaryfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryfour/index.js
@@ -1,11 +1,11 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { SecondaryFourSlice } from "@times-components-native/slice-layout";
 import { TileC, TileAR, TileB } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 import stylesFactory from "./styles";
 
-class SecondaryFour extends Component {
+class SecondaryFour extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/secondaryone/index.js
+++ b/packages/edition-slices/src/slices/secondaryone/index.js
@@ -1,9 +1,9 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { TileA, TileW } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class SecondaryOneSlice extends Component {
+class SecondaryOneSlice extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/secondaryoneandcolumnist/index.js
+++ b/packages/edition-slices/src/slices/secondaryoneandcolumnist/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { SecondaryOneAndColumnistSlice } from "@times-components-native/slice-layout";
 import { TileH, TileT, TileAB, TileB } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class SecondaryOneAndColumnist extends Component {
+class SecondaryOneAndColumnist extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/secondaryoneandfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryoneandfour/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
 import { SectionContext } from "@times-components-native/context";
@@ -11,7 +11,7 @@ import { TileO, TileN } from "../../tiles";
 import styleFactory from "./styles";
 import { ResponsiveSlice } from "../shared";
 
-class SecondaryOneAndFour extends Component {
+class SecondaryOneAndFour extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSlice = this.renderSlice.bind(this);

--- a/packages/edition-slices/src/slices/secondarytwoandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwoandtwo/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { SecondaryTwoAndTwoSlice } from "@times-components-native/slice-layout";
 import { TileC, TileG, TileV, TileAM, TileAN } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class SecondaryTwoAndTwo extends Component {
+class SecondaryTwoAndTwo extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { SecondaryTwoNoPicAndTwoSlice } from "@times-components-native/slice-layout";
 import { TileAE, TileB, TileG } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 
-class SecondaryTwoNoPicAndTwo extends Component {
+class SecondaryTwoNoPicAndTwo extends PureComponent {
   constructor(props) {
     super(props);
     this.renderSmall = this.renderSmall.bind(this);

--- a/packages/edition-slices/src/slices/standard/index.js
+++ b/packages/edition-slices/src/slices/standard/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
 import {
@@ -9,7 +9,7 @@ import { TileK } from "../../tiles";
 import { ResponsiveSlice } from "../shared";
 import styles from "./styles";
 
-class Standard extends Component {
+class Standard extends PureComponent {
   constructor(props) {
     super(props);
 

--- a/packages/section/__tests__/android/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/android/__snapshots__/section.test.js.snap
@@ -333,6 +333,76 @@ exports[`section page 1`] = `
         />
       </View>
     </View>
+    <View>
+      <LeadTwoNoPicAndTwoSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryOneSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryFourSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryTwoNoPicAndTwoSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryTwoNoPicAndTwoSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
     <View
       style={
         Object {

--- a/packages/section/__tests__/ios/__snapshots__/section-tracking.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section-tracking.test.js.snap
@@ -23,6 +23,16 @@ Object {
 }
 `;
 
+exports[`default section page click tracking: onArticlePress 1`] = `
+Array [
+  Array [
+    Object {
+      "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
+    },
+  ],
+]
+`;
+
 exports[`puzzle section page click tracking 1`] = `
 Object {
   "action": "Pressed",

--- a/packages/section/__tests__/ios/__snapshots__/section-tracking.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section-tracking.test.js.snap
@@ -23,16 +23,6 @@ Object {
 }
 `;
 
-exports[`default section page click tracking: onArticlePress 1`] = `
-Array [
-  Array [
-    Object {
-      "id": "522abf2c-e752-11e8-9f32-f2801f1b9fd1",
-    },
-  ],
-]
-`;
-
 exports[`puzzle section page click tracking 1`] = `
 Object {
   "action": "Pressed",

--- a/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
+++ b/packages/section/__tests__/ios/__snapshots__/section.test.js.snap
@@ -333,6 +333,76 @@ exports[`section page 1`] = `
         />
       </View>
     </View>
+    <View>
+      <LeadTwoNoPicAndTwoSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryOneSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryFourSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryTwoNoPicAndTwoSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <SecondaryTwoNoPicAndTwoSlice />
+      <View>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+              "marginHorizontal": 0,
+            }
+          }
+        />
+      </View>
+    </View>
     <View
       style={
         Object {

--- a/packages/section/__tests__/shared-tracking.js
+++ b/packages/section/__tests__/shared-tracking.js
@@ -22,6 +22,7 @@ jest.mock("react-native", () => {
 });
 
 import { ResponsiveContext } from "@times-components-native/responsive";
+import { calculateResponsiveContext } from "@times-components-native/responsive/src/calculateResponsiveContext";
 jest.mock("@times-components-native/image", () => ({
   __esModule: true,
   default: "TimesImage",
@@ -41,7 +42,7 @@ class WithTrackingContext extends Component {
     const { onArticlePress, onPuzzlePress, section } = this.props;
     return (
       <ResponsiveContext.Provider
-        value={{ isTablet: false, editionBreakpoint: "small" }}
+        value={calculateResponsiveContext(400, 600, 1)}
       >
         <Section
           analyticsStream={() => null}

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -161,7 +161,6 @@ const Section: React.FC<Props> = ({
         }
         removeClippedSubviews
         data={data}
-        initialNumToRender={isTablet ? 5 : 2}
         ItemSeparatorComponent={(leadingItem) =>
           renderItemSeperator(isPuzzle)(leadingItem, editionBreakpoint)
         }
@@ -171,7 +170,6 @@ const Section: React.FC<Props> = ({
         onViewableItemsChanged={onViewed ? onViewableItemsChanged : null}
         {...(isPuzzle && { onScrollBeginDrag })}
         renderItem={renderItem(isPuzzle, orientation)}
-        windowSize={3}
       />
       {isPuzzle && isIOS ? (
         <FloatingActionButton


### PR DESCRIPTION
1. Slices are currently re-rendering many times more than is needed. I converted all slices to PureComponent's, which stops the re-rendering 
2. The section flatlist doesn't need to only render 2 or 5 slices at a time. All the data is loaded into the app, and can be rendered all at once. This results in a better scrolling experience - and I didn't notice a massive jump in RAM when doing this.

On master, if I scroll down on a section, I can see the JS thread struggling to stay at 60fps and often dropping massively to 10/20fps. With this change, the JS thread stays at 60fps most of the time and hardly drops to the extent seen on master. 

There is still an issue with the UI thread whilst scrolling that I cannot figure out what is causing this. 

![image](https://user-images.githubusercontent.com/6280629/107039608-09bca980-67b6-11eb-8226-e705fd0fafee.png)
