### PR TITLE
chore: Release v4.0.0 - BREAKING CHANGE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
* (TNLT-6786) BREAKING CHANGE - Updates ReactNative to 0.63.4 and reverts Android Dimensions temporary fix.

Note this will require updating both iOS and Android to build:
https://github.com/newsuk/nuk-tnl-app-android-universal/pull/1191
https://github.com/newsuk/nuk-tnl-app-ios-universal/pull/2345