### PR TITLE
chore: release 9.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "9.4.3",
+  "version": "9.5.0",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
## NO-JIRA

#### Description

Includes removal of OutStream ad play pause functionality.

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
