### PR TITLE
fix: (TNLT-6731) fixes link text size in article

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -204,10 +204,8 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -1278,10 +1276,8 @@ exports[`7. an article with link 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -1383,10 +1379,8 @@ exports[`8. an article with italic link 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -1503,10 +1497,8 @@ exports[`9. an article with bold text followed by bold link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                       "textDecorationLine": "underline",
                     }
                   }
@@ -1606,10 +1598,8 @@ exports[`10. an article with italic and normal text link 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -2464,10 +2454,8 @@ exports[`17. an article skeleton with responsive items 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -457,10 +457,8 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -2016,10 +2014,8 @@ exports[`7. an article with link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -2163,10 +2159,8 @@ exports[`8. an article with italic link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -2325,10 +2319,8 @@ exports[`9. an article with bold text followed by bold link 1`] = `
                       Object {
                         "color": "#006699",
                         "fontFamily": "TimesDigitalW04",
-                        "fontSize": 18,
-                        "lineHeight": 26,
-                        "marginBottom": 25,
-                        "marginTop": 0,
+                        "fontSize": 36,
+                        "lineHeight": 52,
                       },
                     ]
                   }
@@ -2470,10 +2462,8 @@ exports[`10. an article with italic and normal text link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -5787,10 +5777,8 @@ exports[`19. renders content 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -6052,10 +6040,8 @@ exports[`20. an article with inline paragraph 1`] = `
                             Object {
                               "color": "#006699",
                               "fontFamily": "TimesDigitalW04",
-                              "fontSize": 18,
-                              "lineHeight": 26,
-                              "marginBottom": 25,
-                              "marginTop": 0,
+                              "fontSize": 36,
+                              "lineHeight": 52,
                             },
                           ]
                         }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -204,10 +204,8 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -1278,10 +1276,8 @@ exports[`7. an article with link 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -1383,10 +1379,8 @@ exports[`8. an article with italic link 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -1503,10 +1497,8 @@ exports[`9. an article with bold text followed by bold link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                       "textDecorationLine": "underline",
                     }
                   }
@@ -1606,10 +1598,8 @@ exports[`10. an article with italic and normal text link 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }
@@ -2464,10 +2454,8 @@ exports[`17. an article skeleton with responsive items 1`] = `
                   Object {
                     "color": "#006699",
                     "fontFamily": "TimesDigitalW04",
-                    "fontSize": 18,
-                    "lineHeight": 26,
-                    "marginBottom": 25,
-                    "marginTop": 0,
+                    "fontSize": 36,
+                    "lineHeight": 52,
                     "textDecorationLine": "underline",
                   }
                 }

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -457,10 +457,8 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -2016,10 +2014,8 @@ exports[`7. an article with link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -2163,10 +2159,8 @@ exports[`8. an article with italic link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -2325,10 +2319,8 @@ exports[`9. an article with bold text followed by bold link 1`] = `
                       Object {
                         "color": "#006699",
                         "fontFamily": "TimesDigitalW04",
-                        "fontSize": 18,
-                        "lineHeight": 26,
-                        "marginBottom": 25,
-                        "marginTop": 0,
+                        "fontSize": 36,
+                        "lineHeight": 52,
                       },
                     ]
                   }
@@ -2470,10 +2462,8 @@ exports[`10. an article with italic and normal text link 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -5787,10 +5777,8 @@ exports[`19. renders content 1`] = `
                     Object {
                       "color": "#006699",
                       "fontFamily": "TimesDigitalW04",
-                      "fontSize": 18,
-                      "lineHeight": 26,
-                      "marginBottom": 25,
-                      "marginTop": 0,
+                      "fontSize": 36,
+                      "lineHeight": 52,
                     },
                   ]
                 }
@@ -6052,10 +6040,8 @@ exports[`20. an article with inline paragraph 1`] = `
                             Object {
                               "color": "#006699",
                               "fontFamily": "TimesDigitalW04",
-                              "fontSize": 18,
-                              "lineHeight": 26,
-                              "marginBottom": 25,
-                              "marginTop": 0,
+                              "fontSize": 36,
+                              "lineHeight": 52,
                             },
                           ]
                         }

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -77,6 +77,7 @@ export default ({
       return (
         <ArticleLink
           url={href}
+          style={styles.articleLink}
           onPress={(e) =>
             onLinkPress(e, {
               canonicalId,

--- a/packages/article-skeleton/src/styles/article-body/shared.js
+++ b/packages/article-skeleton/src/styles/article-body/shared.js
@@ -1,7 +1,7 @@
 import styleguide, { tabletWidth } from "@times-components-native/styleguide";
 
 const sharedStyles = ({ scale, narrowContent, fontScale }) => {
-  const { colours, fontFactory, spacing, lineHeight } = styleguide({ scale });
+  const { colours, fontFactory, spacing } = styleguide({ scale });
 
   const defaultFont = {
     ...fontFactory({
@@ -24,17 +24,8 @@ const sharedStyles = ({ scale, narrowContent, fontScale }) => {
       paddingVertical: spacing(2),
     },
     articleLink: {
+      ...defaultFont,
       color: colours.functional.action,
-      ...fontFactory({
-        font: "body",
-        fontSize: "bodyMobile",
-      }),
-      lineHeight: lineHeight({
-        font: "body",
-        fontSize: "bodyMobile",
-      }),
-      marginBottom: spacing(5),
-      marginTop: 0,
     },
     articleMainContentRow: {
       paddingLeft: spacing(2),


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-6731

## Issue: Link text size not conforming to body text size

### Before

![simulator_screenshot_6B55F383-F101-432B-B43C-A7FFA3CCCD68](https://user-images.githubusercontent.com/6280629/107956392-02a45100-6f97-11eb-8fa6-41402364a269.png)

### After

![simulator_screenshot_0B5FFF49-CE45-408A-ADB1-B1BAA3763BFE](https://user-images.githubusercontent.com/6280629/107956491-25366a00-6f97-11eb-8acc-84e31960947e.png)

## Issue: Link text wrapping an image then changes line-height for rest of paragraph

### Before 
![simulator_screenshot_ABA75DCD-EC39-4E2E-B148-D75EAAF4C8CD](https://user-images.githubusercontent.com/6280629/107956226-c4a72d00-6f96-11eb-87e0-d07a1acc0461.png)


### After
![simulator_screenshot_63B9CF54-9329-4CC6-9D60-89A66D079DE7](https://user-images.githubusercontent.com/6280629/107955789-1dc29100-6f96-11eb-90de-f1f997282912.png)
