### PR TITLE
chore: Update ad network id

### DIFF
--- a/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
@@ -37,7 +37,7 @@ exports[`advert 1`] = `
         "ad-pixelskin",
         "ad-pixelteads",
       ],
-      "networkId": "25436805",
+      "networkId": "3048",
       "pageTargeting": Object {
         "breakpoint": "huge",
         "cips": null,
@@ -117,7 +117,7 @@ exports[`advert with narrow content 1`] = `
         "ad-pixelskin",
         "ad-pixelteads",
       ],
-      "networkId": "25436805",
+      "networkId": "3048",
       "pageTargeting": Object {
         "breakpoint": "huge",
         "cips": null,
@@ -198,7 +198,7 @@ exports[`advert with width 1`] = `
         "ad-pixelskin",
         "ad-pixelteads",
       ],
-      "networkId": "25436805",
+      "networkId": "3048",
       "pageTargeting": Object {
         "breakpoint": "huge",
         "cips": null,

--- a/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
@@ -37,7 +37,7 @@ exports[`advert 1`] = `
         "ad-pixelskin",
         "ad-pixelteads",
       ],
-      "networkId": "25436805",
+      "networkId": "3048",
       "pageTargeting": Object {
         "breakpoint": "huge",
         "cips": null,
@@ -117,7 +117,7 @@ exports[`advert with narrow content 1`] = `
         "ad-pixelskin",
         "ad-pixelteads",
       ],
-      "networkId": "25436805",
+      "networkId": "3048",
       "pageTargeting": Object {
         "breakpoint": "huge",
         "cips": null,
@@ -198,7 +198,7 @@ exports[`advert with width 1`] = `
         "ad-pixelskin",
         "ad-pixelteads",
       ],
-      "networkId": "25436805",
+      "networkId": "3048",
       "pageTargeting": Object {
         "breakpoint": "huge",
         "cips": null,

--- a/packages/ad/fixtures/article-ad-config.json
+++ b/packages/ad/fixtures/article-ad-config.json
@@ -1,5 +1,5 @@
 {
-  "networkId": "25436805",
+  "networkId": "3048",
   "adUnit": "d.thetimes.co.uk",
   "pageTargeting": {
     "testmode": "null",

--- a/packages/ad/src/ad-composer-prop-types.js
+++ b/packages/ad/src/ad-composer-prop-types.js
@@ -44,7 +44,7 @@ export const defaultProps = {
     bidderSlots: ["header", "inline-ad"],
     bidInitialiser: Promise.resolve(),
     globalSlots: ["ad-pixel", "ad-pixelskin", "ad-pixelteads"],
-    networkId: "25436805",
+    networkId: "3048",
     pageTargeting: {
       label: "This is label",
       title: "This is title",

--- a/packages/article-list/fixtures/article-ad-config.json
+++ b/packages/article-list/fixtures/article-ad-config.json
@@ -1,5 +1,5 @@
 {
-  "networkId": "25436805",
+  "networkId": "3048",
   "adUnit": "d.thetimes.co.uk",
   "pageTargeting": {
     "testmode": "null",

--- a/packages/topic/fixtures/topic-ad-config.json
+++ b/packages/topic/fixtures/topic-ad-config.json
@@ -1,5 +1,5 @@
 {
-  "networkId": "25436805",
+  "networkId": "3048",
   "adUnit": "d.thetimes.co.uk",
   "pageTargeting": {
     "testmode": "null",


### PR DESCRIPTION
- Update ad network id to use the primary network `3048`
