### PR TITLE
fux(TNLT-9703):: bullets ordered by key name

### DIFF
--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -13,6 +13,7 @@ class LeadOneAndOne extends PureComponent {
     this.bullets = Object.keys(this.props.slice)
       .filter((key) => key.toLowerCase().indexOf("bullet") !== -1)
       .filter((key) => this.props.slice[key] !== null)
+      .sort((a, b) => a.localeCompare(b))
       .map((bulletKey) => this.props.slice[bulletKey].article);
   }
 

--- a/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/leadtwonopicandtwo/index.js
@@ -12,6 +12,7 @@ class LeadTwoNoPicAndTwo extends PureComponent {
     this.bullets = Object.keys(this.props.slice)
       .filter((key) => key.toLowerCase().indexOf("bullet") !== -1)
       .filter((key) => this.props.slice[key] !== null)
+      .sort((a, b) => a.localeCompare(b))
       .map((bulletKey) => this.props.slice[bulletKey].article);
   }
 


### PR DESCRIPTION
## [TNLT-9703](https://nidigitalsolutions.jira.com/browse/TNLT-9703)

#### Description

Bullets were previously unordered, now they are ordered by their key, ie `'lead1Bullet1', 'lead1Bullet2', 'lead1Bullet3'`

#### Screenshots 

#### Checklist
 - [x] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [x] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
