### PR TITLE
chore: Release v5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Release of 
- fix: (TNLT-6846) In article puff interactive on narrow content templates 