### PR TITLE
feat: (TNLT-6636) Enabled ads on comment based templates

### DIFF
--- a/packages/ad/__tests__/ad.shared.js
+++ b/packages/ad/__tests__/ad.shared.js
@@ -51,4 +51,16 @@ export default () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("advert with narrow content", () => {
+    const wrapper = shallow(
+      <AdComposer adConfig={adConfig}>
+        <Fragment>
+          <Ad {...props} slotName="header" narrowContent={true} />
+        </Fragment>
+      </AdComposer>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
 };

--- a/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
@@ -14,6 +14,21 @@ exports[`advert 1`] = `
 </Broadcast>
 `;
 
+exports[`advert with narrow content 1`] = `
+<Broadcast
+  channel="adConfig"
+>
+  <Ad
+    baseUrl="https://www.thetimes.co.uk/"
+    contextUrl="https://www.thetimes.co.uk"
+    isLoading={false}
+    narrowContent={true}
+    section="news"
+    slotName="header"
+  />
+</Broadcast>
+`;
+
 exports[`advert with width 1`] = `
 <Broadcast
   channel="adConfig"

--- a/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
@@ -14,6 +14,21 @@ exports[`advert 1`] = `
 </Broadcast>
 `;
 
+exports[`advert with narrow content 1`] = `
+<Broadcast
+  channel="adConfig"
+>
+  <Ad
+    baseUrl="https://www.thetimes.co.uk/"
+    contextUrl="https://www.thetimes.co.uk"
+    isLoading={false}
+    narrowContent={true}
+    section="news"
+    slotName="header"
+  />
+</Broadcast>
+`;
+
 exports[`advert with width 1`] = `
 <Broadcast
   channel="adConfig"

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -4,6 +4,7 @@ import { Subscriber } from "react-broadcast";
 import { View, Text } from "react-native";
 import NetInfo from "@react-native-community/netinfo";
 import { useResponsiveContext } from "@times-components-native/responsive";
+import { getNarrowArticleBreakpoint } from "@times-components-native/styleguide";
 
 import { getPrebidSlotConfig, getSlotConfig, prebidConfig } from "./utils";
 import adInit from "./utils/ad-init";
@@ -82,11 +83,12 @@ export class AdBase extends Component {
       contextUrl,
       display,
       isLoading,
+      narrowContent,
+      orientation,
+      screenWidth,
       slotName,
       style,
       width,
-      screenWidth,
-      orientation,
     } = this.props;
     const { config, hasError, isAdReady, offline } = this.state;
 
@@ -134,7 +136,11 @@ export class AdBase extends Component {
       !isAdReady || hasError
         ? { width: 0 }
         : {
-            width: width || screenWidth,
+            width:
+              width ||
+              (narrowContent
+                ? getNarrowArticleBreakpoint(screenWidth).content
+                : screenWidth),
           };
 
     const isInline = display === "inline";

--- a/packages/article-skeleton/__tests__/body-utils/setup-ad.js
+++ b/packages/article-skeleton/__tests__/body-utils/setup-ad.js
@@ -50,26 +50,6 @@ export default () => {
         }),
       ).toEqual(contentWithoutAd);
     });
-
-    it("should remove ad if tablet and template is not supported template", () => {
-      const contentWithoutAd = content.filter((item) => item.name !== "ad");
-      expect(
-        setupAd({
-          ...skeletonProps,
-          data: { ...skeletonProps.data, template: "maincomment" },
-        }),
-      ).toEqual(contentWithoutAd);
-    });
-
-    it("should not remove ad if not tablet and template is not mainstandard", () => {
-      expect(
-        setupAd({
-          ...skeletonProps,
-          isTablet: false,
-          data: { ...skeletonProps.data, template: "maincomment" },
-        }),
-      ).toEqual(content);
-    });
   });
 
   describe("setupArticleMpuAd", () => {
@@ -97,7 +77,7 @@ export default () => {
       ]);
     });
 
-    it("should return content with a leaderboard if non paragraph precedes and follows 5th paragraph", () => {
+    it("should return content with a leaderboard if non paragraph precedes and follows 5th paragraph and not comment template", () => {
       const crowdedContent = [
         createParagraph("a"),
         createParagraph("b"),
@@ -129,6 +109,53 @@ export default () => {
         {
           name: "ad",
           attributes: { slotName: "native-leaderboard" },
+          children: [],
+        },
+        { name: "image", children: [] },
+        createParagraph("f"),
+        createParagraph("g"),
+        createParagraph("h"),
+        createParagraph("i"),
+        createParagraph("j"),
+      ]);
+    });
+
+    it("should return content with a single mpu (not inlined) if non paragraph precedes and follows 5th paragraph and is comment template", () => {
+      const crowdedContent = [
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        { name: "image", children: [] },
+        createParagraph("e"),
+        { name: "ad", children: [] },
+        { name: "image", children: [] },
+        createParagraph("f"),
+        createParagraph("g"),
+        createParagraph("h"),
+        createParagraph("i"),
+        createParagraph("j"),
+      ];
+
+      const newSkeletonProps = {
+        ...skeletonProps,
+        data: {
+          ...skeletonProps.data,
+          content: crowdedContent,
+          template: "maincomment",
+        },
+      };
+
+      expect(setupAd(newSkeletonProps)).toEqual([
+        createParagraph("a"),
+        createParagraph("b"),
+        createParagraph("c"),
+        createParagraph("d"),
+        { name: "image", children: [] },
+        createParagraph("e"),
+        {
+          name: "ad",
+          attributes: { slotName: "native-single-mpu" },
           children: [],
         },
         { name: "image", children: [] },

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -179,6 +179,7 @@ export default ({
         <Ad
           key={key}
           adConfig={adConfig}
+          narrowContent={narrowContent}
           slotName="native-inline-ad"
           {...attributes}
         />

--- a/packages/article-skeleton/src/body-utils/setupAd.js
+++ b/packages/article-skeleton/src/body-utils/setupAd.js
@@ -10,9 +10,14 @@ const setupArticleMpuAd = (
   const singleMPUThreshold = 8;
   const doubleMPUThreshold = 10;
 
+  const {
+    data: { template },
+  } = skeletonProps;
+
+  const isCommentTemplate = /comment/.test(template);
+
   // Get index of nth (adPosition) paragraph
   let nthParagraphIndex = currentAdSlotIndex;
-
   let hasNonParagraphContentBeforeThreshold = false;
   let lastParagraphIndex;
 
@@ -45,7 +50,9 @@ const setupArticleMpuAd = (
       {
         name: "ad",
         attributes: {
-          slotName: "native-leaderboard",
+          slotName: isCommentTemplate
+            ? "native-single-mpu"
+            : "native-leaderboard",
         },
         children: [],
       },
@@ -106,7 +113,13 @@ const setupArticleMpuAd = (
   ];
 };
 
-const templatesWithAds = ["mainstandard", "indepth", "magazinestandard"];
+const templatesWithAds = [
+  "mainstandard",
+  "maincomment",
+  "indepth",
+  "magazinestandard",
+  "magazinecomment",
+];
 
 export const setupAd = (skeletonProps) => {
   const {


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-6636

* Enables ads on both maincomment and magazinecomment templates
* Follows existing ad logic except for showing a centred single MPU when 5th para sandwiched by non para content.

Comment article with ad:
![Screenshot 2021-02-08 at 18 15 18](https://user-images.githubusercontent.com/5103512/107358490-5c0a0d00-6acb-11eb-983f-18ee6b3b2de8.png)

Magazine Comment article with ad:
![Screenshot 2021-02-08 at 18 14 57](https://user-images.githubusercontent.com/5103512/107358540-6b895600-6acb-11eb-83c3-2c63139aa99e.png)

Comment article with sandwiched 5th paragraph (Note this is a known issue with what is classed as non-paragraph content):
![Screenshot 2021-02-08 at 18 12 44](https://user-images.githubusercontent.com/5103512/107358637-88be2480-6acb-11eb-9fd5-0182bb3d60d7.png)
