### PR TITLE
fix: (TNLT-6840) Ads not displaying in section screens on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "5.0.2-beta0",
+  "version": "5.0.2-beta",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.0.1-beta0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "5.0.2-beta",
+  "version": "5.0.1",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -206,6 +206,7 @@ class DOMContext extends PureComponent {
     const { loaded } = this.state;
 
     return (
+      // Note that this ViewportAwareView must be contained by a Viewport.Tracker to work properly
       <ViewportAwareView
         onViewportEnter={this.loadAd}
         style={{

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -28,7 +28,7 @@ import {
 import { OnArticlePress } from "@times-components-native/types";
 import { SectionTitles } from "./utils/sectionConfigs";
 import { Orientation } from "@times-components-native/responsive/src/context";
-import { Viewport } from "@skele/components"
+import { Viewport } from "@skele/components";
 
 const styles = styleFactory();
 const { SectionEvents } = NativeModules;

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -28,6 +28,7 @@ import {
 import { OnArticlePress } from "@times-components-native/types";
 import { SectionTitles } from "./utils/sectionConfigs";
 import { Orientation } from "@times-components-native/responsive/src/context";
+// @ts-ignore
 import { Viewport } from "@skele/components";
 
 const styles = styleFactory();

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -28,6 +28,7 @@ import {
 import { OnArticlePress } from "@times-components-native/types";
 import { SectionTitles } from "./utils/sectionConfigs";
 import { Orientation } from "@times-components-native/responsive/src/context";
+import { Viewport } from "@skele/components"
 
 const styles = styleFactory();
 const { SectionEvents } = NativeModules;
@@ -206,23 +207,25 @@ const Section: FC<Props> = ({
 
   return (
     <>
-      <FlatList
-        ref={flatListRef}
-        contentContainerStyle={
-          isTablet && isPuzzle && styles.additionalContainerPadding
-        }
-        removeClippedSubviews
-        data={data}
-        ItemSeparatorComponent={(leadingItem) =>
-          renderItemSeperator(isPuzzle)(leadingItem, editionBreakpoint)
-        }
-        keyExtractor={(item) => item.elementId}
-        ListHeaderComponent={getHeaderComponent(isPuzzle, isMagazine)}
-        nestedScrollEnabled
-        onViewableItemsChanged={onViewed ? onViewableItemsChanged : null}
-        {...(isPuzzle && { onScrollBeginDrag })}
-        renderItem={renderItem(isPuzzle, orientation)}
-      />
+      <Viewport.Tracker>
+        <FlatList
+          ref={flatListRef}
+          contentContainerStyle={
+            isTablet && isPuzzle && styles.additionalContainerPadding
+          }
+          removeClippedSubviews
+          data={data}
+          ItemSeparatorComponent={(leadingItem) =>
+            renderItemSeperator(isPuzzle)(leadingItem, editionBreakpoint)
+          }
+          keyExtractor={(item) => item.elementId}
+          ListHeaderComponent={getHeaderComponent(isPuzzle, isMagazine)}
+          nestedScrollEnabled
+          onViewableItemsChanged={onViewed ? onViewableItemsChanged : null}
+          {...(isPuzzle && { onScrollBeginDrag })}
+          renderItem={renderItem(isPuzzle, orientation)}
+        />
+      </Viewport.Tracker>
       {isPuzzle && isIOS ? (
         <FloatingActionButton
           animatedWidth={emailPuzzlesButtonWidth}


### PR DESCRIPTION
##### Problem

Adverts are not displaying on sections on Android

##### Solution

Viewport Aware View that helps to lazy load the ads needs to be contained by a `Viewport.Tracker` to work. Without that, `onViewportEnter` never fires and ads are never loaded.