### PR TITLE
fix(TNLT-8138): Tooltip text does not fill tooltip due to added padding on Android 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/tooltip/__tests__/android/__snapshots__/shared.test.js.snap
+++ b/packages/tooltip/__tests__/android/__snapshots__/shared.test.js.snap
@@ -43,7 +43,6 @@ exports[`Tooltip does not render tooltip if not in tablet 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -138,7 +137,6 @@ exports[`Tooltip renders correctly when type is in tooltips array 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -224,7 +222,6 @@ exports[`Tooltip renders correctly with flexDirectionColumnReverse 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -307,7 +304,6 @@ exports[`Tooltip renders correctly with supplied offsets 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -391,7 +387,6 @@ exports[`Tooltip renders correctly with supplied placement right 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -474,7 +469,6 @@ exports[`Tooltip renders correctly with supplied placement top 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -565,7 +559,6 @@ exports[`Tooltip renders correctly with supplied width 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }

--- a/packages/tooltip/__tests__/android/__snapshots__/tooltip.android.test.js.snap
+++ b/packages/tooltip/__tests__/android/__snapshots__/tooltip.android.test.js.snap
@@ -43,7 +43,6 @@ exports[`Tooltip hides tooltip close button on android only 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }

--- a/packages/tooltip/__tests__/ios/__snapshots__/shared.test.js.snap
+++ b/packages/tooltip/__tests__/ios/__snapshots__/shared.test.js.snap
@@ -90,7 +90,6 @@ exports[`Tooltip does not render tooltip if not in tablet 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -232,7 +231,6 @@ exports[`Tooltip renders correctly when type is in tooltips array 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -365,7 +363,6 @@ exports[`Tooltip renders correctly with flexDirectionColumnReverse 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -495,7 +492,6 @@ exports[`Tooltip renders correctly with supplied offsets 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -626,7 +622,6 @@ exports[`Tooltip renders correctly with supplied placement right 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -756,7 +751,6 @@ exports[`Tooltip renders correctly with supplied placement top 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }
@@ -894,7 +888,6 @@ exports[`Tooltip renders correctly with supplied width 1`] = `
               "fontSize": 16,
               "lineHeight": 18,
               "paddingHorizontal": 30,
-              "paddingRight": 35,
               "paddingVertical": 20,
               "textAlign": "left",
             }

--- a/packages/tooltip/styles/index.ts
+++ b/packages/tooltip/styles/index.ts
@@ -35,7 +35,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 18,
     textAlign: "left",
-    paddingRight: spacing(7),
   },
   close: {
     position: "absolute",
@@ -95,10 +94,28 @@ const styles = StyleSheet.create({
   },
 });
 
-const generateStyles = (options) => {
-  let arrowPlacementStyles,
-    wrapperPlacementStyles = {},
-    containerPlacementStyles = [];
+interface GenerateStyleOptionsProps {
+  arrowOffset: number;
+  flexDirectionColumnReverse: boolean;
+  offsetX: number;
+  offsetY: number;
+  placement: "top" | "right" | "bottom" | "left";
+  width: number;
+}
+
+interface ContainerPlacement {
+  bottom?: number;
+  left?: number;
+  top?: number;
+  right?: number;
+  position?: "relative";
+  marginTop?: number;
+}
+
+const generateStyles = (options: GenerateStyleOptionsProps) => {
+  let arrowPlacementStyles;
+  let wrapperPlacementStyles = {};
+  let containerPlacementStyles: ContainerPlacement[] = [];
 
   switch (options.placement) {
     case "top":


### PR DESCRIPTION
## [TNLT-8138](https://nidigitalsolutions.jira.com/browse/TNLT-8138)

#### Description
On this one i've just removed some padding and updated the file to typescript. I'm not sure why the padding was there to begin with.

It was a tricky one to test. Tested on all emulators and a real Samsung android 12 and real android 11 device, where it's most reproduce-able.

We should just see the same even padding on the tooltips. On iOS there looked like there may have been a reason for the 
padding to avoid the close button, but thought my testing it doesn't seem to be an issue.

#### Screenshots 
Before:
![broken](https://user-images.githubusercontent.com/10746681/142616851-fcbbf8db-c065-4e19-ae4c-13a076dc57b8.jpeg)
After:
![working](https://user-images.githubusercontent.com/10746681/142616855-5c99568c-3e27-4f5d-90ce-279e781c9229.jpeg)



#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
