### PR TITLE
fix: Article end tracking event

### DIFF
--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-end-tracking.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-end-tracking.ios.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ArticleEndTracking renders the component and triggers the onViewed callback when in viewport 1`] = `
 <View
   inViewport={false}
-  onViewportEnter={[Function]}
+  onViewportEnter={[MockFunction]}
   testID="viewportAwareView"
 />
 `;
@@ -17,19 +17,6 @@ Array [
         "eventTime": "2018-01-01T00:00:00.000Z",
       },
       "component": "Page",
-      "object": "Article",
-    },
-  ],
-  Array [
-    Object {
-      "action": "onViewed",
-      "attrs": Object {
-        "eventTime": "2018-01-01T00:00:00.000Z",
-        "event_navigation_action": "navigation",
-        "event_navigation_browsing_method": "scroll",
-        "event_navigation_name": "article : view end",
-      },
-      "component": "ArticleEndTracking",
       "object": "Article",
     },
   ],

--- a/packages/article-skeleton/src/article-body/article-end-tracking.js
+++ b/packages/article-skeleton/src/article-body/article-end-tracking.js
@@ -3,7 +3,7 @@ import { Platform, View } from "react-native";
 import PropTypes from "prop-types";
 import { Viewport } from "@skele/components";
 
-import { withTrackEvents } from "@times-components-native/tracking";
+import { withTrackEvents, withTrackingContext } from "@times-components-native/tracking";
 
 const ArticleEndTracking = ({ onViewed }) => {
   if (Platform.OS === "android") return null;

--- a/packages/article-skeleton/src/article-body/article-end-tracking.js
+++ b/packages/article-skeleton/src/article-body/article-end-tracking.js
@@ -23,17 +23,26 @@ ArticleEndTracking.propTypes = {
   onViewed: PropTypes.func.isRequired,
 };
 
-export default withTrackEvents(ArticleEndTracking, {
-  analyticsEvents: [
-    {
-      actionName: "onViewed",
-      eventName: "onViewed",
-      getAttrs: () => ({
-        event_navigation_action: "navigation",
-        event_navigation_name: "article : view end",
-        event_navigation_browsing_method: "scroll",
-      }),
-      trackingName: "ArticleEndTracking",
-    },
-  ],
+export default withTrackingContext(
+  withTrackEvents(ArticleEndTracking, {
+    analyticsEvents: [
+      {
+        actionName: "onPress",
+        eventName: "onPress",
+        getAttrs: () => ({
+          event_navigation_action: "navigation",
+          event_navigation_name: "article : view end",
+          event_navigation_browsing_method: "scroll",
+        }),
+        trackingName: "ArticleEndTracking",
+      },
+    ],
+  }), {
+  getAttrs: ({ newsletterPuffName }) => ({
+    event_navigation_action: "navigation",
+    event_navigation_name: "article : view end",
+    event_navigation_browsing_method: "scroll",
+  }),
+  trackingName: "ArticleEndTracking",
+  trackingObjectName: "ArticleEndTracking",
 });


### PR DESCRIPTION
This PR changes the analytics event that gets triggered on article bottom reached.

As much as I understood wrapping the ArticleEndTracking with withTrackingContext, triggers an event rather than view event. So this fix should work.

Due to the fact that in the rest of the project these kind of events are handled in native app (TheTimesProjectD -> AnalyticsService), I can't be 100% sure that withTrackingContext is right way to handle it.