### PR TITLE
fix: tnlt 8784 android drop cap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "7.0.6",
+  "version": "7.0.6-beta",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/drop-cap/src/drop-cap.tsx
+++ b/packages/drop-cap/src/drop-cap.tsx
@@ -54,8 +54,8 @@ const DropCap: React.FC<Props> = ({
     <View
       style={[
         {
-          width,
-          height,
+          width: dropCapFontSize,
+          height: dropCapFontSize,
         },
       ]}
     >
@@ -66,10 +66,9 @@ const DropCap: React.FC<Props> = ({
             color: dropCapColor,
             fontFamily: fonts[dropCapFont as keyof typeof fonts],
             fontSize: dropCapFontSize,
-            lineHeight: height,
+            lineHeight: dropCapFontSize,
             marginHorizontal: 1,
             marginVertical: 1,
-            paddingTop: additionalPadding,
             width,
           },
         ]}


### PR DESCRIPTION
## [TNLT-XXXX](https://nidigitalsolutions.jira.com/browse/TNLT-XXXX)

#### Description

Issue seems to be created by differences between height prop and dropCapSize prop.

Making all size elements use dropCapSize fixes this.

#### Screenshots 

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
