### PR TITLE
Restore build command without 'ram-' for android bundle WIP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ publish_android: &PUBLISH_ANDROID
                 command: |
                     cd ~/project/
                     yarn android:clean-lib:aar
+                    yarn android:build-lib
                     yarn android:publish-lib:aar:remote
                     bash ./scripts/publish-android.sh
                 working_directory: ~/project/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "ios:build-lib:js": "mkdir -p lib/ios/assets/js && mkdir -p lib/ios/assets/res/graphql && cp ./packages/provider-queries/src/*.graphql ./lib/ios/assets/res/graphql",
     "ios:build-lib:update-version": "cat package.json | grep version | head -1 | sed 's/[\",\t ]//g' | awk -F: '{ print \"Bundle Version: \" $2 }' > lib/ios/assets/js/version.meta",
     "android:native": "react-native start --config ./lib/android/metro.config.js",
+    "android:build-lib": "yarn android:build-lib:js && yarn android:build-lib:aar",
+    "android:build-lib:js": "mkdir -p lib/android/xnative/src/main/assets/ && mkdir -p lib/android/xnative/src/main/res/ && react-native bundle --platform android --dev false --minify --entry-file lib/android/index.android.js --bundle-output lib/android/xnative/src/main/assets/index.android.bundle --assets-dest lib/android/xnative/src/main/res/",
     "android:clean-lib:aar": "cd lib/android && ./gradlew clean && cd -",
     "android:build-lib:aar": "cd lib/android && ./gradlew generateReactArchives && ./gradlew assemble && cd -",
     "android:publish-lib:aar:remote": "cd lib/android && ./gradlew publish && cd -",


### PR DESCRIPTION
Restore build command without 'ram-' for android bundle WIP

#### Description
It should fix https://app.circleci.com/pipelines/github/newsuk/times-components-native/3463/workflows/ecfc1f05-09e3-4403-ad57-ef633eeacb36/jobs/19775

Introduced in https://github.com/newsuk/times-components-native/pull/675


#### Checklist
 - [x] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [x] Tested on Android emulator
 - [ ] Tested on Tablet
