### PR TITLE
style(TNLT-9761): change topic border from highlighted to unhighlighted state

### DIFF
--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
@@ -23,10 +23,10 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#006699",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -73,10 +73,10 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#006699",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -123,10 +123,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#006699",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -163,10 +163,10 @@ exports[`4. article topic with style 1`] = `
     <View
       style={
         Object {
-          "borderColor": "#006699",
+          "borderColor": "#DBDBDB",
           "borderRadius": 2,
-          "borderWidth": 2,
-          "padding": 9,
+          "borderWidth": 1,
+          "padding": 10,
         }
       }
     >
@@ -202,10 +202,10 @@ exports[`5. article topic with no additional style 1`] = `
     <View
       style={
         Object {
-          "borderColor": "#006699",
+          "borderColor": "#DBDBDB",
           "borderRadius": 2,
-          "borderWidth": 2,
-          "padding": 9,
+          "borderWidth": 1,
+          "padding": 10,
         }
       }
     >

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
@@ -29,10 +29,10 @@ exports[`1. group of topics 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#006699",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -85,10 +85,10 @@ exports[`2. group of topics at large scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#006699",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -141,10 +141,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#006699",
+            "borderColor": "#DBDBDB",
             "borderRadius": 2,
-            "borderWidth": 2,
-            "padding": 9,
+            "borderWidth": 1,
+            "padding": 10,
           }
         }
       >
@@ -187,10 +187,10 @@ exports[`4. article topic with style 1`] = `
     <View
       style={
         Object {
-          "borderColor": "#006699",
+          "borderColor": "#DBDBDB",
           "borderRadius": 2,
-          "borderWidth": 2,
-          "padding": 9,
+          "borderWidth": 1,
+          "padding": 10,
         }
       }
     >
@@ -232,10 +232,10 @@ exports[`5. article topic with no additional style 1`] = `
     <View
       style={
         Object {
-          "borderColor": "#006699",
+          "borderColor": "#DBDBDB",
           "borderRadius": 2,
-          "borderWidth": 2,
-          "padding": 9,
+          "borderWidth": 1,
+          "padding": 10,
         }
       }
     >

--- a/packages/article-topics/src/article-topic.js
+++ b/packages/article-topics/src/article-topic.js
@@ -19,7 +19,7 @@ const ArticleTopic = ({ fontSize, lineHeight, name, onPress, slug }) => {
             url={makeTopicUrl({ slug })}
             testIDProp="topic"
           >
-            <View style={[styles.container, styles.borderHighlight]}>
+            <View style={[styles.container]}>
               <Text
                 accessibilityComponentType="button"
                 accessibilityRole="button"


### PR DESCRIPTION
## [TNLT-9761](https://nidigitalsolutions.jira.com/browse/TNLT-9761)

#### Description

The border for topic labels is now a subtle grey, as opposed to blue.

Looking at past commits, there was a highlighted state and an unhighlighted state, and highlighting functionality was removed, with the highlighted state remaining as the default. I have changed this so the unhighlighted state is the default

#### Screenshots 

![Simulator Screen Shot - iPhone 13 mini - 2022-08-30 at 12 36 15](https://user-images.githubusercontent.com/1517021/187427324-c563a359-2603-4971-bdf5-5f86499c77cc.png)
![Simulator Screen Shot - iPhone 13 mini - 2022-08-30 at 12 35 58](https://user-images.githubusercontent.com/1517021/187427345-52a919f0-9a19-4394-9f0a-ae5530f56e73.png)


#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
