### PR TITLE
fix(TNLT-9402): inline images are getting closed automatically and redirecting back to the article page

### DIFF
--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import ArticleMagazineComment from "@times-components-native/article-magazine-comment";
 import ArticleInDepth from "@times-components-native/article-in-depth";
 import ArticleMagazineStandard from "@times-components-native/article-magazine-standard";
@@ -40,12 +40,15 @@ const Article = (props) => {
   if (template === "takeoverpage") {
     throw new TakeoverBailout("Aborted react render: Takeover page");
   }
-  let onImagePressArticle = null;
-  if (onImagePress) {
-    content = addIndexesToInlineImages(content, leadAsset);
-    const mediaList = getMediaList(content, leadAsset);
-    onImagePressArticle = (index) => onImagePress(index, mediaList);
-  }
+  let onImagePressArticle = useMemo(() => {
+    if (onImagePress) {
+      content = addIndexesToInlineImages(content, leadAsset);
+      const mediaList = getMediaList(content, leadAsset);
+      return (index) => onImagePress(index, mediaList);
+    }
+    return null;
+  }, []);
+
   const Component = getComponentByTemplate(template, isArticleTablet);
   const newProps = {
     ...props,


### PR DESCRIPTION
## [TNLT-9402](https://nidigitalsolutions.jira.com/browse/TNLT-9402)

#### Description

Rotating the device with an article inline image open created a red screen error (attached) in dev mode, and exited the image viewer (to return to the article) in non-dev mode.

I memoised the assignment of imageIndex so that it does not unnecessarily run multiple times

#### Screenshots 

#### Checklist
 - [x] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [x] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
