### PR TITLE
fix: (TNLT-6770) Remove extra padding on interactives

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -126,7 +126,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           style={
             Object {
               "marginBottom": 20,
-              "paddingHorizontal": 10,
             }
           }
         >
@@ -797,7 +796,6 @@ exports[`2. an article with interactives 1`] = `
           style={
             Object {
               "marginBottom": 20,
-              "paddingHorizontal": 10,
             }
           }
         >
@@ -2374,7 +2372,6 @@ exports[`17. an article skeleton with responsive items 1`] = `
           style={
             Object {
               "marginBottom": 20,
-              "paddingHorizontal": 10,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -159,7 +159,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               false,
               false,
@@ -1343,7 +1342,6 @@ exports[`2. an article with interactives 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               false,
               false,
@@ -1375,7 +1373,6 @@ exports[`2. an article with interactives 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               false,
               Object {
@@ -4407,7 +4404,6 @@ exports[`19. renders content 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               undefined,
               false,

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -126,7 +126,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           style={
             Object {
               "marginBottom": 20,
-              "paddingHorizontal": 10,
             }
           }
         >
@@ -797,7 +796,6 @@ exports[`2. an article with interactives 1`] = `
           style={
             Object {
               "marginBottom": 20,
-              "paddingHorizontal": 10,
             }
           }
         >
@@ -2374,7 +2372,6 @@ exports[`17. an article skeleton with responsive items 1`] = `
           style={
             Object {
               "marginBottom": 20,
-              "paddingHorizontal": 10,
             }
           }
         >

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -159,7 +159,6 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               false,
               false,
@@ -1343,7 +1342,6 @@ exports[`2. an article with interactives 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               false,
               false,
@@ -1375,7 +1373,6 @@ exports[`2. an article with interactives 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               false,
               Object {
@@ -4407,7 +4404,6 @@ exports[`19. renders content 1`] = `
             Array [
               Object {
                 "marginBottom": 20,
-                "paddingHorizontal": 10,
               },
               undefined,
               false,

--- a/packages/article-skeleton/src/styles/article-body/shared.js
+++ b/packages/article-skeleton/src/styles/article-body/shared.js
@@ -53,7 +53,6 @@ const sharedStyles = ({ scale, narrowContent, fontScale }) => {
     },
     interactiveContainer: {
       marginBottom: spacing(4),
-      paddingHorizontal: spacing(2),
     },
     interactiveContainerTablet: {
       alignSelf: "center",


### PR DESCRIPTION
- https://nidigitalsolutions.jira.com/browse/TNLT-6770
- Remove extra padding on interactives on mobile

**Before**
![Image from iOS (2)](https://user-images.githubusercontent.com/5861100/108499263-ef022e80-72a5-11eb-87a9-eb716991e7af.png)


**After**
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-19 at 10 51 37](https://user-images.githubusercontent.com/5861100/108498947-7ef3a880-72a5-11eb-8cd2-9e502727d6b3.png)
![Screenshot_1613732486](https://user-images.githubusercontent.com/5861100/108498962-83b85c80-72a5-11eb-8261-2d32a683b1e1.png)



**Tablet**
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-02-19 at 11 40 41](https://user-images.githubusercontent.com/5861100/108500208-55d41780-72a7-11eb-90e8-8cf91a6cfef0.png)
