### PR TITLE
fix: (TNLT-6674) memoize article content

### DIFF
--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -17,12 +17,11 @@ import fixup from "./body-utils";
 import ErrorBoundary from "./boundary";
 import { useResponsiveContext } from "@times-components-native/responsive";
 
-const ArticleWithContent = (props) => {
+const MemoisedArticle = React.memo((props) => {
   const {
     Header,
     data,
     analyticsStream,
-    onArticleRead,
     onCommentGuidelinesPress,
     onCommentsPress,
     onTooltipPresented,
@@ -35,27 +34,7 @@ const ArticleWithContent = (props) => {
 
   const { windowWidth } = useResponsiveContext();
 
-  const [hasBeenRead, setHasBeenRead] = useState(false);
-
   const { id, url, content, template } = data;
-
-  const setArticleRead = () => {
-    setHasBeenRead(true);
-    onArticleRead && onArticleRead(id);
-  };
-
-  useEffect(() => {
-    if (!hasBeenRead) {
-      const delay = setTimeout(() => {
-        setArticleRead();
-      }, 6000);
-      return () => clearTimeout(delay);
-    }
-  }, [hasBeenRead]);
-
-  const handleScroll = () => {
-    !hasBeenRead && setArticleRead();
-  };
 
   const Footer = () => (
     <Gutter>
@@ -106,6 +85,42 @@ const ArticleWithContent = (props) => {
   };
 
   return (
+    <>
+      <Gutter>
+        <Header width={Math.min(maxWidth, windowWidth)} />
+      </Gutter>
+
+      {fixedContent.map((item, index) => (
+        <ContentChild key={`fixedContent-${index}`} item={item} index={index} />
+      ))}
+    </>
+  );
+});
+
+const ArticleWithContent = (props) => {
+  const { onArticleRead, data } = props;
+
+  const [hasBeenRead, setHasBeenRead] = useState(false);
+
+  const setArticleRead = () => {
+    setHasBeenRead(true);
+    onArticleRead && onArticleRead(data.id);
+  };
+
+  useEffect(() => {
+    if (!hasBeenRead) {
+      const delay = setTimeout(() => {
+        setArticleRead();
+      }, 6000);
+      return () => clearTimeout(delay);
+    }
+  }, [hasBeenRead]);
+
+  const handleScroll = () => {
+    !hasBeenRead && setArticleRead();
+  };
+
+  return (
     <View style={styles.articleContainer}>
       <Viewport.Tracker>
         <ScrollView
@@ -113,17 +128,7 @@ const ArticleWithContent = (props) => {
           onScroll={handleScroll}
           scrollEventThrottle={400}
         >
-          <Gutter>
-            <Header width={Math.min(maxWidth, windowWidth)} />
-          </Gutter>
-
-          {fixedContent.map((item, index) => (
-            <ContentChild
-              key={`fixedContent-${index}`}
-              item={item}
-              index={index}
-            />
-          ))}
+          <MemoisedArticle {...props} />
         </ScrollView>
       </Viewport.Tracker>
     </View>


### PR DESCRIPTION
Part of https://nidigitalsolutions.jira.com/browse/TNLT-6674

## Problem

Whenever we render the article AST, it appears that the entire component tree is being destroyed and recreated. This is causing issues like ad's re-rendering and showing a different image whilst the user is scrolling.

Also, whenever an article was marked as read, that state change was causing a re-render of the article.

## Solution

1. Extract the components that renders the article AST into its own component such that it's not impacted by the `hasBeenRead` state changes.
2. Memoise this new wrapped component to prevent unnecessary re-renders.