### PR TITLE
fix(TNLT-9332): revert article-skeleton state to use static state object

### DIFF
--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -154,8 +154,8 @@ const MemoisedArticle = React.memo((props) => {
 const ArticleWithContent = (props) => {
   const { onArticleRead, data } = props;
   const articleReadTimerDuration = 6000;
-  let [hasBeenRead, setHasBeenRead] = useState(false);
-  let [articleReadDelayTimeoutID, setArticleReadDelayTimeoutId] = useState();
+  let hasBeenRead = false;
+  let articleReadDelay = null;
 
   /**
    * Ref for scroll view stored to allow scrollToRef
@@ -196,13 +196,11 @@ const ArticleWithContent = (props) => {
 
   const setArticleReadTimeout = (articleId) => {
     if (articleId === data.id && !hasBeenRead) {
-      const timeoutId = setTimeout(() => {
+      articleReadDelay = setTimeout(() => {
         setArticleRead();
       }, articleReadTimerDuration);
-
-      setArticleReadDelayTimeoutId(timeoutId);
     } else {
-      clearTimeout(articleReadDelayTimeoutID);
+      clearTimeout(articleReadDelay);
     }
   };
 
@@ -217,7 +215,7 @@ const ArticleWithContent = (props) => {
 
   const setArticleRead = () => {
     if (hasBeenRead) return;
-    setHasBeenRead(true);
+    hasBeenRead = true;
     onArticleRead && onArticleRead(data.id);
   };
 

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -76,9 +76,8 @@ const Section: FC<Props> = (props) => {
       "scrollToArticleId",
       scrollToOffset,
     );
-    return () => {
-      sectionEventsListener.remove();
-    };
+
+    return sectionEventsListener.remove;
   }, []);
 
   const onViewableItemsChanged = useCallback((info) => {
@@ -127,7 +126,7 @@ const Section: FC<Props> = (props) => {
     );
   };
 
-  const renderItemSeperator = (isPuzzle: boolean) => (
+  const renderItemSeparator = (isPuzzle: boolean) => (
     { leadingItem }: any,
     editionBreakpoint: string,
   ) => {
@@ -199,7 +198,7 @@ const Section: FC<Props> = (props) => {
         removeClippedSubviews
         data={data}
         ItemSeparatorComponent={(leadingItem) =>
-          renderItemSeperator(isPuzzle)(leadingItem, editionBreakpoint)
+          renderItemSeparator(isPuzzle)(leadingItem, editionBreakpoint)
         }
         keyExtractor={(item) => item.elementId}
         ListHeaderComponent={getHeaderComponent(isPuzzle, isMagazine)}


### PR DESCRIPTION
## [TNLT-9332](https://nidigitalsolutions.jira.com/browse/TNLT-9332)

#### Description

Reverts how the state is handled in article-skeleton to a previous method.

Regression was found due to how the `useState` hook forces a re-render of the component rather than using the alternative approach.

A full write up of the problems each case causes can be found here - https://nidigitalsolutions.jira.com/browse/TNLT-9332

#### Screenshots 

https://user-images.githubusercontent.com/101340058/169545363-9529d8d0-1465-4962-a43f-be4c60a3c580.mov


#### Checklist
 - [x] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [x] Tested on iOS simulator
 - [x] Tested on Android emulator
 - [ ] Tested on Tablet
