### PR TITLE
fix: (TNLT-7048) SupplementLeadOneAndFourV2 Lead Tile image in iOS landscape

### DIFF
--- a/packages/edition-slices/src/tiles/shared/tile-image.tsx
+++ b/packages/edition-slices/src/tiles/shared/tile-image.tsx
@@ -41,6 +41,7 @@ const TileImage: FC<Props> = ({
       <Image
         onLayout={handleOnLayout}
         {...props}
+        style={style}
         key={isPortrait ? "tile-image-portrait" : "tile-image-landscape"}
       />
       {!hideVideoIcon && (


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/TNLT-7048

* Fixes the landscape layout of the LeadTile image in the SupplementLeadOneAndFourV2 (only used by iOS) when lead asset is a video.

**Before:**
![Screenshot 2021-03-15 at 17 29 15](https://user-images.githubusercontent.com/5103512/111196038-ca535b00-85b4-11eb-955d-9bfbcfcfd9f0.png)


**After:**
![Screenshot 2021-03-15 at 17 30 18](https://user-images.githubusercontent.com/5103512/111196068-d0e1d280-85b4-11eb-8fec-272ce08671ca.png)

![Screenshot 2021-03-15 at 17 30 37](https://user-images.githubusercontent.com/5103512/111196108-d8a17700-85b4-11eb-8ea6-fa847248367b.png)
