### PR TITLE
feat(TNLT-9671): fix read state opacity for bullets

### DIFF
--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -60,7 +60,6 @@ function ArticleSummary({
         <View
           style={{
             marginTop: 16,
-            opacity: articleReadState.read ? 0.5 : 1,
           }}
         >
           {bullets.map((bullet, index) => {

--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -71,6 +71,7 @@ function ArticleSummary({
                   flexDirection: "row",
                   marginBottom: 8,
                   paddingVertical: 2,
+                  opacity: bullet.readState?.read ? 0.5 : 1,
                 }}
                 onPress={() => onPress({ id: bullet.id })}
               >

--- a/packages/edition-slices/src/configured-tiles/tile-col-standard/index.tsx
+++ b/packages/edition-slices/src/configured-tiles/tile-col-standard/index.tsx
@@ -26,13 +26,14 @@ import {
   Tile,
 } from "@times-components-native/fixture-generator/src/types";
 import { Orientation } from "@times-components-native/responsive/src/types";
+import { Bullet } from "../../tiles/shared/article-summary";
 
 interface Props {
   onPress: OnArticlePress;
   tile: TransformConfiguredTile;
   breakpoint: EditionBreakpointKeys;
   orientation: Orientation;
-  bullets?: string[];
+  bullets?: Bullet[];
 }
 
 const TileColStandard: FC<Props> = ({

--- a/packages/edition-slices/src/tiles/shared/article-summary.tsx
+++ b/packages/edition-slices/src/tiles/shared/article-summary.tsx
@@ -44,6 +44,15 @@ type MarkAsReadProps = {
   opacity: number;
 };
 
+export type Bullet = {
+  id: string;
+  shortHeadline: string;
+};
+
+type BulletWithReadState = Bullet & {
+  readState: ArticleReadState;
+};
+
 interface Props {
   bylines?: BylineInput[];
   bylineStyle?: StyleProp<ViewStyle>;
@@ -67,7 +76,7 @@ interface Props {
   starStyle?: StyleProp<ViewStyle>;
   hideLabel?: boolean;
   whiteSpaceHeight?: number;
-  bullets?: string[];
+  bullets?: Bullet[];
   onPress?: OnArticlePress | (() => null);
 }
 
@@ -189,6 +198,13 @@ const ArticleSummary: React.FC<Props> = ({
     getIsLiveState(),
   );
 
+  const bulletsWithReadState: BulletWithReadState[] = bullets?.length
+    ? bullets.map((bullet) => ({
+        ...bullet,
+        readState: getArticleReadState(readArticles, id, getIsLiveState()),
+      }))
+    : [];
+
   useEffect(() => {
     if (!articleReadState.animate) return;
 
@@ -306,7 +322,7 @@ const ArticleSummary: React.FC<Props> = ({
       saveStar={withStar && renderSaveStar()}
       style={style}
       center={!!centeredStar}
-      bullets={bullets}
+      bullets={bulletsWithReadState}
       onPress={onPress}
     />
   );

--- a/packages/edition-slices/src/tiles/shared/tile-summary.tsx
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleProp, TextStyle, ViewStyle } from "react-native";
-import ArticleSummary from "./article-summary";
+import ArticleSummary, { Bullet } from "./article-summary";
 import {
   BylineInput,
   Markup,
@@ -32,7 +32,7 @@ interface Props {
   starStyle?: StyleProp<ViewStyle>;
   hideLabel?: boolean;
   whiteSpaceHeight?: number;
-  bullets?: string[];
+  bullets?: Bullet[];
   onPress?: OnArticlePress | (() => null);
 }
 


### PR DESCRIPTION
## [TNLT-9671](https://nidigitalsolutions.jira.com/browse/TNLT-9671)

#### Description

The opacity of a bullet point in a tile does not come from the tile's parent article read state, but instead from the read state of the article in the bullet itself.

#### Screenshots 

#### Checklist
 - [x] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [x] Tested on iOS simulator
 - [x] Tested on Android emulator
 - [ ] Tested on Tablet
