### PR TITLE
chore: Disable article end tracking for Android

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-end-tracking.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-end-tracking.android.test.js.snap
@@ -1,37 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleEndTracking renders the component and triggers the onViewed callback when in viewport 1`] = `
-<View
-  inViewport={false}
-  onViewportEnter={[Function]}
-  testID="viewportAwareView"
-/>
-`;
-
-exports[`ArticleEndTracking should track the viewed component in analytics 1`] = `
-Array [
-  Array [
-    Object {
-      "action": "Viewed",
-      "attrs": Object {
-        "eventTime": "2018-01-01T00:00:00.000Z",
-      },
-      "component": "Page",
-      "object": "Article",
-    },
-  ],
-  Array [
-    Object {
-      "action": "onViewed",
-      "attrs": Object {
-        "eventTime": "2018-01-01T00:00:00.000Z",
-        "event_navigation_action": "navigation",
-        "event_navigation_browsing_method": "scroll",
-        "event_navigation_name": "article : view end",
-      },
-      "component": "ArticleEndTracking",
-      "object": "Article",
-    },
-  ],
-]
-`;
+exports[`ArticleEndTracking does not render the component for Android 1`] = `null`;

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -723,11 +723,7 @@ exports[`1. article with header 1`] = `
           </View>
         </View>
       </View>
-      <View>
-        <View
-          inViewport={false}
-        />
-      </View>
+      <View />
       <View>
         <View>
           <ArticleExtras

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images-with-style.android.test.js.snap
@@ -41,9 +41,7 @@ exports[`1. a primary image 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -113,9 +111,7 @@ exports[`2. a fullwidth image 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -185,9 +181,7 @@ exports[`3. a secondary image 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -257,9 +251,7 @@ exports[`4. an inline image 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
@@ -48,11 +48,7 @@ exports[`1. a primary image 1`] = `
           }
         />
       </View>
-      <View>
-        <View
-          inViewport={false}
-        />
-      </View>
+      <View />
       <View>
         <View>
           <ArticleExtras
@@ -115,11 +111,7 @@ exports[`2. a fullwidth image 1`] = `
           }
         />
       </View>
-      <View>
-        <View
-          inViewport={false}
-        />
-      </View>
+      <View />
       <View>
         <View>
           <ArticleExtras
@@ -182,11 +174,7 @@ exports[`3. a secondary image 1`] = `
           }
         />
       </View>
-      <View>
-        <View
-          inViewport={false}
-        />
-      </View>
+      <View />
       <View>
         <View>
           <ArticleExtras
@@ -249,11 +237,7 @@ exports[`4. an inline image 1`] = `
           }
         />
       </View>
-      <View>
-        <View
-          inViewport={false}
-        />
-      </View>
+      <View />
       <View>
         <View>
           <ArticleExtras

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-tablet.android.test.js.snap
@@ -75,9 +75,7 @@ exports[`1. with inline video 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -147,9 +145,7 @@ exports[`2. with ad on mainstandard 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -219,9 +215,7 @@ exports[`3. with ad on maincomment 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -743,9 +743,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -845,9 +843,7 @@ exports[`2. an article with interactives 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -905,9 +901,7 @@ exports[`3. an article with no content 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1112,9 +1106,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1248,9 +1240,7 @@ exports[`6. an article with heading tags 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1360,9 +1350,7 @@ exports[`7. an article with link 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1483,9 +1471,7 @@ exports[`8. an article with italic link 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1603,9 +1589,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1729,9 +1713,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1842,9 +1824,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -1939,9 +1919,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -2039,9 +2017,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -2144,9 +2120,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -2296,9 +2270,7 @@ exports[`15. an article starting with single quote 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -2448,9 +2420,7 @@ exports[`16. an article starting with double quote 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {
@@ -3188,9 +3158,7 @@ exports[`17. an article skeleton with responsive items 1`] = `
             "width": undefined,
           }
         }
-      >
-        <View />
-      </View>
+      />
       <View
         style={
           Object {

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1267,11 +1267,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -1422,11 +1418,7 @@ exports[`2. an article with interactives 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -1512,11 +1504,7 @@ exports[`3. an article with no content 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -1783,11 +1771,7 @@ exports[`5. an article with a nested markup in first paragraph displays a drop c
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -1981,11 +1965,7 @@ exports[`6. an article with heading tags 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -2143,11 +2123,7 @@ exports[`7. an article with link 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -2316,11 +2292,7 @@ exports[`8. an article with italic link 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -2486,11 +2458,7 @@ exports[`9. an article with bold text followed by bold link 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -2662,11 +2630,7 @@ exports[`10. an article with italic and normal text link 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -2820,11 +2784,7 @@ exports[`11. an article with bold and italic text at the same time 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -2962,11 +2922,7 @@ exports[`12. an article with text wrapped in inline element 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -3107,11 +3063,7 @@ exports[`13. an article with paragraph with text and inline element 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -3257,11 +3209,7 @@ exports[`14. an article with inline inside a bold tag 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -3458,11 +3406,7 @@ exports[`15. an article starting with single quote 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -3659,11 +3603,7 @@ exports[`16. an article starting with double quote 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -6154,11 +6094,7 @@ exports[`19. renders content 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [
@@ -6392,11 +6328,7 @@ exports[`20. an article with inline paragraph 1`] = `
             },
           ]
         }
-      >
-        <View
-          inViewport={false}
-        />
-      </View>
+      />
       <View
         style={
           Array [

--- a/packages/article-skeleton/__tests__/article-end-tracking.base.android.js
+++ b/packages/article-skeleton/__tests__/article-end-tracking.base.android.js
@@ -1,0 +1,31 @@
+import React from "react";
+import mockDate from "mockdate";
+import { create } from "react-test-renderer";
+
+import ArticleEndTracking from "../src/article-body/article-end-tracking";
+
+export default () => {
+  describe("ArticleEndTracking", () => {
+    beforeEach(() => {
+      mockDate.set(1514764800000, 0);
+    });
+
+    afterEach(() => {
+      mockDate.reset();
+    });
+
+    it("does not render the component for Android", () => {
+      const mockedOnViewed = jest.fn();
+      const mockedAnalyticsStream = jest.fn();
+
+      const output = create(
+        <ArticleEndTracking
+          analyticsStream={mockedAnalyticsStream}
+          onViewed={mockedOnViewed}
+        />,
+      );
+
+      expect(output).toMatchSnapshot();
+    });
+  });
+};

--- a/packages/article-skeleton/src/article-body/article-end-tracking.js
+++ b/packages/article-skeleton/src/article-body/article-end-tracking.js
@@ -1,11 +1,13 @@
 import React from "react";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import PropTypes from "prop-types";
 import { Viewport } from "@skele/components";
 
 import { withTrackEvents } from "@times-components-native/tracking";
 
 const ArticleEndTracking = ({ onViewed }) => {
+  if (Platform.OS === "android") return null;
+
   const ViewportAwareView = Viewport.Aware(View);
 
   return (


### PR DESCRIPTION
Disable article end tracking for Android until `Viewport.Aware` fixed or replaced.
