### PR TITLE
fix(TNLT-10243): ad space now defaults to 250 height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "times-components-native",
   "private": true,
-  "version": "11.0.7",
+  "version": "11.0.8",
   "description": "A collection of react-native components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {

--- a/packages/ad/__tests__/__snapshots__/ad.test.tsx.snap
+++ b/packages/ad/__tests__/__snapshots__/ad.test.tsx.snap
@@ -4,11 +4,26 @@ exports[`** AD ** 1`] = `
 <View
   inViewport={false}
   onViewportEnter={[Function]}
+  pointerEvents="box-none"
   style={
     Object {
-      "height": 0,
+      "height": 290,
       "width": 750,
     }
   }
-/>
+>
+  <View
+    inViewport={false}
+    onViewportEnter={[Function]}
+    onViewportLeave={[Function]}
+    style={
+      Object {
+        "height": 10,
+        "position": "absolute",
+        "top": 40,
+        "width": 10,
+      }
+    }
+  />
+</View>
 `;

--- a/packages/ad/__tests__/__snapshots__/sponsored-ad.test.tsx.snap
+++ b/packages/ad/__tests__/__snapshots__/sponsored-ad.test.tsx.snap
@@ -11,10 +11,10 @@ exports[`SponsoredAd renders Dianomi script tag 1`] = `
   \\"show source\\";
 
   var window = _ref.window,
-      document = _ref.document,
-      MutationObserver = _ref.MutationObserver,
-      width = _ref.width,
-      ratio = _ref.ratio;
+    document = _ref.document,
+    MutationObserver = _ref.MutationObserver,
+    width = _ref.width,
+    ratio = _ref.ratio;
   window.ReactNativeWebView.postMessage(JSON.stringify({
     running: \\"error\\"
   }));
@@ -64,10 +64,10 @@ exports[`SponsoredAd renders the require number of ad items 1`] = `
   \\"show source\\";
 
   var window = _ref.window,
-      document = _ref.document,
-      MutationObserver = _ref.MutationObserver,
-      width = _ref.width,
-      ratio = _ref.ratio;
+    document = _ref.document,
+    MutationObserver = _ref.MutationObserver,
+    width = _ref.width,
+    ratio = _ref.ratio;
   window.ReactNativeWebView.postMessage(JSON.stringify({
     running: \\"error\\"
   }));

--- a/packages/ad/src/dom-context.tsx
+++ b/packages/ad/src/dom-context.tsx
@@ -82,8 +82,8 @@ const DOMContext = (props: DomContextType) => {
   const webViewRef = React.useRef<WebView>(null);
   const [state, dispatch] = useReducer(reducer, {
     loadAd: false,
-    adHeight: 0,
-    padding: 0,
+    adHeight: 250,
+    padding: PADDING,
   });
   const networkId = config.adNetworkId;
   const adUnit =
@@ -311,6 +311,7 @@ const DOMContext = (props: DomContextType) => {
         })
       }
       style={viewPortStyle}
+      pointerEvents="box-none"
     >
       {state.loadAd && (
         <WebView


### PR DESCRIPTION
## [TNLT-10243](https://nidigitalsolutions.jira.com/browse/TNLT-10243)

#### Description

Adding a default height for the ads slots

#### Screenshots 

#### Checklist
 - [ ] Unit tests
 - [ ] Updated E2E tests
 - [ ] Updated storybook
 - [ ] Tested on iOS simulator
 - [ ] Tested on Android emulator
 - [ ] Tested on Tablet
