### PR TITLE
fix: search box focus area

### DIFF
--- a/packages/search/__tests__/android/__snapshots__/search-bar.test.ts.snap
+++ b/packages/search/__tests__/android/__snapshots__/search-bar.test.ts.snap
@@ -267,6 +267,7 @@ exports[`Search Bar should render correctly 1`] = `
             "lineHeight": undefined,
             "marginLeft": 10,
             "paddingTop": 7,
+            "width": "100%",
           }
         }
         underlineColorAndroid="transparent"

--- a/packages/search/__tests__/ios/__snapshots__/search-bar.test.ts.snap
+++ b/packages/search/__tests__/ios/__snapshots__/search-bar.test.ts.snap
@@ -255,6 +255,7 @@ exports[`Search Bar should render correctly 1`] = `
             "lineHeight": undefined,
             "marginLeft": 10,
             "paddingTop": 4,
+            "width": "100%",
           }
         }
         underlineColorAndroid="transparent"

--- a/packages/search/src/search-bar/styles/search-bar-styles.ts
+++ b/packages/search/src/search-bar/styles/search-bar-styles.ts
@@ -33,7 +33,7 @@ export const styles = StyleSheet.create({
       font: "supporting",
       fontSize: "body",
     }),
-    width: '100%',
+    width: "100%",
     backgroundColor: colours.functional.grey,
     color: colours.functional.black,
   },

--- a/packages/search/src/search-bar/styles/search-bar-styles.ts
+++ b/packages/search/src/search-bar/styles/search-bar-styles.ts
@@ -33,7 +33,7 @@ export const styles = StyleSheet.create({
       font: "supporting",
       fontSize: "body",
     }),
-
+    width: '100%',
     backgroundColor: colours.functional.grey,
     color: colours.functional.black,
   },


### PR DESCRIPTION
This PR fixes the bug that caused the search box focus area to be too small. Now it is possible to focus on the search box by tapping across the whole text input area.
