### PR TITLE
fix(TNLT-2244): prevent underline extending beyond link text

### DIFF
--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -1697,7 +1697,7 @@ exports[`10. an article with italic and normal text link 1`] = `
                     </Text>
                   </Text>
                   <Text>
-                     Coronavirus Charity Appeal
+                    Coronavirus Charity Appeal
                   </Text>
                 </Text>
                 <Text>

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -2543,7 +2543,7 @@ exports[`10. an article with italic and normal text link 1`] = `
                     </Text>
                   </Text>
                   <Text>
-                     Coronavirus Charity Appeal
+                    Coronavirus Charity Appeal
                   </Text>
                 </Text>
                 <Text>

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -1719,7 +1719,7 @@ exports[`10. an article with italic and normal text link 1`] = `
                     </Text>
                   </Text>
                   <Text>
-                     Coronavirus Charity Appeal
+                    Coronavirus Charity Appeal
                   </Text>
                 </Text>
                 <Text>

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -2585,7 +2585,7 @@ exports[`10. an article with italic and normal text link 1`] = `
                     </Text>
                   </Text>
                   <Text>
-                     Coronavirus Charity Appeal
+                    Coronavirus Charity Appeal
                   </Text>
                 </Text>
                 <Text>

--- a/packages/article-skeleton/fixtures/mixed-link-article-content.js
+++ b/packages/article-skeleton/fixtures/mixed-link-article-content.js
@@ -28,7 +28,7 @@ export default [
             name: "text",
             children: [],
             attributes: {
-              value: " Coronavirus Charity Appeal",
+              value: "Coronavirus Charity Appeal",
             },
           },
         ],

--- a/packages/markup-forest/src/markup-forest.js
+++ b/packages/markup-forest/src/markup-forest.js
@@ -10,9 +10,14 @@ export const render = (renderers) => {
      * Recursively render all child elements
      */
     if (children) {
-      renderedChildren = children.map((child, index) =>
-        run(child, `${key}.${index}`, index),
-      );
+      renderedChildren = children.map((child, index) => {
+        if (name === "link") {
+          if (child.name === "text") {
+            child.attributes.value = child.attributes?.value.trim();
+          }
+        }
+        return run(child, `${key}.${index}`, index);
+      });
     }
 
     /**


### PR DESCRIPTION
## [TNLT-2244](https://nidigitalsolutions.jira.com/browse/TNLT-2244)

#### Description

As detailed in the ticket, sometimes link text had blank space at the beginning or end, causing the link underline UI to appear underneath the blank space, making it appear to extend before/after the link text.

This fix trims link text during the rendering process, to avoid this.

#### Screenshots 

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
