### PR TITLE
feat: (TNLT-9357) improve article read state mgmt & performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "9.7.9",
+  "version": "9.7.10",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
## [TNLT-9357](https://nidigitalsolutions.jira.com/browse/TNLT-9357)

#### Description

The hasBeenRead property in article skeleton was simply a variable, which meant it wouldn't persist if the parent re-rendered.

Changing this to a useRef means that it will persist across re-renders. Using useRef as opposed to useState also means that a change to this value on scroll is recognised within the setTimeout (the 6 second delayed trigger for setting hasRead), meaning that we avoid duplicate events.

It wasn't necessary, but I also memoised `setLayoutRef` and `scrollToRef` functions as they were causing unnecessary re-renders of the child memoised article.

#### Screenshots 

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
