### PR TITLE
feat: revert isRead feature to tablet only

### DIFF
--- a/packages/edition-slices/__tests__/article-read-state.base.js
+++ b/packages/edition-slices/__tests__/article-read-state.base.js
@@ -12,20 +12,38 @@ jest.mock("react-native", () => {
 export default () => {
   describe("getArticleReadState", () => {
     test("returns correct value when readArticles is null", () => {
-      expect(getArticleReadState(null, "foo")).toEqual({
+      expect(getArticleReadState(false, null, "foo")).toEqual({
         read: false,
         animate: false,
       });
     });
     test("returns correct value when readArticles is empty array", () => {
-      expect(getArticleReadState([], "foo")).toEqual({
+      expect(getArticleReadState(false, [], "foo")).toEqual({
         read: false,
         animate: false,
       });
     });
-    test("returns correct value when readArticles are set but id doesn't match", () => {
+    test("returns correct value when readArticles are set and isTablet is false", () => {
       expect(
         getArticleReadState(
+          false,
+          [
+            {
+              id: "foo",
+              highlight: false,
+            },
+          ],
+          "foo",
+        ),
+      ).toEqual({
+        read: false,
+        animate: false,
+      });
+    });
+    test("returns correct value when readArticles are set and isTablet is true but id doesn't match", () => {
+      expect(
+        getArticleReadState(
+          true,
           [
             {
               id: "foo",
@@ -39,9 +57,10 @@ export default () => {
         animate: false,
       });
     });
-    test("returns correct value when readArticles are set and id matches", () => {
+    test("returns correct value when readArticles are set and isTablet is true and id matches", () => {
       expect(
         getArticleReadState(
+          true,
           [
             {
               id: "bar",
@@ -55,9 +74,10 @@ export default () => {
         animate: false,
       });
     });
-    test("returns correct value when readArticles are set, id matches and highlight is set", () => {
+    test("returns correct value when readArticles are set and isTablet is true, id matches and highlight is set", () => {
       expect(
         getArticleReadState(
+          true,
           [
             {
               id: "bar",
@@ -71,9 +91,9 @@ export default () => {
         animate: true,
       });
     });
-    test("returns false for read articles if the article is live", () => {
+    test("returns false for read articles if the article is live and isTablet is true", () => {
       expect(
-        getArticleReadState([{ read: true, animate: false }], "x", true),
+        getArticleReadState(true, [{ read: true, animate: false }], "x", true),
       ).toEqual({
         read: false,
         animate: false,

--- a/packages/edition-slices/src/tiles/shared/article-summary.tsx
+++ b/packages/edition-slices/src/tiles/shared/article-summary.tsx
@@ -73,6 +73,7 @@ interface Props {
   underneathTextStar?: boolean;
   centeredStar?: boolean;
   isDarkStar?: boolean;
+  isTablet: boolean;
   starStyle?: StyleProp<ViewStyle>;
   hideLabel?: boolean;
   whiteSpaceHeight?: number;
@@ -81,6 +82,7 @@ interface Props {
 }
 
 export const getArticleReadState = (
+  isTablet: boolean,
   readArticles: Array<ArticleRead> | null,
   articleId: string,
   isLive: boolean = false,
@@ -93,10 +95,12 @@ export const getArticleReadState = (
     };
   }
   return {
-    read: readArticles?.some((obj) => obj.id === articleId) ?? false,
+    read:
+      isTablet && (readArticles?.some((obj) => obj.id === articleId) ?? false),
     animate:
-      readArticles?.some((obj) => obj.highlight && obj.id === articleId) ??
-      false,
+      isTablet &&
+      (readArticles?.some((obj) => obj.highlight && obj.id === articleId) ??
+        false),
   };
 };
 
@@ -144,6 +148,7 @@ const ArticleSummary: React.FC<Props> = ({
   underneathTextStar = false,
   centeredStar = false,
   isDarkStar = false,
+  isTablet = false,
   starStyle,
   hideLabel = false,
   bullets = [],
@@ -193,6 +198,7 @@ const ArticleSummary: React.FC<Props> = ({
   };
 
   const articleReadState = getArticleReadState(
+    isTablet,
     readArticles,
     id,
     getIsLiveState(),
@@ -201,7 +207,12 @@ const ArticleSummary: React.FC<Props> = ({
   const bulletsWithReadState: BulletWithReadState[] = bullets?.length
     ? bullets.map((bullet) => ({
         ...bullet,
-        readState: getArticleReadState(readArticles, id, getIsLiveState()),
+        readState: getArticleReadState(
+          isTablet,
+          readArticles,
+          id,
+          getIsLiveState(),
+        ),
       }))
     : [];
 

--- a/packages/edition-slices/src/tiles/shared/tile-summary.tsx
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.tsx
@@ -63,10 +63,11 @@ const TileSummary: React.FC<Props> = ({
 }) => {
   return (
     <ResponsiveContext.Consumer>
-      {() => (
+      {({ isTablet }) => (
         <SectionContext.Consumer>
           {({ readArticles }) => (
             <ArticleSummary
+              isTablet={isTablet}
               bylines={bylines}
               bylineStyle={bylineStyle}
               bylineOnTop={bylineOnTop}


### PR DESCRIPTION
#### Description

[TNLT-9716](https://nidigitalsolutions.jira.com/browse/TNLT-9716)

~There is no ticket for this, but~ A request has been made to revert the isRead feature so that it only applies on tablet devices.

#### Screenshots 

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
