### PR TITLE
fix(TNLT-9771): adding onpress prop to tileZ for landscape fix

### DIFF
--- a/packages/edition-slices/src/tiles/tile-z/index.js
+++ b/packages/edition-slices/src/tiles/tile-z/index.js
@@ -45,6 +45,7 @@ const TileZ = ({
               whiteSpaceHeight={whiteSpaceHeight}
               withStar={false}
               bullets={bullets}
+              onPress={onPress}
             />
           )}
         />


### PR DESCRIPTION
## [TNLT-9771](https://nidigitalsolutions.jira.com/browse/TNLT-9771)

#### Description

Passing down missing onPress prop to tile used in tablet landscape 

#### Screenshots 

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
