### PR TITLE
feat: Add analtyics to Search

### DIFF
--- a/packages/pages/src/search/index.tsx
+++ b/packages/pages/src/search/index.tsx
@@ -4,7 +4,6 @@ import { Search } from "@times-components-native/search";
 import { withErrorBoundaries } from "@times-components-native/pages/src/with-error-boundaries";
 import { SearchProps } from "@times-components-native/search/src/search";
 
-const { track } = NativeModules.ReactAnalytics;
 const { onArticlePress } = NativeModules.SearchEvents;
 
 export interface SearchPageProps {

--- a/packages/pages/src/search/index.tsx
+++ b/packages/pages/src/search/index.tsx
@@ -18,11 +18,7 @@ const SearchPage = withErrorBoundaries(
     }
 
     return (
-      <Search
-        analyticsStream={track}
-        onArticlePress={onArticlePress}
-        algoliaConfig={algoliaConfig}
-      />
+      <Search onArticlePress={onArticlePress} algoliaConfig={algoliaConfig} />
     );
   },
 );

--- a/packages/search/src/search-list/search-list-empty-state.tsx
+++ b/packages/search/src/search-list/search-list-empty-state.tsx
@@ -1,30 +1,42 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { NativeModules } from "react-native";
 import { Text, Image, KeyboardAvoidingView, Platform } from "react-native";
 import { styles } from "./styles/search-list-empty-state-styles";
 import { ImageIcons } from "@times-components-native/icons/src/icons/imageIcons";
+import { TTrackingData } from "../types";
+
+const { track } = NativeModules.ReactAnalytics;
 
 interface SearchListEmptyStateProps {
   message: string;
   title: string;
   icon?: string;
+  trackingData: TTrackingData;
 }
 
-const SearchListEmptyState: React.FC<SearchListEmptyStateProps> = ({
+function SearchListEmptyState({
   message,
   title,
   icon = "search",
-}) => (
-  <KeyboardAvoidingView
-    behavior={Platform.OS === "ios" ? "padding" : "height"}
-    style={styles.listEmptyStateContainer}
-  >
-    <Image
-      source={ImageIcons[icon]}
-      style={{ width: 200, height: 200, alignSelf: "center" }}
-    />
-    <Text style={styles.listEmptyTitle}>{title}</Text>
-    <Text style={styles.listEmptyMessage}>{message}</Text>
-  </KeyboardAvoidingView>
-);
+  trackingData,
+}: SearchListEmptyStateProps) {
+  useEffect(() => {
+    track(trackingData);
+  }, []);
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      style={styles.listEmptyStateContainer}
+    >
+      <Image
+        source={ImageIcons[icon]}
+        style={{ width: 200, height: 200, alignSelf: "center" }}
+      />
+      <Text style={styles.listEmptyTitle}>{title}</Text>
+      <Text style={styles.listEmptyMessage}>{message}</Text>
+    </KeyboardAvoidingView>
+  );
+}
 
 export default SearchListEmptyState;

--- a/packages/search/src/search-list/search-list-empty-state.tsx
+++ b/packages/search/src/search-list/search-list-empty-state.tsx
@@ -3,7 +3,7 @@ import { NativeModules } from "react-native";
 import { Text, Image, KeyboardAvoidingView, Platform } from "react-native";
 import { styles } from "./styles/search-list-empty-state-styles";
 import { ImageIcons } from "@times-components-native/icons/src/icons/imageIcons";
-import { TTrackingData } from "@times-components-native/types";
+import { TrackingData } from "@times-components-native/types";
 
 const { track } = NativeModules.ReactAnalytics;
 
@@ -11,7 +11,7 @@ interface SearchListEmptyStateProps {
   message: string;
   title: string;
   icon?: string;
-  trackingData: TTrackingData;
+  trackingData: TrackingData;
 }
 
 function SearchListEmptyState({

--- a/packages/search/src/search-list/search-list-empty-state.tsx
+++ b/packages/search/src/search-list/search-list-empty-state.tsx
@@ -3,7 +3,7 @@ import { NativeModules } from "react-native";
 import { Text, Image, KeyboardAvoidingView, Platform } from "react-native";
 import { styles } from "./styles/search-list-empty-state-styles";
 import { ImageIcons } from "@times-components-native/icons/src/icons/imageIcons";
-import { TTrackingData } from "../types";
+import { TTrackingData } from "@times-components-native/types";
 
 const { track } = NativeModules.ReactAnalytics;
 

--- a/packages/search/src/search-list/search-list.tsx
+++ b/packages/search/src/search-list/search-list.tsx
@@ -6,7 +6,7 @@ import ArticleListItemSeparator from "@times-components-native/article-list/src/
 import SearchListLoader from "@times-components-native/search/src/search-list/search-list-loader";
 import { styles } from "./styles/search-list-styles";
 import SearchListEmptyState from "./search-list-empty-state";
-import { TTrackingData } from "../types";
+import { TTrackingData } from "@times-components-native/types";
 
 export interface SearchListProps {
   hits: Hit[];

--- a/packages/search/src/search-list/search-list.tsx
+++ b/packages/search/src/search-list/search-list.tsx
@@ -6,6 +6,7 @@ import ArticleListItemSeparator from "@times-components-native/article-list/src/
 import SearchListLoader from "@times-components-native/search/src/search-list/search-list-loader";
 import { styles } from "./styles/search-list-styles";
 import SearchListEmptyState from "./search-list-empty-state";
+import { TTrackingData } from "../types";
 
 export interface SearchListProps {
   hits: Hit[];
@@ -28,10 +29,11 @@ const SearchList: FC<SearchListProps> = ({
   };
 
   useEffect(() => {
-    const trackingData = {
+    const trackingData: TTrackingData = {
       object: "Search",
       action: "Search results",
       component: "Search",
+      attrs: { eventTime: new Date() },
     };
     track(trackingData);
   }, []);

--- a/packages/search/src/search-list/search-list.tsx
+++ b/packages/search/src/search-list/search-list.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from "react";
-import { FlatList, View } from "react-native";
+import React, { FC, useEffect } from "react";
+import { FlatList, View, NativeModules } from "react-native";
 import SearchListItem from "./search-list-item";
 import { Hit } from "../types";
 import ArticleListItemSeparator from "@times-components-native/article-list/src/article-list-item-separator";
@@ -13,6 +13,8 @@ export interface SearchListProps {
   fetchMore: () => void;
 }
 
+const { track } = NativeModules.ReactAnalytics;
+
 const SearchList: FC<SearchListProps> = ({
   hits,
   onArticlePress,
@@ -24,6 +26,15 @@ const SearchList: FC<SearchListProps> = ({
       return fetchMore();
     }
   };
+
+  useEffect(() => {
+    const trackingData = {
+      object: "Search",
+      action: "Search results",
+      component: "Search",
+    };
+    track(trackingData);
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -40,6 +51,11 @@ const SearchList: FC<SearchListProps> = ({
               icon="emptyResultsIcon"
               title="Sorry, we found no results"
               message="Please check all words are spelled correctly, or try a different search term"
+              trackingData={{
+                object: "Search",
+                action: "No search results",
+                component: "Search ",
+              }}
             />
           }
           ListFooterComponent={SearchListLoader}

--- a/packages/search/src/search-list/search-list.tsx
+++ b/packages/search/src/search-list/search-list.tsx
@@ -6,7 +6,7 @@ import ArticleListItemSeparator from "@times-components-native/article-list/src/
 import SearchListLoader from "@times-components-native/search/src/search-list/search-list-loader";
 import { styles } from "./styles/search-list-styles";
 import SearchListEmptyState from "./search-list-empty-state";
-import { TTrackingData } from "@times-components-native/types";
+import { TrackingData } from "@times-components-native/types";
 
 export interface SearchListProps {
   hits: Hit[];
@@ -29,7 +29,7 @@ const SearchList: FC<SearchListProps> = ({
   };
 
   useEffect(() => {
-    const trackingData: TTrackingData = {
+    const trackingData: TrackingData = {
       object: "Search",
       action: "Search results",
       component: "Search",

--- a/packages/search/src/search-results.tsx
+++ b/packages/search/src/search-results.tsx
@@ -43,6 +43,7 @@ const SearchResults: FC<InfiniteHitsProps> = ({
           object: "Search",
           action: "No internet found",
           component: "Search",
+          attrs: { eventTime: new Date() },
         }}
       />
     );
@@ -58,6 +59,7 @@ const SearchResults: FC<InfiniteHitsProps> = ({
           object: "Search",
           action: "Empty state",
           component: "Search",
+          attrs: { eventTime: new Date() },
         }}
       />
     );

--- a/packages/search/src/search-results.tsx
+++ b/packages/search/src/search-results.tsx
@@ -39,6 +39,11 @@ const SearchResults: FC<InfiniteHitsProps> = ({
         icon="offline"
         title={"You appear to be offline"}
         message="Please check your network connection and try again"
+        trackingData={{
+          object: "Search",
+          action: "No internet found",
+          component: "Search",
+        }}
       />
     );
   }
@@ -49,10 +54,14 @@ const SearchResults: FC<InfiniteHitsProps> = ({
         title="Over 2 million articles"
         message="Search our archive of articles from The Times and The Sunday Times going all the way back to 2001"
         icon="search"
+        trackingData={{
+          object: "Search",
+          action: "Empty state",
+          component: "Search",
+        }}
       />
     );
   }
-
   return (
     <SearchList
       hits={hits}

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -1,10 +1,12 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
+import { NativeModules } from "react-native";
 import { SearchBarComponent } from "./search-bar/search-bar";
 import SearchResults from "@times-components-native/search/src/search-results";
 import { connectSearchBox, InstantSearch } from "react-instantsearch-native";
 import algoliasearch, { SearchClient } from "algoliasearch";
-import { withTrackingContext } from "@times-components-native/tracking";
 import { useIsConnected } from "@times-components-native/utils/src/useIsConnected";
+
+const { track } = NativeModules.ReactAnalytics;
 
 export interface SearchProps {
   onArticlePress: (url: string) => void;
@@ -32,6 +34,16 @@ const Search: FC<SearchProps> = ({ onArticlePress, algoliaConfig }) => {
   const ConnectedSearchBar = connectSearchBox((props) => (
     <SearchBarComponent {...props} isConnected={isConnected} />
   ));
+
+  useEffect(() => {
+    track({
+      object: "Search",
+      action: "Viewed",
+      component: "Page",
+      attrs: {},
+    });
+  }, []);
+
   return (
     <InstantSearch
       indexName={algoliaConfig.ALGOLIA_INDEX}
@@ -46,10 +58,4 @@ const Search: FC<SearchProps> = ({ onArticlePress, algoliaConfig }) => {
   );
 };
 
-const trackingContext = (Component: React.FC<any>) =>
-  withTrackingContext(Component, {
-    getAttrs: () => ({}),
-    trackingObjectName: "Search",
-  });
-
-export default trackingContext(Search);
+export default Search;

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -86,14 +86,3 @@ export interface Hit {
     };
   };
 }
-
-type TTrackingAtrributes = {
-  eventTime: Date;
-};
-
-export type TTrackingData = {
-  object: string;
-  action: string;
-  component: string;
-  attrs?: TTrackingAtrributes;
-};

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -86,3 +86,9 @@ export interface Hit {
     };
   };
 }
+
+export type TTrackingData = {
+  object: string;
+  action: string;
+  component: string;
+};

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -87,8 +87,13 @@ export interface Hit {
   };
 }
 
+type TTrackingAtrributes = {
+  eventTime: Date;
+};
+
 export type TTrackingData = {
   object: string;
   action: string;
   component: string;
+  attrs?: TTrackingAtrributes;
 };

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./ui-types";
 export * from "./domain-types";
 export * from "./measurements";
+export * from "./tracking";

--- a/packages/types/tracking.ts
+++ b/packages/types/tracking.ts
@@ -1,10 +1,10 @@
-type TTrackingAtrributes = {
+type TrackingAtrributes = {
   eventTime: Date;
 };
 
-export type TTrackingData = {
+export type TrackingData = {
   object: string;
   action: string;
   component: string;
-  attrs?: TTrackingAtrributes;
+  attrs?: TrackingAtrributes;
 };

--- a/packages/types/tracking.ts
+++ b/packages/types/tracking.ts
@@ -1,0 +1,10 @@
+type TTrackingAtrributes = {
+  eventTime: Date;
+};
+
+export type TTrackingData = {
+  object: string;
+  action: string;
+  component: string;
+  attrs?: TTrackingAtrributes;
+};


### PR DESCRIPTION
Add custom tracking events for the Search feature
ref: https://nidigitalsolutions.jira.com/browse/TNLT-7407
* Search page
* Search results page
* Offline page
* No results page

Note: This PR uses the native bridge Track function directly for simplicity. This is used in preference to withTrackingContext as this code is deprecated and uses unecessary abstraction.

example

```
import { NaviteModules } from 'react-native';

const { track } = NativeModules.ReactAnalytics;

track(trackingData)
```
