### PR TITLE
fix: (TNLT-6846) In article puff interactive on narrow content templates

### DIFF
--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -36,7 +36,13 @@ export default ({
   onParagraphTextLayout,
 }) => {
   const { fontScale } = Dimensions.get("window");
-  const styles = styleFactory({ scale, narrowContent, fontScale });
+  const { narrowArticleBreakpoint } = useResponsiveContext();
+  const styles = styleFactory({
+    scale,
+    narrowContent,
+    fontScale,
+    narrowArticleBreakpoint,
+  });
 
   return {
     text(key, attributes) {

--- a/packages/article-skeleton/src/styles/article-body/shared.js
+++ b/packages/article-skeleton/src/styles/article-body/shared.js
@@ -1,6 +1,11 @@
 import styleguide, { tabletWidth } from "@times-components-native/styleguide";
 
-const sharedStyles = ({ scale, narrowContent, fontScale }) => {
+const sharedStyles = ({
+  scale,
+  narrowContent,
+  fontScale,
+  narrowArticleBreakpoint,
+}) => {
   const { colours, fontFactory, spacing } = styleguide({ scale });
 
   const defaultFont = {
@@ -57,6 +62,10 @@ const sharedStyles = ({ scale, narrowContent, fontScale }) => {
     interactiveContainerTablet: {
       alignSelf: "center",
       width: tabletWidth,
+      ...(narrowContent && {
+        alignSelf: "flex-start",
+        maxWidth: narrowArticleBreakpoint.content,
+      }),
     },
     interactiveContainerFullWidth: {
       width: "100%",


### PR DESCRIPTION
- Improve the layout of the interactives of type `in-article-puff`
- https://nidigitalsolutions.jira.com/browse/TNLT-6846
- There is also work to be done _within the interactive code itself_ which will come at a later date.


### iPhone (Before)
<img width="428" alt="Screenshot 2021-03-04 at 14 05 48" src="https://user-images.githubusercontent.com/1736782/109980698-13272c00-7cf8-11eb-8739-5d786c99f6a2.png">

### iPhone (After)
<img width="436" alt="Screenshot 2021-03-04 at 14 04 46" src="https://user-images.githubusercontent.com/1736782/109980716-16bab300-7cf8-11eb-8e98-1b3f5fdd88e4.png">

### iPad Portrait (Before)
<img width="918" alt="Screenshot 2021-03-04 at 14 02 01" src="https://user-images.githubusercontent.com/1736782/109981097-7d3fd100-7cf8-11eb-835d-50122a669cce.png">

### iPad Portrait (After)
<img width="911" alt="Screenshot 2021-03-04 at 14 02 26" src="https://user-images.githubusercontent.com/1736782/109980776-2b974680-7cf8-11eb-9897-67ca7940cc10.png">


### iPad Landscape (Before)
<img width="1269" alt="Screenshot 2021-03-04 at 14 02 12" src="https://user-images.githubusercontent.com/1736782/109980990-64cfb680-7cf8-11eb-8191-4b63edb8ff44.png">

### iPad Landscape (After)
<img width="1247" alt="Screenshot 2021-03-04 at 14 02 38" src="https://user-images.githubusercontent.com/1736782/109981028-6a2d0100-7cf8-11eb-8897-c3044a0229bd.png">

